### PR TITLE
Add device filtering capabilities (wildcard and regex) to monitor-events

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,9 +3,12 @@
 Release History
 ===============
 
-0.6.1
+0.6.2
 +++++++++++++++
 * Added wildcard and regex device filtering to monitor-events.
+
+0.6.1
++++++++++++++++
 * Added --output support to monitor-events. Supports either json or yaml, i.e. az iot hub monitor-events --hub-name {} -d {} --output yaml
 * Changed monitor-events to output JSON by default
 * Added support to parse and display payload as JSON if system property Content-Type is provided and application/json (i.e. send-d2c-message ... --props $.ct=application/json from the CLI) or if monitor-events has a property --content-type/--ct of application/json (i.e. monitor-events --ct application/json).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 0.6.1
 +++++++++++++++
+* Added wildcard and regex device filtering to monitor-events.
 * Added --output support to monitor-events. Supports either json or yaml, i.e. az iot hub monitor-events --hub-name {} -d {} --output yaml
 * Changed monitor-events to output JSON by default
 * Added support to parse and display payload as JSON if system property Content-Type is provided and application/json (i.e. send-d2c-message ... --props $.ct=application/json from the CLI) or if monitor-events has a property --content-type/--ct of application/json (i.e. monitor-events --ct application/json).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Release History
 
 0.6.2
 +++++++++++++++
-* Added wildcard and regex device filtering to monitor-events.
+* Added support for deviceId wildcards and IoT Hub query language filtering to monitor-events.
 
 0.6.1
 +++++++++++++++

--- a/azext_iot/_constants.py
+++ b/azext_iot/_constants.py
@@ -6,7 +6,7 @@
 
 import os
 
