### PR TITLE
Unit test mock pattern fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,5 @@ ignore =
     E501,  # line too long, it is covered by pylint
     E722,  # bare except, bad practice, to be removed in the future
     F401,  # imported but unused, it is covered by pylint
-    C901   # code flow is too complex, to be removed in the future
+    C901,  # code flow is too complex, to be removed in the future
+    W504   # line break after binary operator

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ score=no
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods
 # useless-object-inheritance: Because we have to be explict for Py2
 # useless-import-alias: This is quite subjective and depends on the dev
-disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,wrong-import-order,useless-object-inheritance,useless-import-alias
+disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,wrong-import-order,useless-object-inheritance,useless-import-alias,W504
 
 [TYPECHECK]
 # For Azure CLI extensions, we ignore some import errors as they'll be available in the environment of the CLI

--- a/azext_iot/common/pip.py
+++ b/azext_iot/common/pip.py
@@ -6,7 +6,7 @@
 
 import subprocess
 import sys
-from azure.cli.core.extensions import get_extension_path, extension_exists  # pylint: disable=no-name-in-module
+from azure.cli.core.extension import get_extension_path, extension_exists  # pylint: disable=no-name-in-module
 from knack.log import get_logger
 from azext_iot._constants import EXTENSION_NAME
 

--- a/azext_iot/common/pip.py
+++ b/azext_iot/common/pip.py
@@ -6,7 +6,7 @@
 
 import subprocess
 import sys
-from azure.cli.core.extension import get_extension_path, extension_exists  # pylint: disable=no-name-in-module
+from azure.cli.core.extensions import get_extension_path, extension_exists  # pylint: disable=no-name-in-module
 from knack.log import get_logger
 from azext_iot._constants import EXTENSION_NAME
 

--- a/azext_iot/tests/test_iot_dps_unit.py
+++ b/azext_iot/tests/test_iot_dps_unit.py
@@ -48,20 +48,16 @@ def fixture_sas(mocker):
 @pytest.fixture(params=[400, 401, 500])
 def serviceclient_generic_error(mocker, fixture_gdcs, fixture_sas, request):
     service_client = mocker.patch(path_service_client)
-    response = mocker.MagicMock(name='response')
-    response.error_code = request.param
-    del response._attribute_map
-    response.text = json.dumps({'error': 'something failed'})
-
-    service_client.return_value = response
+    service_client.return_value = build_mock_response(mocker, request.param, {'error': 'something failed'})
     return service_client
 
 
 def build_mock_response(mocker, status_code=200, payload=None):
     response = mocker.MagicMock(name='response')
     response.status_code = status_code
-    response.text = json.dumps(payload)
+    del response.context
     del response._attribute_map
+    response.text.return_value = json.dumps(payload)
     return response
 
 
@@ -419,11 +415,7 @@ class TestEnrollmentShow():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps(generate_enrollment_show())
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, generate_enrollment_show())
         return service_client
 
     def test_enrollment_show(self, serviceclient):
@@ -447,10 +439,7 @@ class TestEnrollmentList():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     @pytest.mark.parametrize("servresult, servtotal, top", [
@@ -461,7 +450,7 @@ class TestEnrollmentList():
         ([generate_enrollment_show()], 1, 100)
     ])
     def test_enrollment_list(self, serviceclient, servresult, servtotal, top):
-        serviceclient.return_value.text = json.dumps(servresult)
+        serviceclient.return_value.text.return_value = json.dumps(servresult)
         pagesize = len(servresult)
         continuation = []
 
@@ -930,11 +919,7 @@ class TestEnrollmentGroupShow():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps(generate_enrollment_group_show())
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, generate_enrollment_group_show())
         return service_client
 
     def test_enrollment_group_show(self, serviceclient):
@@ -957,10 +942,7 @@ class TestEnrollmentGroupList():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     @pytest.mark.parametrize("servresult, servtotal, top", [
@@ -971,7 +953,7 @@ class TestEnrollmentGroupList():
         ([generate_enrollment_group_show()], 1, 100)
     ])
     def test_enrollment_group_list(self, serviceclient, servresult, servtotal, top):
-        serviceclient.return_value.text = json.dumps(servresult)
+        serviceclient.return_value.text.return_value = json.dumps(servresult)
         pagesize = len(servresult)
         continuation = []
 
@@ -1031,10 +1013,7 @@ class TestEnrollmentGroupDelete():
     @pytest.fixture(params=[204])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     def test_enrollment_group_delete(self, serviceclient):
@@ -1062,11 +1041,7 @@ class TestRegistrationShow():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps(generate_registration_state_show())
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, generate_registration_state_show())
         return service_client
 
     def test_registration_show(self, serviceclient):
@@ -1089,13 +1064,9 @@ class TestRegistrationList():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
         result = []
         result.append(generate_registration_state_show())
