### PR TITLE
[Bug Fix] DT monitor-events with passing interface name

### DIFF
--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -219,7 +219,7 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
                 telemetry_data = {'display': telemetry.get('displayName'), 'unit': telemetry.get('unit')}
                 pnp_context['interface'][entity['name']][telemetry['name']] = telemetry_data
 
-    _iot_hub_monitor_events(cmd=cmd, interface=interface_name, pnp_context=pnp_context,
+    _iot_hub_monitor_events(cmd=cmd, interface_name=interface_name, pnp_context=pnp_context,
                             hub_name=hub_name, device_id=device_id, consumer_group=consumer_group, timeout=timeout,
                             enqueued_time=None, resource_group_name=resource_group_name,
                             yes=yes, properties=properties, repair=repair,

--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -182,7 +182,7 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
     source_model = source_model.lower()
     pnp_context = {'enabled': True, 'interface': {}}
     target_interfaces = []
-    interface_id = None
+    interface_name = None
     if all([device_id, device_query]):
         raise CLIError('You cannot use --device-id/-d and --device-query/-q at the same time!')
 
@@ -199,7 +199,7 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
 
         if interface:
             target_interfaces.append(target_interface)
-            interface_id = interface
+            interface_name = interface
         else:
             target_interfaces = interface_list
 
@@ -219,7 +219,7 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
                 telemetry_data = {'display': telemetry.get('displayName'), 'unit': telemetry.get('unit')}
                 pnp_context['interface'][entity['name']][telemetry['name']] = telemetry_data
 
-    _iot_hub_monitor_events(cmd=cmd, interface=interface_id, pnp_context=pnp_context,
+    _iot_hub_monitor_events(cmd=cmd, interface=interface_name, pnp_context=pnp_context,
                             hub_name=hub_name, device_id=device_id, consumer_group=consumer_group, timeout=timeout,
                             enqueued_time=None, resource_group_name=resource_group_name,
                             yes=yes, properties=properties, repair=repair,

--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -185,9 +185,6 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
     if all([device_id, device_query]):
         raise CLIError('You cannot use --device-id/-d and --device-query/-q at the same time!')
 
-    if all([interface, device_query]):
-        raise CLIError('You cannot use --interface/-i and --device-query/-q at the same time!')
-
     if device_id:
         device_interfaces = _iot_digitaltwin_interface_list(cmd, device_id, hub_name, resource_group_name, login)
         interface_list = _get_device_default_interface_dict(device_interfaces)

--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -199,12 +199,12 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
 
         if interface:
             target_interfaces.append(target_interface)
-            interface_id = target_interface['urn_id']
+            interface_id = interface
         else:
             target_interfaces = interface_list
 
         for entity in target_interfaces:
-            pnp_context['interface'][entity['urn_id']] = {}
+            pnp_context['interface'][entity['name']] = {}
             found_telemetry = []
             if source_model == ModelSourceType.device.value.lower():
                 found_telemetry = _device_interface_elements(cmd, device_id, entity['urn_id'], INTERFACE_TELEMETRY,
@@ -217,7 +217,7 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
 
             for telemetry in found_telemetry:
                 telemetry_data = {'display': telemetry.get('displayName'), 'unit': telemetry.get('unit')}
-                pnp_context['interface'][entity['urn_id']][telemetry['name']] = telemetry_data
+                pnp_context['interface'][entity['name']][telemetry['name']] = telemetry_data
 
     _iot_hub_monitor_events(cmd=cmd, interface=interface_id, pnp_context=pnp_context,
                             hub_name=hub_name, device_id=device_id, consumer_group=consumer_group, timeout=timeout,

--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -182,7 +182,6 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
     source_model = source_model.lower()
     pnp_context = {'enabled': True, 'interface': {}}
     target_interfaces = []
-    interface_name = None
     if all([device_id, device_query]):
         raise CLIError('You cannot use --device-id/-d and --device-query/-q at the same time!')
 
@@ -199,7 +198,6 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
 
         if interface:
             target_interfaces.append(target_interface)
-            interface_name = interface
         else:
             target_interfaces = interface_list
 
@@ -219,9 +217,9 @@ def iot_digitaltwin_monitor_events(cmd, device_id=None, device_query=None, inter
                 telemetry_data = {'display': telemetry.get('displayName'), 'unit': telemetry.get('unit')}
                 pnp_context['interface'][entity['name']][telemetry['name']] = telemetry_data
 
-    _iot_hub_monitor_events(cmd=cmd, interface_name=interface_name, pnp_context=pnp_context,
-                            hub_name=hub_name, device_id=device_id, consumer_group=consumer_group, timeout=timeout,
-                            enqueued_time=None, resource_group_name=resource_group_name,
+    _iot_hub_monitor_events(cmd=cmd, interface_name=interface, pnp_context=pnp_context,
+                            hub_name=hub_name, device_id=device_id, consumer_group=consumer_group,
+                            timeout=timeout, resource_group_name=resource_group_name,
                             yes=yes, properties=properties, repair=repair,
                             login=login, device_query=device_query)
 

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -193,14 +193,14 @@ async def monitor_events(
             return
 
         if pnp_context:
-            msg_interface_id = str(
+            msg_interface_name = str(
                 msg.annotations.get(b"iothub-interface-name"), "utf8"
             )
-            if not msg_interface_id:
+            if not msg_interface_name:
                 return
-
+            # interface_id: it is the interface name
             if interface_id:
-                if msg_interface_id != interface_id:
+                if msg_interface_name != interface_id:
                     return
 
         event_source = {"event": {}}
@@ -229,12 +229,12 @@ async def monitor_events(
         event_source["event"]["payload"] = payload
 
         if pnp_context:
-            event_source["event"]["interface"] = msg_interface_id
+            event_source["event"]["interface"] = msg_interface_name
 
             msg_schema = str(
                 msg.application_properties.get(b"iothub-message-schema"), "utf8"
             )
-            interface_context = pnp_context["interface"].get(msg_interface_id)
+            interface_context = pnp_context["interface"].get(msg_interface_name)
             if interface_context:
                 msg_schema_context = interface_context.get(msg_schema)
                 if msg_schema_context:

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -34,7 +34,7 @@ def executor(
     output=None,
     content_type=None,
     devices=None,
-    interface_id=None,
+    interface_name=None,
     pnp_context=None,
 ):
 
@@ -50,7 +50,7 @@ def executor(
             output,
             content_type,
             devices,
-            interface_id,
+            interface_name,
             pnp_context,
         )
     )
@@ -105,7 +105,7 @@ async def initiate_event_monitor(
     output=None,
     content_type=None,
     devices=None,
-    interface_id=None,
+    interface_name=None,
     pnp_context=None,
 ):
     def _get_conn_props():
@@ -145,7 +145,7 @@ async def initiate_event_monitor(
                     output=output,
                     content_type=content_type,
                     devices=devices,
-                    interface_id=interface_id,
+                    interface_name=interface_name,
                     pnp_context=pnp_context,
                 )
             )
@@ -166,7 +166,7 @@ async def monitor_events(
     output=None,
     content_type=None,
     devices=None,
-    interface_id=None,
+    interface_name=None,
     pnp_context=None,
 ):
     source = uamqp.address.Source(
@@ -198,9 +198,8 @@ async def monitor_events(
             )
             if not msg_interface_name:
                 return
-            # interface_id: it is the interface name
-            if interface_id:
-                if msg_interface_name != interface_id:
+            if interface_name:
+                if msg_interface_name != interface_name:
                     return
 
         event_source = {"event": {}}

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1334,7 +1334,7 @@ def iot_device_upload_file(cmd, device_id, file_path, content_type, hub_name=Non
 def iot_hub_monitor_events(cmd, hub_name=None, device_id=None, consumer_group='$Default', timeout=300,
                            enqueued_time=None, resource_group_name=None, yes=False, properties=None, repair=False,
                            login=None, content_type=None, device_query=None):
-    _iot_hub_monitor_events(cmd, interface=None, pnp_context=None, hub_name=hub_name, device_id=device_id,
+    _iot_hub_monitor_events(cmd, hub_name=hub_name, device_id=device_id,
                             consumer_group=consumer_group, timeout=timeout, enqueued_time=enqueued_time,
                             resource_group_name=resource_group_name, yes=yes, properties=properties,
                             repair=repair, login=login, content_type=content_type, device_query=device_query)
@@ -1361,7 +1361,7 @@ def iot_hub_distributed_tracing_show(cmd, hub_name, device_id, resource_group_na
                                             device_twin['properties']['reported'])
 
 
-def _iot_hub_monitor_events(cmd, interface=None, pnp_context=None,
+def _iot_hub_monitor_events(cmd, interface_name=None, pnp_context=None,
                             hub_name=None, device_id=None, consumer_group='$Default', timeout=300,
                             enqueued_time=None, resource_group_name=None, yes=False, properties=None, repair=False,
                             login=None, content_type=None, device_query=None):
@@ -1392,7 +1392,7 @@ def _iot_hub_monitor_events(cmd, interface=None, pnp_context=None,
                      output=output,
                      content_type=content_type,
                      devices=device_ids,
-                     interface_name=interface,
+                     interface_name=interface_name,
                      pnp_context=pnp_context)
 
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1392,7 +1392,7 @@ def _iot_hub_monitor_events(cmd, interface=None, pnp_context=None,
                      output=output,
                      content_type=content_type,
                      devices=device_ids,
-                     interface_id=interface,
+                     interface_name=interface,
                      pnp_context=pnp_context)
 
 

--- a/azext_iot/tests/test_iot_digitaltwin_unit.py
+++ b/azext_iot/tests/test_iot_digitaltwin_unit.py
@@ -31,7 +31,7 @@ hub_entity = 'myhub.azure-devices.net'
 # Patch Paths #
 path_mqtt_client = 'azext_iot.operations._mqtt.mqtt.Client'
 path_service_client = 'msrest.service_client.ServiceClient.send'
-path_ghcs = 'azext_iot.operations.hub.get_iot_hub_connection_string'
+path_ghcs = 'azext_iot.operations.digitaltwin.get_iot_hub_connection_string'
 path_pnpcs = 'azext_iot.operations.pnp.get_iot_pnp_connection_string'
 path_iot_hub_service_factory = 'azext_iot.common._azure.iot_hub_service_factory'
 path_sas = 'azext_iot._factory.SasTokenAuthentication'
@@ -449,6 +449,15 @@ class TestDTMonitorEvents(object):
                                                yes=True, properties='all',
                                                login=mock_target['cs'])),
         (digitaltwin_monitor_events_create_req(device_id=device_id,
+                                               source_model='public', timeout=100,
+                                               yes=True, properties='all',
+                                               hub_name='myhub')),
+        (digitaltwin_monitor_events_create_req(device_id=device_id,
+                                               source_model='public', timeout=100,
+                                               yes=True, properties='all',
+                                               hub_name='myhub',
+                                               resource_group_name='myrg')),
+        (digitaltwin_monitor_events_create_req(device_id=device_id,
                                                source_model='private', repo_id=mock_pnptarget['repository_id'],
                                                yes=True, properties='all',
                                                login=mock_target['cs'])),
@@ -461,6 +470,10 @@ class TestDTMonitorEvents(object):
                                                device_query='select * from devices', 
                                                login=mock_target['cs'])),
         (digitaltwin_monitor_events_create_req(source_model='public',
+                                               interface_name='environmentalSensor',
+                                               login=mock_target['cs'])),
+        (digitaltwin_monitor_events_create_req(source_model='public',
+                                               device_query='select * from devices', 
                                                interface_name='environmentalSensor',
                                                login=mock_target['cs']))])
     def test_iot_digitaltwin_monitor_events(self, fixture_cmd, fixture_monitor_events, serviceclient, req):
@@ -517,9 +530,20 @@ class TestDTMonitorEvents(object):
         else:
             assert not monitor_events_args['timeout']
 
-        assert not monitor_events_args['hub_name']
-        assert not monitor_events_args['resource_group_name']
-        assert monitor_events_args['login'] == req['login']
+        if req['login']:
+            assert monitor_events_args['login'] == req['login']
+        else:
+            assert not monitor_events_args['login']
+
+        if req['hub_name']:
+            assert monitor_events_args['hub_name'] == req['hub_name']
+        else:
+            assert not monitor_events_args['hub_name']
+
+        if req['resource_group_name']:
+            assert monitor_events_args['resource_group_name'] == req['resource_group_name']
+        else:
+            assert not monitor_events_args['resource_group_name']
 
         if req['yes']:
             assert monitor_events_args['yes'] == req['yes']
@@ -555,11 +579,6 @@ class TestDTMonitorEvents(object):
     @pytest.mark.parametrize("req", [
         (digitaltwin_monitor_events_create_req(device_id=device_id,
                                                device_query='select * from devices',
-                                               source_model='public',
-                                               yes=True, properties='all',
-                                               login=mock_target['cs'])),
-        (digitaltwin_monitor_events_create_req(device_query='select * from devices',
-                                               interface_name='environmentalSensor',
                                                source_model='public',
                                                yes=True, properties='all',
                                                login=mock_target['cs'])),


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