-VERSION = '0.6.1'
+VERSION = '0.6.2'
 EXTENSION_NAME = 'azure-cli-iot-ext'
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = 'iotext'

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -42,6 +42,12 @@ helps['iot hub monitor-events'] = """
     - name: Basic usage when filtering on target device
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d [Device ID]
+    - name: Basic usage when filtering targeted devices with a wildcard in the ID
+      text: >
+        az iot hub monitor-events -n [IoTHub Name] -d Device*
+    - name: Basic usage when filtering targeted devices with regex filter
+      text: >
+        az iot hub monitor-events -n [IoTHub Name] --device-regex 'Device-[0-9]*'
     - name: Filter device and specify an Event Hub consumer group to bind to.
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d [Device ID] --cg [Consumer Group Name]

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -45,6 +45,9 @@ helps['iot hub monitor-events'] = """
     - name: Basic usage when filtering targeted devices with a wildcard in the ID
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d Device*
+    - name: Filter devices using IoT Hub query language
+      text: >
+        az iot hub monitor-events -n [IoTHub Name] -q "select * from devices where tags.location.region = 'US'"
     - name: Filter device and specify an Event Hub consumer group to bind to.
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d [Device ID] --cg [Consumer Group Name]

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -45,9 +45,6 @@ helps['iot hub monitor-events'] = """
     - name: Basic usage when filtering targeted devices with a wildcard in the ID
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d Device*
-    - name: Basic usage when filtering targeted devices with regex filter
-      text: >
-        az iot hub monitor-events -n [IoTHub Name] --device-regex 'Device-[0-9]*'
     - name: Filter device and specify an Event Hub consumer group to bind to.
       text: >
         az iot hub monitor-events -n [IoTHub Name] -d [Device ID] --cg [Consumer Group Name]

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -119,8 +119,6 @@ def load_arguments(self, _):
         context.argument('properties', options_list=['--properties', '--props', '-p'], arg_type=event_msg_prop_type)
         context.argument('content_type', options_list=['--content-type', '--ct'],
                          help='Specify the Content-Type of the message payload to automatically format the output to that type.')
-        context.argument('device_regex', options_list=['--device-regex', '--regex'],
-                         help='Specify a regular expression to filter devices')
 
     with self.argument_context('iot hub monitor-feedback') as context:
         context.argument('wait_on_id', options_list=['--wait-on-msg', '-w'],

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -119,6 +119,8 @@ def load_arguments(self, _):
         context.argument('properties', options_list=['--properties', '--props', '-p'], arg_type=event_msg_prop_type)
         context.argument('content_type', options_list=['--content-type', '--ct'],
                          help='Specify the Content-Type of the message payload to automatically format the output to that type.')
+        context.argument('device_regex', options_list=['--device_regex', '--regex'],
+                         help='Specify a regular expression to filter devices')
 
     with self.argument_context('iot hub monitor-feedback') as context:
         context.argument('wait_on_id', options_list=['--wait-on-msg', '-w'],

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -119,7 +119,7 @@ def load_arguments(self, _):
         context.argument('properties', options_list=['--properties', '--props', '-p'], arg_type=event_msg_prop_type)
         context.argument('content_type', options_list=['--content-type', '--ct'],
                          help='Specify the Content-Type of the message payload to automatically format the output to that type.')
-        context.argument('device_regex', options_list=['--device_regex', '--regex'],
+        context.argument('device_regex', options_list=['--device-regex', '--regex'],
                          help='Specify a regular expression to filter devices')
 
     with self.argument_context('iot hub monitor-feedback') as context:

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -119,6 +119,7 @@ def load_arguments(self, _):
         context.argument('properties', options_list=['--properties', '--props', '-p'], arg_type=event_msg_prop_type)
         context.argument('content_type', options_list=['--content-type', '--ct'],
                          help='Specify the Content-Type of the message payload to automatically format the output to that type.')
+        context.argument('device_query', options_list=['--device-query', '-q'], help='Specify a custom query to filter devices.')
 
     with self.argument_context('iot hub monitor-feedback') as context:
         context.argument('wait_on_id', options_list=['--wait-on-msg', '-w'],

--- a/azext_iot/azext_metadata.json
+++ b/azext_iot/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.minCliCoreVersion": "2.0.24",
-    "version": "0.6.1"
+    "version": "0.6.2"
 }

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -26,10 +26,11 @@ logger = get_logger(__name__)
 DEBUG = True
 
 
-def executor(target, consumer_group, enqueued_time, device_id=None, properties=None, timeout=0, output=None, content_type=None):
+def executor(target, consumer_group, enqueued_time, device_id=None, properties=None, timeout=0, output=None, content_type=None,
+             device_regex=None):
     coroutines = []
     coroutines.append(initiate_event_monitor(target, consumer_group, enqueued_time, device_id, properties,
-                                             timeout, output, content_type))
+                                             timeout, output, content_type, device_regex))
     loop = asyncio.get_event_loop()
     if loop.is_closed():
         loop = asyncio.new_event_loop()
@@ -66,7 +67,7 @@ def executor(target, consumer_group, enqueued_time, device_id=None, properties=N
 
 
 async def initiate_event_monitor(target, consumer_group, enqueued_time, device_id=None, properties=None,
-                                 timeout=0, output=None, content_type=None):
+                                 timeout=0, output=None, content_type=None, device_regex=None):
     def _get_conn_props():
         properties = {}
         properties["product"] = "az.cli.iot.extension"
@@ -110,13 +111,14 @@ async def initiate_event_monitor(target, consumer_group, enqueued_time, device_i
                                              device_id=device_id,
                                              timeout=timeout,
                                              output=output,
-                                             content_type=content_type))
+                                             content_type=content_type,
+                                             device_regex=device_regex))
         await asyncio.gather(*coroutines, return_exceptions=True)
 
 
 # pylint: disable=too-many-statements
 async def monitor_events(endpoint, connection, path, auth, partition, consumer_group, enqueuedtimeutc,
-                         properties, device_id=None, timeout=0, output=None, content_type=None):
+                         properties, device_id=None, timeout=0, output=None, content_type=None, device_regex=None):
     source = uamqp.address.Source('amqps://{}/{}/ConsumerGroups/{}/Partitions/{}'.format(endpoint, path,
                                                                                          consumer_group, partition))
     source.set_filter(
@@ -125,7 +127,7 @@ async def monitor_events(endpoint, connection, path, auth, partition, consumer_g
     def _output_msg_kpi(msg):
         # TODO: Determine if amqp filters can support boolean operators for multiple conditions
         origin = str(msg.annotations.get(b'iothub-connection-device-id'), 'utf8')
-        if device_id and origin != device_id:
+        if (device_id and origin != device_id) or (device_regex and not re.match(device_regex, origin)):
             return
 
         event_source = {'event': {}}

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -26,11 +26,10 @@ logger = get_logger(__name__)
 DEBUG = True
 
 
-def executor(target, consumer_group, enqueued_time, device_id=None, properties=None, timeout=0, output=None, content_type=None,
-             device_regex=None):
+def executor(target, consumer_group, enqueued_time, device_id=None, properties=None, timeout=0, output=None, content_type=None):
     coroutines = []
     coroutines.append(initiate_event_monitor(target, consumer_group, enqueued_time, device_id, properties,
-                                             timeout, output, content_type, device_regex))
+                                             timeout, output, content_type))
     loop = asyncio.get_event_loop()
     if loop.is_closed():
         loop = asyncio.new_event_loop()
@@ -67,7 +66,7 @@ def executor(target, consumer_group, enqueued_time, device_id=None, properties=N
 
 
 async def initiate_event_monitor(target, consumer_group, enqueued_time, device_id=None, properties=None,
-                                 timeout=0, output=None, content_type=None, device_regex=None):
+                                 timeout=0, output=None, content_type=None):
     def _get_conn_props():
         properties = {}
         properties["product"] = "az.cli.iot.extension"
@@ -111,14 +110,13 @@ async def initiate_event_monitor(target, consumer_group, enqueued_time, device_i
                                              device_id=device_id,
                                              timeout=timeout,
                                              output=output,
-                                             content_type=content_type,
-                                             device_regex=device_regex))
+                                             content_type=content_type))
         await asyncio.gather(*coroutines, return_exceptions=True)
 
 
 # pylint: disable=too-many-statements
 async def monitor_events(endpoint, connection, path, auth, partition, consumer_group, enqueuedtimeutc,
-                         properties, device_id=None, timeout=0, output=None, content_type=None, device_regex=None):
+                         properties, device_id=None, timeout=0, output=None, content_type=None):
     source = uamqp.address.Source('amqps://{}/{}/ConsumerGroups/{}/Partitions/{}'.format(endpoint, path,
                                                                                          consumer_group, partition))
     source.set_filter(
@@ -127,13 +125,13 @@ async def monitor_events(endpoint, connection, path, auth, partition, consumer_g
     def _output_msg_kpi(msg):
         # TODO: Determine if amqp filters can support boolean operators for multiple conditions
         origin = str(msg.annotations.get(b'iothub-connection-device-id'), 'utf8')
-        if device_id:
-            regex = re.escape(device_id).replace("\\*", ".*").replace('\\?', ".") + "$"
-            if not re.match(regex, origin):
+        if device_id and device_id != origin:
+            if '*' in device_id or '?' in device_id:
+                regex = re.escape(device_id).replace("\\*", ".*").replace('\\?', ".") + "$"
+                if not re.match(regex, origin):
+                    return
+            else:
                 return
-
-        if device_regex and not re.match(device_regex, origin):
-            return
 
         event_source = {'event': {}}
 

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -127,7 +127,12 @@ async def monitor_events(endpoint, connection, path, auth, partition, consumer_g
     def _output_msg_kpi(msg):
         # TODO: Determine if amqp filters can support boolean operators for multiple conditions
         origin = str(msg.annotations.get(b'iothub-connection-device-id'), 'utf8')
-        if (device_id and origin != device_id) or (device_regex and not re.match(device_regex, origin)):
+        if device_id:
+            regex = re.escape(device_id).replace("\\*", ".*").replace('\\?', ".") + "$"
+            if not re.match(regex, origin):
+                return
+
+        if device_regex and not re.match(device_regex, origin):
             return
 
         event_source = {'event': {}}

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1116,7 +1116,7 @@ def iot_device_upload_file(cmd, device_id, file_path, content_type, hub_name=Non
 # pylint: disable=too-many-locals
 def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$Default', timeout=300,
                            enqueued_time=None, resource_group_name=None, yes=False, properties=None, repair=False,
-                           login=None, content_type=None, device_regex=None):
+                           login=None, content_type=None):
     import importlib
     from azext_iot.common.deps import ensure_uamqp
     from azext_iot.common.utility import validate_min_python_version
@@ -1149,9 +1149,7 @@ def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$
                      timeout=timeout,
                      device_id=device_id,
                      output=output,
-                     content_type=content_type,
-                     device_regex=device_regex)
-
+                     content_type=content_type)
 
 def iot_hub_monitor_feedback(cmd, hub_name=None, device_id=None, yes=False,
                              wait_on_id=None, repair=False, resource_group_name=None, login=None):

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1116,10 +1116,11 @@ def iot_device_upload_file(cmd, device_id, file_path, content_type, hub_name=Non
 # pylint: disable=too-many-locals
 def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$Default', timeout=300,
                            enqueued_time=None, resource_group_name=None, yes=False, properties=None, repair=False,
-                           login=None, content_type=None):
+                           login=None, content_type=None, device_query=None):
     import importlib
     from azext_iot.common.deps import ensure_uamqp
     from azext_iot.common.utility import validate_min_python_version
+
     validate_min_python_version(3, 5)
 
     if timeout < 0:
@@ -1141,6 +1142,13 @@ def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$
     if not enqueued_time:
         enqueued_time = calculate_millisec_since_unix_epoch_utc()
 
+    device_ids = {}
+    if device_query:
+        devices_result = iot_query(cmd, device_query, hub_name, None, resource_group_name, login=login)
+        if devices_result:
+            for device_result in devices_result:
+                device_ids[device_result['deviceId']] = True
+
     target = get_iot_hub_connection_string(cmd, hub_name, resource_group_name, include_events=True, login=login)
     events3.executor(target,
                      consumer_group=consumer_group,
@@ -1149,7 +1157,8 @@ def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$
                      timeout=timeout,
                      device_id=device_id,
                      output=output,
-                     content_type=content_type)
+                     content_type=content_type,
+                     devices=device_ids)
 
 def iot_hub_monitor_feedback(cmd, hub_name=None, device_id=None, yes=False,
                              wait_on_id=None, repair=False, resource_group_name=None, login=None):

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1160,6 +1160,7 @@ def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$
                      content_type=content_type,
                      devices=device_ids)
 
+
 def iot_hub_monitor_feedback(cmd, hub_name=None, device_id=None, yes=False,
                              wait_on_id=None, repair=False, resource_group_name=None, login=None):
     from azext_iot.common.deps import ensure_uamqp

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1116,11 +1116,10 @@ def iot_device_upload_file(cmd, device_id, file_path, content_type, hub_name=Non
 # pylint: disable=too-many-locals
 def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$Default', timeout=300,
                            enqueued_time=None, resource_group_name=None, yes=False, properties=None, repair=False,
-                           login=None, content_type=None):
+                           login=None, content_type=None, device_regex=None):
     import importlib
     from azext_iot.common.deps import ensure_uamqp
     from azext_iot.common.utility import validate_min_python_version
-
     validate_min_python_version(3, 5)
 
     if timeout < 0:
@@ -1150,7 +1149,8 @@ def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$
                      timeout=timeout,
                      device_id=device_id,
                      output=output,
-                     content_type=content_type)
+                     content_type=content_type,
+                     device_regex=device_regex)
 
 
 def iot_hub_monitor_feedback(cmd, hub_name=None, device_id=None, yes=False,

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -36,8 +36,9 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 
 PRIMARY_THUMBPRINT = 'A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C'
 SECONDARY_THUMBPRINT = '14963E8F3BA5B3984110B3C1CA8E8B8988599087'
-device_regex_prefix = "regex-test-device-"
-device_prefix = 'test-device-'
+
+DEVICE_REGEX_PREFIX = 'regex-test-device-'
+DEVICE_PREFIX = 'test-device-'
 
 
 class TestIoTHub(LiveScenarioTest):
@@ -65,7 +66,7 @@ class TestIoTHub(LiveScenarioTest):
         if devices:
             device_ids = []
             for _ in range(devices):
-                device_ids.append(self.create_random_name(prefix=device_prefix, length=32))
+                device_ids.append(self.create_random_name(prefix=DEVICE_PREFIX, length=32))
             result['device_ids'] = device_ids
 
         if edge_devices:
@@ -89,7 +90,7 @@ class TestIoTHub(LiveScenarioTest):
         if regex_test_devices:
             regex_device_ids = []
             for _ in range(regex_test_devices):
-                regex_device_ids.append(self.create_random_name(prefix=device_regex_prefix, length=32))
+                regex_device_ids.append(self.create_random_name(prefix=DEVICE_REGEX_PREFIX, length=32))
             result['regex_device_ids'] = regex_device_ids
 
         self._entity_names = result
@@ -1195,7 +1196,7 @@ class TestIoTHub(LiveScenarioTest):
         device_count = 10
 
         regex_device_count = 5
-        device_regex = device_regex_prefix + "[a-z]*"
+        device_regex = DEVICE_REGEX_PREFIX + '[.]*'
 
         # Test with invalid connection string
         self.cmd('iot hub monitor-events -t 1 -y --login {}'.format(LIVE_HUB_CS + 'zzz'), expect_failure=True)
@@ -1234,7 +1235,7 @@ class TestIoTHub(LiveScenarioTest):
 
         # Monitor events with device-id wildcards
         self.command_execute_assert('iot hub monitor-events -n {} -g {} -d {} --et {} -t 10 -y -p sys anno app'
-                                    .format(LIVE_HUB, LIVE_RG, device_prefix + '*', enqueued_time),
+                                    .format(LIVE_HUB, LIVE_RG, DEVICE_PREFIX + '*', enqueued_time),
                                     device_ids)
 
         # Monitor events with --login parameter
@@ -1282,7 +1283,6 @@ class TestIoTHub(LiveScenarioTest):
         # Monitor messages to ensure it returns improperly formatted JSON
         self.command_execute_assert('iot hub monitor-events -n {} -g {} --cg {} --et {} -t 10 -y'.format(
             LIVE_HUB, LIVE_RG, LIVE_CONSUMER_GROUPS[0], enqueued_time), ['{\\r\\n\\"payload_data1\\"\\"payload_value1\\"\\r\\n}'])
-
 
         enqueued_time = calculate_millisec_since_unix_epoch_utc()
 

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -39,6 +39,7 @@ SECONDARY_THUMBPRINT = '14963E8F3BA5B3984110B3C1CA8E8B8988599087'
 
 DEVICE_PREFIX = 'test-device-'
 
+
 class TestIoTHub(LiveScenarioTest):
     def __init__(self, _):
         from iotext_test_tools import DummyCliOutputProducer
@@ -1219,7 +1220,7 @@ class TestIoTHub(LiveScenarioTest):
                                     device_ids)
 
         # Monitor events for specific devices using query language
-        device_subset_include = device_ids[:device_count//2]
+        device_subset_include = device_ids[:device_count // 2]
         device_include_string = ', '.join(['\'' + deviceId + '\'' for deviceId in device_subset_include])
         query_string = 'select * from devices where deviceId in [{}]'.format(device_include_string)
 
@@ -1228,7 +1229,7 @@ class TestIoTHub(LiveScenarioTest):
                                     device_subset_include)
 
         # Expect failure for excluded devices
-        device_subset_exclude = device_ids[device_count//2:]
+        device_subset_exclude = device_ids[device_count // 2:]
         with pytest.raises(Exception):
             self.command_execute_assert('iot hub monitor-events -n {} -g {} --device-query "{}" --et {} -t 10 -y -p sys anno app'
                                         .format(LIVE_HUB, LIVE_RG, query_string, enqueued_time),


### PR DESCRIPTION
The purpose of this PR is to add device filtering capabilities to the monitor-events command.

This allows users to filter devices with wildcards in the Device ID (like: "Device?Name*" ) as well as with a separate regex argument such as "Device[0-9]*"


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