-        response.text = json.dumps(result)
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, result)
         return service_client
 
     def test_registration_list(self, serviceclient):
@@ -1117,10 +1088,7 @@ class TestRegistrationDelete():
     @pytest.fixture(params=[204])
     def serviceclient(self, mocker, fixture_gdcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     def test_registration_delete(self, serviceclient):

--- a/azext_iot/tests/test_iot_ext_unit.py
+++ b/azext_iot/tests/test_iot_ext_unit.py
@@ -79,8 +79,9 @@ def serviceclient_generic_error(mocker, fixture_ghcs, fixture_sas, request):
     service_client = mocker.patch(path_service_client)
     response = mocker.MagicMock(name='response')
     response.status_code = request.param
+    del response.context
     del response._attribute_map
-    response.text = json.dumps({'error': 'something failed'})
+    response.text.return_value = json.dumps({'error': 'something failed'})
 
     service_client.return_value = response
     return service_client
@@ -91,8 +92,9 @@ def serviceclient_generic_invalid_or_missing_etag(mocker, fixture_ghcs, fixture_
     service_client = mocker.patch(path_service_client)
     response = mocker.MagicMock(name='response')
     response.status_code = 200
+    del response.context
     del response._attribute_map
-    response.text = json.dumps(request.param)
+    response.text.return_value = json.dumps(request.param)
 
     service_client.return_value = response
     return service_client
@@ -108,10 +110,11 @@ def mqttclient_generic_error(mocker, fixture_ghcs, fixture_sas):
 def build_mock_response(mocker, status_code=200, payload=None, headers=None):
     response = mocker.MagicMock(name='response')
     response.status_code = status_code
-    response.text = json.dumps(payload)
+    del response.context
+    del response._attribute_map
+    response.text.return_value = json.dumps(payload)
     if headers:
         response.headers = headers
-    del response._attribute_map
     return response
 
 
@@ -311,17 +314,15 @@ class TestDeviceList():
     @pytest.fixture(params=[(200, 10), (200, 0)])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        response.status_code = request.param[0]
-        del response._attribute_map
         result = []
         size = request.param[1]
         for _ in range(size):
             result.append(generate_device_show())
         service_client.expected_size = size
-        response.text = json.dumps(result)
-        response.headers = {'x-ms-continuation': None}
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param[0],
+                                                          result,
+                                                          {'x-ms-continuation': None})
         return service_client
 
     @pytest.mark.parametrize("top, edge", [(10, True), (1000, False)])
@@ -514,11 +515,7 @@ class TestDeviceModuleShow():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps(generate_device_module_show())
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     def test_device_module_show(self, serviceclient):
@@ -540,17 +537,15 @@ class TestDeviceModuleList():
     @pytest.fixture(params=[(200, 10), (200, 0)])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        response.status_code = request.param[0]
-        del response._attribute_map
         result = []
         size = request.param[1]
         for _ in range(size):
             result.append(generate_device_module_show())
         service_client.expected_size = size
-        response.text = json.dumps(result)
-        response.headers = {'x-ms-continuation': None}
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param[0],
+                                                          result,
+                                                          {'x-ms-continuation': None})
         return service_client
 
     @pytest.mark.parametrize("top", [10, 1000])
@@ -824,9 +819,6 @@ class TestConfigList():
     @pytest.fixture(params=[(200, 10)])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        response.status_code = request.param[0]
-        del response._attribute_map
         result = []
         size = request.param[1]
         for _ in range(size):
@@ -834,9 +826,10 @@ class TestConfigList():
         for _ in range(size):
             result.append(generate_device_config(content_type='device', scenario='update'))
         service_client.expected_size = size
-        response.text = json.dumps(result)
-        response.headers = {'x-ms-continuation': None}
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param[0],
+                                                          result,
+                                                          {'x-ms-continuation': None})
         return service_client
 
     @pytest.mark.parametrize("top", [1, 10])
@@ -1054,12 +1047,9 @@ class TestDeviceTwinShow():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps([generate_device_twin_show()])
-        response.headers = {'x-ms-continuation': None}
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param,
+                                                          [generate_device_twin_show()],
+                                                          {'x-ms-continuation': None})
         return service_client
 
     def test_device_twin_show(self, serviceclient):
@@ -1113,11 +1103,9 @@ class TestDeviceTwinReplace():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        response.status_code = request.param
-        del response._attribute_map
-        response.text = json.dumps(generate_device_twin_show(moduleId=module_id))
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param,
+                                                          generate_device_twin_show(moduleId=module_id))
         return service_client
 
     # Replace does a GET/SHOW first
@@ -1146,7 +1134,7 @@ class TestDeviceTwinReplace():
     ])
     def test_device_twin_replace_invalid_args(self, serviceclient, req, exp):
         with pytest.raises(exp):
