### PR TITLE
filter certain meta elements of edge deployment payload + help update

### DIFF
--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -658,9 +658,12 @@ helps['iot edge deployment list'] = """
 
 helps['iot edge deployment update'] = """
     type: command
-    short-summary: Update an IoT Edge deployment with the specified properties.
-    long-summary: Use --set followed by property assignments for updating a deployment.
-                  Leverage properties returned from 'az iot edge deployment show'.
+    short-summary: Update specified properties of an IoT Edge deployment.
+    long-summary: |
+                  Use --set followed by property assignments for updating a deployment.
+
+                  Note: IoT Edge deployment content is immutable. Deployment properties that can be
+                  updated are 'labels', 'metrics', 'priority' and 'targetCondition'.
     examples:
     - name: Alter the labels and target condition of an existing edge deployment
       text: >

--- a/azext_iot/tests/test_iot_pnp_int.py
+++ b/azext_iot/tests/test_iot_pnp_int.py
@@ -36,9 +36,7 @@ class TestPnPModel(LiveScenarioTest):
     rand_val = random.randint(1, 10001)
 
     def __init__(self, _):
-        from . import DummyCliOutputProducer
         super(TestPnPModel, self).__init__(_)
-        self.cli_ctx = DummyCliOutputProducer()
         self.kwargs.update({
             'endpoint': _endpoint,
             'repo': _repo_id,


### PR DESCRIPTION
- Help for `deployment update` accurately describes what can be updated in an edge deployment
- Filter certain elements of edge deployment payload, requested in issue #100 
- Removed legacy test artifact, that CLI core supports natively
- integration + unit tests

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
