### PR TITLE
Re-add deprecated config-id parameter.

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -259,11 +259,6 @@ def load_arguments(self, _):
         context.argument('content_type', options_list=['--content-type', '--ct'],
                          help='MIME Type of file.')
 
-    # Remove after deprecation
-    with self.argument_context('iot hub apply-configuration') as context:
-        context.argument('content', options_list=['--content', '-k'],
-                         help='Configuration content. Provide file path or raw json.')
-
     with self.argument_context('iot hub configuration') as context:
         context.argument('config_id', options_list=['--config-id', '-c'],
                          help='Target device configuration name.')
@@ -282,8 +277,9 @@ def load_arguments(self, _):
                          help='Maximum number of configurations to return.')
 
     with self.argument_context('iot edge') as context:
-        context.argument('config_id', options_list=['--deployment-id', '-d'],
-                         help='Target deployment name.')
+        context.argument('config_id', options_list=['--deployment-id', '-d', '--config-id', '-c'],
+                         help="Target deployment name. Option '--config-id' has been deprecated and will be "
+                         "removed in a future release. Use '--deployment-id' instead.")
         context.argument('target_condition', options_list=['--target-condition', '--tc', '-t'],
                          help='Target condition in which an Edge deployment applies to.')
         context.argument('priority', options_list=['--priority', '--pri'],

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -6,7 +6,7 @@
 
 import os
 
-VERSION = "0.8.4"
+VERSION = "0.8.5"
 EXTENSION_NAME = "azure-cli-iot-ext"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -1550,7 +1550,7 @@ class TestIoTEdgeDeployments(IoTLiveScenarioTest):
 
         # Certain elements such as $schema included in the edge payload will be popped before validation
         self.cmd(
-            """iot edge deployment create --deployment-id {} --hub-name {} --resource-group {} --priority {}
+            """iot edge deployment create --config-id {} --hub-name {} --resource-group {} --priority {}
                     --target-condition \"{}\" --labels {} --content '{}'""".format(
                 config_ids[1],
                 LIVE_HUB,


### PR DESCRIPTION
Resolves #113 

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