-            serviceclient.return_value.text = json.dumps(req)
+            serviceclient.return_value.text.return_value = json.dumps(req)
             subject.iot_device_twin_replace(fixture_cmd, device_id, hub_name=mock_target['entity'],
                                             target_json=json.dumps(req))
 
@@ -1221,7 +1209,8 @@ class TestDeviceModuleTwinReplace():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        service_client.return_value = build_mock_response(mocker, request.param,
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param,
                                                           payload=generate_device_twin_show(moduleId=module_id))
         return service_client
 
@@ -1252,7 +1241,7 @@ class TestDeviceModuleTwinReplace():
     ])
     def test_device_module_twin_replace_invalid_args(self, serviceclient, req, exp):
         with pytest.raises(exp):
-            serviceclient.return_value.text = json.dumps(req)
+            serviceclient.return_value.text.return_value = json.dumps(req)
             subject.iot_device_module_twin_replace(fixture_cmd, device_id, hub_name=mock_target['entity'],
                                                    module_id=module_id, target_json=json.dumps(req))
 
@@ -1274,6 +1263,7 @@ class TestQuery():
         service_client = mocker.patch(path_service_client)
         response = mocker.MagicMock(name='response')
         response.status_code = request.param
+        del response.context
         del response._attribute_map
         service_client.return_value = response
         return service_client
@@ -1286,7 +1276,7 @@ class TestQuery():
         (generic_query, [generate_device_twin_show()], 1, 100)
     ])
     def test_query_basic(self, serviceclient, query, servresult, servtotal, top):
-        serviceclient.return_value.text = json.dumps(servresult)
+        serviceclient.return_value.text.return_value = json.dumps(servresult)
         pagesize = len(servresult)
         continuation = []
 
@@ -1346,11 +1336,9 @@ class TestDeviceMethodInvoke():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps({'payload': 'value', 'status': 0})
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker,
+                                                          request.param,
+                                                          {'payload': 'value', 'status': 0})
         return service_client
 
     @pytest.mark.parametrize("methodbody", ['{"key":"value"}', None])
@@ -1402,11 +1390,7 @@ class TestDeviceModuleMethodInvoke():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = json.dumps({'payload': 'value', 'status': 0})
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {'payload': 'value', 'status': 0})
         return service_client
 
     @pytest.mark.parametrize("methodbody", ['{"key":"value"}', None])
@@ -1595,9 +1579,7 @@ class TestDeviceMessaging():
     @pytest.fixture
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker)
         return service_client
 
     def test_c2d_receive(self, serviceclient):
@@ -1714,11 +1696,7 @@ class TestDeviceSimulate():
     @pytest.fixture(params=[204])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        response.text = ""
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, "")
         return service_client
 
     @pytest.fixture()
@@ -1775,10 +1753,7 @@ class TestMonitorEvents():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        del response._attribute_map
-        response.status_code = request.param
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param)
         existing_target = fixture_ghcs.return_value
         existing_target['events'] = {}
         existing_target['events']['partition_ids'] = []

--- a/azext_iot/tests/test_iot_ext_unit.py
+++ b/azext_iot/tests/test_iot_ext_unit.py
@@ -77,26 +77,14 @@ def fixture_sas(mocker):
 @pytest.fixture(params=[400, 401, 500])
 def serviceclient_generic_error(mocker, fixture_ghcs, fixture_sas, request):
     service_client = mocker.patch(path_service_client)
-    response = mocker.MagicMock(name='response')
-    response.status_code = request.param
-    del response.context
-    del response._attribute_map
-    response.text.return_value = json.dumps({'error': 'something failed'})
-
-    service_client.return_value = response
+    service_client.return_value = build_mock_response(mocker, request.param, {'error': 'something failed'})
     return service_client
 
 
 @pytest.fixture(params=[{'etag': None}, {}])
 def serviceclient_generic_invalid_or_missing_etag(mocker, fixture_ghcs, fixture_sas, request):
     service_client = mocker.patch(path_service_client)
-    response = mocker.MagicMock(name='response')
-    response.status_code = 200
-    del response.context
-    del response._attribute_map
-    response.text.return_value = json.dumps(request.param)
-
-    service_client.return_value = response
+    service_client.return_value = build_mock_response(mocker, 200, request.param)
     return service_client
 
 
@@ -1261,11 +1249,7 @@ class TestQuery():
     @pytest.fixture(params=[200])
     def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
         service_client = mocker.patch(path_service_client)
-        response = mocker.MagicMock(name='response')
-        response.status_code = request.param
-        del response.context
-        del response._attribute_map
-        service_client.return_value = response
+        service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
     @pytest.mark.parametrize("query, servresult, servtotal, top", [


### PR DESCRIPTION
This PR is focused on fixing the IoT Hub + DPS mocking pattern as msrest serviceclient interaction has changed recently breaking our CI.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
