### PR TITLE
Removing the duplicate command "az iot hub show-connection-string"

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Release History
 * Added support for edge offline commands.
 * Upgrade service Sdk to 2018-08-30-preview.
 * Added --set-parent and --add-children to device-identity create to support edge offline feature.
+* BREAKING CHANGES: The command "az iot hub show-connection-string" will no longer return the output with key "cs".
 
 0.6.1
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ Release History
 * Added support for edge offline commands.
 * Upgrade service Sdk to 2018-08-30-preview.
 * Added --set-parent and --add-children to device-identity create to support edge offline feature.
-* BREAKING CHANGES: The command "az iot hub show-connection-string" will no longer return the output with key "cs".
+* BREAKING CHANGES: The commands "az iot hub show-connection-string", "az iot hub device-identity show-connection-string" and "az iot hub module-identity show-connection-string" will no longer return the output with key "cs".
 
 0.6.1
 +++++++++++++++

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -418,11 +418,6 @@ helps['iot hub query'] = """
         az iot hub query -n {iothub_name} -q "select * from devices.modules where devices.deviceId = '{device_id}'"
 """
 
-helps['iot hub show-connection-string'] = """
-    type: command
-    short-summary: Show a target IoT Hub Connection String.
-"""
-
 helps['iot hub configuration'] = """
     type: group
     short-summary: Manage IoT device configurations at scale

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -26,8 +26,6 @@ def load_command_table(self, _):
         cmd_group.command('monitor-events', 'iot_hub_monitor_events')
         cmd_group.command('monitor-feedback', 'iot_hub_monitor_feedback')
 
-        cmd_group.command('show-connection-string', 'iot_get_hub_connection_string')
-
     with self.command_group('iot hub device-identity', command_type=iothub_ops) as cmd_group:
         cmd_group.command('create', 'iot_device_create')
         cmd_group.command('show', 'iot_device_show')

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -976,7 +976,7 @@ def iot_get_device_connection_string(cmd, device_id, hub_name=None, key_type='pr
     result = {}
     device = iot_device_show(cmd, device_id,
                              hub_name=hub_name, resource_group_name=resource_group_name, login=login)
-    result['cs'] = _build_device_or_module_connection_string(device, key_type)
+    result['connectionString'] = _build_device_or_module_connection_string(device, key_type)
     return result
 
 
@@ -985,7 +985,7 @@ def iot_get_module_connection_string(cmd, device_id, module_id, hub_name=None, k
     result = {}
     module = iot_device_module_show(cmd, device_id, module_id,
                                     resource_group_name=resource_group_name, hub_name=hub_name, login=login)
-    result['cs'] = _build_device_or_module_connection_string(None, key_type, module)
+    result['connectionString'] = _build_device_or_module_connection_string(None, key_type, module)
     return result
 
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -961,6 +961,8 @@ def _build_device_or_module_connection_string(device, key_type='primary', module
     raise CLIError('Unable to form target connection string')
 
 
+# Introducing breaking changes by removing this command as same command exist in core-cli.
+# Only removing the command and keeping command defination for further references.
 def iot_get_hub_connection_string(cmd, hub_name, policy_name='iothubowner', key_type='primary',
                                   resource_group_name=None):
     result = {}

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -356,15 +356,15 @@ class TestIoTHub(LiveScenarioTest):
 
         self.cmd('iot hub device-identity show-connection-string -d {} -n {} -g {}'
                  .format(edge_device_ids[0], LIVE_HUB, LIVE_RG),
-                 checks=[self.check_pattern('cs', sym_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', sym_conn_str_pattern)])
 
         self.cmd('iot hub device-identity show-connection-string -d {} -n {} -g {} --kt {}'
                  .format(edge_device_ids[0], LIVE_HUB, LIVE_RG, 'secondary'),
-                 checks=[self.check_pattern('cs', sym_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', sym_conn_str_pattern)])
 
         self.cmd('iot hub device-identity show-connection-string -d {} -n {} -g {}'
                  .format(device_ids[2], LIVE_HUB, LIVE_RG),
-                 checks=[self.check_pattern('cs', cer_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', cer_conn_str_pattern)])
 
         self.cmd('iot hub generate-sas-token -n {} -g {} -d {}'.format(LIVE_HUB, LIVE_RG, edge_device_ids[0]), checks=[
             self.exists('sas')
@@ -650,16 +650,16 @@ class TestIoTHub(LiveScenarioTest):
             LIVE_HUB, edge_device_ids[0], module_ids[0])
         self.cmd('iot hub module-identity show-connection-string -d {} -n {} -g {} -m {}'
                  .format(edge_device_ids[0], LIVE_HUB, LIVE_RG, module_ids[0]),
-                 checks=[self.check_pattern('cs', mod_sym_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', mod_sym_conn_str_pattern)])
 
         # With connection string
         self.cmd('iot hub module-identity show-connection-string -d {} --login {} -m {}'
                  .format(edge_device_ids[0], LIVE_HUB_CS, module_ids[0]),
-                 checks=[self.check_pattern('cs', mod_sym_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', mod_sym_conn_str_pattern)])
 
         self.cmd('iot hub module-identity show-connection-string -d {} -n {} -g {} -m {} --kt {}'
                  .format(edge_device_ids[0], LIVE_HUB, LIVE_RG, module_ids[0], "secondary"),
-                 checks=[self.check_pattern('cs', mod_sym_conn_str_pattern)])
+                 checks=[self.check_pattern('connectionString', mod_sym_conn_str_pattern)])
 
         for i in module_ids:
             if module_ids.index(i) == (len(module_ids) - 1):

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -128,19 +128,6 @@ class TestIoTHub(LiveScenarioTest):
             self._remove_entities()
 
     def test_hub(self):
-        hub_policy = "iothubowner"
-
-        hub_conn_str_pattern = r'^HostName={}\.azure-devices\.net;SharedAccessKeyName={};SharedAccessKey='.format(
-            LIVE_HUB, hub_policy)
-
-        self.cmd('iot hub show-connection-string -n {} -g {}'.format(LIVE_HUB, LIVE_RG), checks=[
-            self.check_pattern('cs', hub_conn_str_pattern)
-        ])
-        self.cmd('iot hub show-connection-string -n {} -g {} --kt {}'.format(LIVE_HUB, LIVE_RG, 'secondary'), checks=[
-            self.check_pattern('cs', hub_conn_str_pattern)
-        ])
-        self.cmd('iot hub show-connection-string -n {} -g {} --kt {} --pn doesnotexist'.format(LIVE_HUB, LIVE_RG, 'secondary'),
-                 expect_failure=True)
 
         self.cmd('az iot hub generate-sas-token -n {} -g {}'.format(LIVE_HUB, LIVE_RG), checks=[
             self.exists('sas')


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
