### PR TITLE
Fix sas token generation with duration time defined

### DIFF
--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -593,7 +593,7 @@ def _iot_build_sas_token(cmd, hub_name=None, device_id=None, policy_name='iothub
         policy = target['policy']
         key = target['primarykey'] if key_type == 'primary' else target['secondarykey']
 
-    return SasTokenAuthentication(uri, policy, key, time() + duration)
+    return SasTokenAuthentication(uri, policy, key, time() + int(duration))
 
 
 # pylint: disable=inconsistent-return-statements


### PR DESCRIPTION

Before:

az iot hub generate-sas-token  --device-id "dev_2" --resource-group "IotHub" --hub-name "iothub" -po device -du 1000
unsupported operand type(s) for +: 'float' and 'str'
Traceback (most recent call last):
  File "/usr/lib64/az/lib/python2.7/site-packages/knack/cli.py", line 197, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/lib64/az/lib/python2.7/site-packages/azure/cli/core/commands/__init__.py", line 347, in execute
    six.reraise(*sys.exc_info())
  File "/usr/lib64/az/lib/python2.7/site-packages/azure/cli/core/commands/__init__.py", line 319, in execute
    result = cmd(params)
  File "/usr/lib64/az/lib/python2.7/site-packages/azure/cli/core/commands/__init__.py", line 180, in __call__
    return super(AzCliCommand, self).__call__(*args, **kwargs)
  File "/usr/lib64/az/lib/python2.7/site-packages/knack/commands.py", line 109, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/lib64/az/lib/python2.7/site-packages/azure/cli/core/__init__.py", line 420, in default_command_handler
    result = op(**command_args)
  File "/home/joaohf/.azure/cliextensions/azure-cli-iot-ext/azext_iot/operations/hub.py", line 552, in iot_get_sas_token
    policy_name, key_type, duration, resource_group_name).generate_sas_token()}
  File "/home/joaohf/.azure/cliextensions/azure-cli-iot-ext/azext_iot/operations/hub.py", line 559, in _iot_build_sas_token
    duration = time() + duration
TypeError: unsupported operand type(s) for +: 'float' and 'str'


After duration to integer:

az iot hub generate-sas-token  --device-id "dev_2" --resource-group "IotHub" --hub-name "iothub" -po device -du 5184000
{
  "sas": "SharedAccessSignature ....se=1529095015"
}
