### PR TITLE
Better json parsing for json input arguments +other improvements

### DIFF
--- a/.azure-devops/create-release.yml
+++ b/.azure-devops/create-release.yml
@@ -11,7 +11,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -25,7 +25,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -40,7 +40,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.x'
+      pythonVersion: '3.7.x'
 
   - script: 'pip install .'
     displayName: 'Install the whl locally'

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -128,8 +128,9 @@ jobs:
       versionSpec: '3.7.x'
       architecture: 'x64'
 
-  - template: templates/install-azure-cli-released.yml
+  - template: templates/install-azure-cli-edge.yml
   - template: templates/install-azdev.yml
+  - template: templates/setup-ci-machine.yml # Likely temporary fix due to pkg_resources.ContextualVersionConflict from six ver 1.13.0 vs pinned 1.12.0
   - template: templates/download-install-local-azure-iot-cli-extension.yml
 
   - script: 'azdev cli-lint --ci --extensions $(iot_ext_package)'

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -31,7 +31,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -50,7 +50,7 @@ jobs:
   
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.x'
+      pythonVersion: '3.7.x'
 
 - job: 'Run_Tests_Windows_Azure_CLI_Released_Version'
   dependsOn : [Build_Publish_Azure_CLI_Test_SDK, 'Build_Publish_Azure_IoT_CLI_Extension']
@@ -60,7 +60,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.x'
+      pythonVersion: '3.7.x'
       runWithAzureCliReleased: 'true'
 
 - job: 'Run_Tests_Ubuntu'
@@ -74,7 +74,7 @@ jobs:
       Python36:
         python.version: '3.6.x'
       Python37:
-        python.version: '3.x'
+        python.version: '3.7.x'
     maxParallel: 3
 
   steps:
@@ -92,7 +92,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.x'
+      pythonVersion: '3.7.x'
 
 - job: 'Run_Style_Check'
   dependsOn: ['Build_Publish_Azure_CLI_Test_SDK','Build_Publish_Azure_IoT_CLI_Extension']
@@ -102,7 +102,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-released.yml
@@ -125,7 +125,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.x'
+      versionSpec: '3.7.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-released.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 exclude: ^(sdk/)
 repos:
-  - repo: https://github.com/psf/black
-    rev: stable
-    hooks:
-      - id: black
+  # Prevent python black hook from executing
+  #- repo: https://github.com/psf/black
+  #  rev: stable
+  #  hooks:
+  #    - id: black
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.8
     hooks:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,19 +3,28 @@
 Release History
 ===============
 
+0.8.6
++++++++++++++++
+- Improves json handling for arguments that require json.
+- Edge deployments support metric definitions at creation time (like device configurations)
+
+0.8.5
++++++++++++++++
+- Re-adds deprecated parameter --config-id to edge related commands. Note: --deployment-id/-d are the proper parameters to use in place of config-id when using edge deployment related commands.
+
 0.8.4
 +++++++++++++++
-- Device simulate now supports sending arbitrary message properties (like in send-d2c-message)
-- The preview dt monitor events command has been simplified. It works the same as vanilla iot hub monitoring but filters dt events and allows filtering by interface
-- Help content improvements
-- Remove long since deprecated parameter `--config-id` from edge deployments
+- Device simulate now supports sending arbitrary message properties (like in send-d2c-message).
+- The preview dt monitor events command has been simplified. It works the same as vanilla iot hub monitoring but filters dt events and allows filtering by interface.
+- Help content improvements.
+- Remove long since deprecated parameter `--config-id` from edge deployments.
 
 0.8.3
 +++++++++++++++
-- Removes long since deprecated command `az iot hub apply-configuration`
-- Resolve issue #100
+- Removes long since deprecated command `az iot hub apply-configuration`.
+- Resolve issue #100.
 - Improve help content for `az iot edge deployment update` to explicitly show what can be updated.
-- Fix message annotation used to filter Digital Twin events in `az iot dt monitor-events`
+- Fix message annotation used to filter Digital Twin events in `az iot dt monitor-events`.
 
 0.8.2
 +++++++++++++++

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -651,6 +651,13 @@ helps['iot edge deployment create'] = """
         az iot edge deployment create -d {deployment_name} -n {iothub_name} --content ../modules_content.json
         --labels "{\\"key\\":\\"value\\"}"
         --target-condition "tags.environment='dev'"
+    - name: Create a deployment that applies for devices tagged with environment 'dev'
+            with user metrics inline (bash syntax example).
+      text: >
+        az iot edge deployment create -d {deployment_name} -n {iothub_name} --content ../modules_content.json
+        --target-condition "tags.environment='dev'"
+        --metrics '{"queries": {"mymetrik": "SELECT deviceId from devices where
+        properties.reported.lastDesiredStatus.code = 200"}}'
 """
 
 helps['iot edge deployment show'] = """

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -6,7 +6,7 @@
 
 import os
 
-VERSION = "0.8.5"
+VERSION = "0.8.6"
 EXTENSION_NAME = "azure-cli-iot-ext"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/operations/digitaltwin.py
+++ b/azext_iot/operations/digitaltwin.py
@@ -6,12 +6,12 @@
 
 from os.path import exists
 from knack.util import CLIError
-from azure.cli.core.util import read_file_content
 from azext_iot.constants import PNP_ENDPOINT
 from azext_iot._factory import _bind_sdk
 from azext_iot.common.shared import SdkType, ModelSourceType
 from azext_iot.common._azure import get_iot_hub_connection_string
 from azext_iot.common.utility import (shell_safe_json_parse,
+                                      read_file_content,
                                       unpack_msrest_error)
 from azext_iot.operations.pnp import (iot_pnp_interface_show,
                                       iot_pnp_interface_list,

--- a/azext_iot/operations/pnp.py
+++ b/azext_iot/operations/pnp.py
@@ -15,8 +15,9 @@ from azext_iot._factory import _bind_sdk
 from azext_iot.constants import PNP_API_VERSION, PNP_ENDPOINT
 from azext_iot.common.utility import (unpack_pnp_http_error,
                                       get_sas_token,
-                                      shell_safe_json_parse)
-from azure.cli.core.util import read_file_content
+                                      shell_safe_json_parse,
+                                      read_file_content,
+                                      looks_like_file)
 
 logger = get_logger(__name__)
 
@@ -210,13 +211,6 @@ def _iot_pnp_model_delete(cmd, endpoint, repository, model_id, login):
         raise CLIError(unpack_pnp_http_error(e))
 
 
-def _looks_like_file(element):
-    element = element.lower()
-    if element.endswith(('.txt', '.json', '.md', '.rst', '.doc', '.docx')):
-        return True
-    return False
-
-
 def _validate_model_definition(model_def):
     if exists(model_def):
         model_def = str(read_file_content(model_def))
@@ -227,7 +221,7 @@ def _validate_model_definition(model_def):
         return shell_safe_json_parse(model_def)
     except ValueError as e:
         logger.debug('Received definition: %s', model_def)
-        if _looks_like_file(model_def):
+        if looks_like_file(model_def):
             raise CLIError('The definition content looks like its from a file. Please ensure the path is correct.')
         raise CLIError('Malformed capability model definition. '
                        'Use --debug to see what was received. Error details: {}'.format(e))

--- a/azext_iot/sdk/service/models/cloud_to_device_method.py
+++ b/azext_iot/sdk/service/models/cloud_to_device_method.py
@@ -33,9 +33,10 @@ class CloudToDeviceMethod(Model):
     #     'payload': {'readonly': True},
     # }
 
+    # @digimaun - payload altered from '{object}' to 'object' since primitives can be passed in.
     _attribute_map = {
         'method_name': {'key': 'methodName', 'type': 'str'},
-        'payload': {'key': 'payload', 'type': '{object}'},
+        'payload': {'key': 'payload', 'type': 'object'},
         'response_timeout_in_seconds': {'key': 'responseTimeoutInSeconds', 'type': 'int'},
         'connect_timeout_in_seconds': {'key': 'connectTimeoutInSeconds', 'type': 'int'},
     }

--- a/azext_iot/tests/conftest.py
+++ b/azext_iot/tests/conftest.py
@@ -7,6 +7,8 @@
 
 import pytest
 import json
+import os
+
 from azext_iot.common.sas_token_auth import SasTokenAuthentication
 
 path_iot_hub_service_factory = "azext_iot.common._azure.iot_hub_service_factory"
@@ -14,7 +16,9 @@ path_service_client = "msrest.service_client.ServiceClient.send"
 path_ghcs = "azext_iot.operations.hub.get_iot_hub_connection_string"
 path_sas = "azext_iot._factory.SasTokenAuthentication"
 path_mqtt_client = "azext_iot.operations._mqtt.mqtt.Client"
-path_iot_hub_monitor_events_entrypoint = "azext_iot.operations.hub._iot_hub_monitor_events"
+path_iot_hub_monitor_events_entrypoint = (
+    "azext_iot.operations.hub._iot_hub_monitor_events"
+)
 hub_entity = "myhub.azure-devices.net"
 
 mock_target = {}
@@ -25,6 +29,13 @@ mock_target["policy"] = "iothubowner"
 mock_target["subscription"] = "5952cff8-bcd1-4235-9554-af2c0348bf23"
 mock_target["location"] = "westus2"
 mock_target["sku_tier"] = "Standard"
+
+
+@pytest.fixture()
+def set_cwd():
+    from inspect import getsourcefile
+
+    os.chdir(os.path.dirname(os.path.abspath(getsourcefile(lambda: 0))))
 
 
 @pytest.fixture()
@@ -73,9 +84,7 @@ def serviceclient_generic_invalid_or_missing_etag(
 @pytest.fixture()
 def mqttclient(mocker, fixture_ghcs, fixture_sas):
     client = mocker.patch(path_mqtt_client)
-    mock_conn = mocker.patch(
-        "azext_iot.operations._mqtt.mqtt_client_wrap.is_connected"
-    )
+    mock_conn = mocker.patch("azext_iot.operations._mqtt.mqtt_client_wrap.is_connected")
     mock_conn.return_value = True
     return client
 

--- a/azext_iot/tests/test_config_modules_content.json
+++ b/azext_iot/tests/test_config_modules_content.json
@@ -62,6 +62,7 @@
     },
     "metrics": {
         "queries": {
+            "mymetrik": "select deviceId from devices where tags.location='US'"
         }
     }
 }

--- a/azext_iot/tests/test_iot_digitaltwin_unit.py
+++ b/azext_iot/tests/test_iot_digitaltwin_unit.py
@@ -14,8 +14,7 @@ from azext_iot.constants import PNP_ENDPOINT
 from azext_iot.tests.conftest import build_mock_response
 from azext_iot.tests.generators import create_req_monitor_events
 from knack.util import CLIError
-from azure.cli.core.util import read_file_content
-
+from azext_iot.common.utility import read_file_content
 
 _device_digitaltwin_invoke_command_payload = (
     "test_device_digitaltwin_invoke_command.json"

--- a/azext_iot/tests/test_iot_ext_int.py
+++ b/azext_iot/tests/test_iot_ext_int.py
@@ -9,7 +9,7 @@ import random
 import json
 import pytest
 
-from azure.cli.core.util import read_file_content
+from azext_iot.common.utility import read_file_content
 from . import IoTLiveScenarioTest
 from azext_iot.constants import DEVICE_DEVICESCOPE_PREFIX
 
@@ -1511,13 +1511,14 @@ class TestIoTEdgeDeployments(IoTLiveScenarioTest):
 
         # With connection string and file path
         self.cmd(
-            "iot edge deployment create -d {} --login {} --pri {} --tc \"{}\" --lab {} -k '{}'".format(
+            "iot edge deployment create -d {} --login {} --pri {} --tc \"{}\" --lab {} -k '{}' --metrics '{}'".format(
                 config_ids[0],
                 LIVE_HUB_CS,
                 priority,
                 condition,
                 '"{generic_dict}"',
                 content_path,
+                content_path
             ),
             checks=[
                 self.check("id", config_ids[0]),
@@ -1530,6 +1531,10 @@ class TestIoTEdgeDeployments(IoTLiveScenarioTest):
                         "modulesContent"
                     ],
                 ),
+                self.check(
+                    "metrics.queries",
+                    json.loads(self.kwargs["configuration_payload"])["metrics"]["queries"]
+                )
             ],
         )
 
@@ -1571,6 +1576,10 @@ class TestIoTEdgeDeployments(IoTLiveScenarioTest):
                         "content"
                     ]["modulesContent"],
                 ),
+                self.check(
+                    "metrics.queries",
+                    {}
+                )
             ],
         )
 

--- a/azext_iot/tests/test_iot_ext_unit.py
+++ b/azext_iot/tests/test_iot_ext_unit.py
@@ -16,12 +16,12 @@ from azext_iot.common.utility import (
     validate_min_python_version,
     url_encode_dict,
     validate_key_value_pairs,
+    read_file_content
 )
 from azext_iot.common.sas_token_auth import SasTokenAuthentication
 from azext_iot.constants import TRACING_PROPERTY
 from azext_iot.tests.generators import create_req_monitor_events
 from knack.util import CLIError
-from azure.cli.core.util import read_file_content
 from .conftest import (
     fixture_cmd,
     build_mock_response,
@@ -443,10 +443,10 @@ class TestDeviceUpdate:
                         "type": "selfSigned",
                     }
                 ),
-                ValueError,
+                CLIError,
             ),
-            (generate_device_show(authentication={"type": "doesnotexist"}), ValueError),
-            (generate_device_show(etag=None), LookupError),
+            (generate_device_show(authentication={"type": "doesnotexist"}), CLIError),
+            (generate_device_show(etag=None), CLIError),
         ],
     )
     def test_device_update_invalid_args(self, serviceclient, req, exp):
@@ -491,7 +491,7 @@ class TestDeviceDelete:
         headers = args[0][1]
         assert headers["If-Match"] == '"{}"'.format(serviceclient.expected_etag)
 
-    @pytest.mark.parametrize("exception", [LookupError])
+    @pytest.mark.parametrize("exception", [CLIError])
     def test_device_delete_invalid_args(
         self, serviceclient_generic_invalid_or_missing_etag, exception
     ):
@@ -744,13 +744,13 @@ class TestDeviceModuleUpdate:
                         "type": "selfSigned",
                     }
                 ),
-                ValueError,
+                CLIError,
             ),
             (
                 generate_device_module_show(authentication={"type": "doesnotexist"}),
-                ValueError,
+                CLIError,
             ),
-            (generate_device_module_show(etag=None), LookupError),
+            (generate_device_module_show(etag=None), CLIError),
         ],
     )
     def test_device_module_update_invalid_args(self, serviceclient, req, exp):
@@ -801,7 +801,7 @@ class TestDeviceModuleDelete:
         assert method == "DELETE"
         assert headers["If-Match"] == '"{}"'.format(serviceclient.expected_etag)
 
-    @pytest.mark.parametrize("exception", [LookupError])
+    @pytest.mark.parametrize("exception", [CLIError])
     def test_device_module_invalid_args(
         self, serviceclient_generic_invalid_or_missing_etag, exception
     ):
@@ -1197,7 +1197,7 @@ class TestConfigUpdate:
         "req", [(generate_device_config(scenario="update", etag=""))]
     )
     def test_config_update_invalid_args(self, serviceclient, req):
-        with pytest.raises(LookupError):
+        with pytest.raises(CLIError):
             subject.iot_hub_configuration_update(
                 fixture_cmd,
                 config_id=config_id,
@@ -1337,7 +1337,7 @@ class TestConfigDelete:
         assert "{}/configurations/{}?".format(mock_target["entity"], config_id) in url
         assert headers["If-Match"] == '"{}"'.format(serviceclient.expected_etag)
 
-    @pytest.mark.parametrize("expected", [LookupError])
+    @pytest.mark.parametrize("expected", [CLIError])
     def test_config_delete_invalid_args(
         self, serviceclient_generic_invalid_or_missing_etag, expected
     ):
@@ -1635,7 +1635,7 @@ class TestDeviceTwinUpdate:
         assert "twins/{}".format(device_id) in args[0][0].url
 
     @pytest.mark.parametrize(
-        "req, exp", [(generate_device_twin_show(etag=None), LookupError)]
+        "req, exp", [(generate_device_twin_show(etag=None), CLIError)]
     )
     def test_device_twin_update_invalid_args(self, serviceclient, req, exp):
         with pytest.raises(exp):
@@ -1701,8 +1701,8 @@ class TestDeviceTwinReplace:
     @pytest.mark.parametrize(
         "req, exp",
         [
-            (generate_device_twin_show(etag=None), LookupError),
-            ({"invalid": "payload"}, LookupError),
+            (generate_device_twin_show(etag=None), CLIError),
+            ({"invalid": "payload"}, CLIError),
         ],
     )
     def test_device_twin_replace_invalid_args(self, serviceclient, req, exp):
@@ -1798,7 +1798,7 @@ class TestDeviceModuleTwinUpdate:
                     properties={"desired": {"key": "value"}},
                     etag=None,
                 ),
-                LookupError,
+                CLIError,
             ),
             (generate_device_twin_show(moduleId=module_id), CLIError),
         ],
@@ -1871,8 +1871,8 @@ class TestDeviceModuleTwinReplace:
     @pytest.mark.parametrize(
         "req, exp",
         [
-            (generate_device_twin_show(moduleId=module_id, etag=None), LookupError),
-            ({"invalid": "payload"}, LookupError),
+            (generate_device_twin_show(moduleId=module_id, etag=None), CLIError),
+            ({"invalid": "payload"}, CLIError),
         ],
     )
     def test_device_module_twin_replace_invalid_args(self, serviceclient, req, exp):
@@ -2863,7 +2863,7 @@ class TestEdgeOffline:
         service_client.side_effect = test_side_effect
         return service_client
 
-    @pytest.mark.parametrize("exp", [LookupError])
+    @pytest.mark.parametrize("exp", [CLIError])
     def test_device_setparent_invalid_etag(self, sc_invalid_etag_setparent, exp):
         with pytest.raises(exp):
             subject.iot_device_set_parent(
@@ -2959,7 +2959,7 @@ class TestEdgeOffline:
         service_client.side_effect = test_side_effect
         return service_client
 
-    @pytest.mark.parametrize("exp", [LookupError])
+    @pytest.mark.parametrize("exp", [CLIError])
     def test_device_addchildren_invalid_etag(self, sc_invalid_etag_setparent, exp):
         with pytest.raises(exp):
             subject.iot_device_children_add(
@@ -3107,7 +3107,7 @@ class TestEdgeOffline:
         service_client.side_effect = test_side_effect
         return service_client
 
-    @pytest.mark.parametrize("exp", [LookupError])
+    @pytest.mark.parametrize("exp", [CLIError])
     def test_device_removechildrenlist_invalid_etag(
         self, sc_invalid_etag_removechildrenlist, exp
     ):
@@ -3231,7 +3231,7 @@ class TestEdgeOffline:
         service_client.side_effect = test_side_effect
         return service_client
 
-    @pytest.mark.parametrize("exp", [LookupError])
+    @pytest.mark.parametrize("exp", [CLIError])
     def test_device_removechildrenall_invalid_etag(
         self, sc_invalid_etag_removechildrenall, exp
     ):

--- a/azext_iot/tests/test_iot_pnp_int.py
+++ b/azext_iot/tests/test_iot_pnp_int.py
@@ -11,7 +11,7 @@ import os
 from io import open
 from os.path import exists
 from azure.cli.testsdk import LiveScenarioTest
-from azure.cli.core.util import read_file_content
+from azext_iot.common.utility import read_file_content
 
 
 # Set these to the proper PnP Endpoint, PnP Cstring and PnP Repository for Live Integration Tests.

--- a/azext_iot/tests/test_iot_pnp_unit.py
+++ b/azext_iot/tests/test_iot_pnp_unit.py
@@ -10,9 +10,8 @@ import os
 
 from uuid import uuid4
 from azext_iot.operations import pnp as subject
-from azext_iot.common.utility import url_encode_str
+from azext_iot.common.utility import url_encode_str, read_file_content
 from knack.util import CLIError
-from azure.cli.core.util import read_file_content
 from .conftest import fixture_cmd, path_service_client, build_mock_response
 
 _repo_endpoint = "https://{}.{}".format(str(uuid4()), "com")

--- a/azext_iot/tests/test_iot_utility_unit.py
+++ b/azext_iot/tests/test_iot_utility_unit.py
@@ -1,31 +1,28 @@
 import pytest
+import json
 from knack.util import CLIError
 from azext_iot.common.utility import validate_min_python_version
 from azext_iot.common.deps import ensure_uamqp
 from azext_iot._validators import mode2_iot_login_handler
 from azext_iot.constants import EVENT_LIB
+from azext_iot.common.utility import process_json_arg, read_file_content, logger
 
 
-class TestMinPython():
-    @pytest.mark.parametrize("pymajor, pyminor", [
-        (3, 6),
-        (3, 4),
-        (2, 7)
-    ])
+class TestMinPython(object):
+    @pytest.mark.parametrize("pymajor, pyminor", [(3, 6), (3, 4), (2, 7)])
     def test_min_python(self, mocker, pymajor, pyminor):
-        version_mock = mocker.patch('azext_iot.common.utility.sys.version_info')
+        version_mock = mocker.patch("azext_iot.common.utility.sys.version_info")
         version_mock.major = pymajor
         version_mock.minor = pyminor
 
         assert validate_min_python_version(2, 7)
 
-    @pytest.mark.parametrize("pymajor, pyminor, exception", [
-        (3, 6, SystemExit),
-        (3, 4, SystemExit),
-        (2, 7, SystemExit)
-    ])
+    @pytest.mark.parametrize(
+        "pymajor, pyminor, exception",
+        [(3, 6, SystemExit), (3, 4, SystemExit), (2, 7, SystemExit)],
+    )
     def test_min_python_error(self, mocker, pymajor, pyminor, exception):
-        version_mock = mocker.patch('azext_iot.common.utility.sys.version_info')
+        version_mock = mocker.patch("azext_iot.common.utility.sys.version_info")
         version_mock.major = 2
         version_mock.minor = 6
 
@@ -33,101 +30,178 @@ class TestMinPython():
             validate_min_python_version(pymajor, pyminor)
 
 
-class TestMode2Handler():
-    @pytest.mark.parametrize("hub_name, dps_name, login", [
-        ('myhub', '[]', None),
-        ('[]', 'mydps', None),
-        (None, None, 'mylogin'),
-        ('myhub', '[]', 'mylogin'),
-        ('[]', 'mydps', 'mylogin'),
-        ('[]', '[]', '[]'),
-        ('myhub', '[]', '[]'),
-        ('[]', 'mydps', '[]'),
-    ])
+class TestMode2Handler(object):
+    @pytest.mark.parametrize(
+        "hub_name, dps_name, login",
+        [
+            ("myhub", "[]", None),
+            ("[]", "mydps", None),
+            (None, None, "mylogin"),
+            ("myhub", "[]", "mylogin"),
+            ("[]", "mydps", "mylogin"),
+            ("[]", "[]", "[]"),
+            ("myhub", "[]", "[]"),
+            ("[]", "mydps", "[]"),
+        ],
+    )
     def test_mode2_login(self, mocker, hub_name, dps_name, login):
-        mock_cmd = mocker.MagicMock(name='mock cmd')
-        mock_cmd.name = 'iot '
-        mock_ns = mocker.MagicMock(name='mock ns')
-        if login != '[]':
+        mock_cmd = mocker.MagicMock(name="mock cmd")
+        mock_cmd.name = "iot "
+        mock_ns = mocker.MagicMock(name="mock ns")
+        if login != "[]":
             mock_ns.login = login
-        if hub_name != '[]':
+        if hub_name != "[]":
             mock_ns.hub_name = hub_name
-        if dps_name != '[]':
+        if dps_name != "[]":
             mock_ns.dps_name = dps_name
 
         mode2_iot_login_handler(mock_cmd, mock_ns)
 
-    @pytest.mark.parametrize("hub_name, dps_name, login", [
-        (None, None, None)
-    ])
+    @pytest.mark.parametrize("hub_name, dps_name, login", [(None, None, None)])
     def test_mode2_login_error(self, mocker, hub_name, dps_name, login):
-        mock_cmd = mocker.MagicMock(name='mock cmd')
-        mock_cmd.name = 'iot '
-        mock_ns = mocker.MagicMock(name='mock ns')
-        if login != '[]':
+        mock_cmd = mocker.MagicMock(name="mock cmd")
+        mock_cmd.name = "iot "
+        mock_ns = mocker.MagicMock(name="mock ns")
+        if login != "[]":
             mock_ns.login = login
-        if hub_name != '[]':
+        if hub_name != "[]":
             mock_ns.hub_name = hub_name
-        if dps_name != '[]':
+        if dps_name != "[]":
             mock_ns.dps_name = dps_name
 
         with pytest.raises(CLIError):
             mode2_iot_login_handler(mock_cmd, mock_ns)
 
 
-class TestEnsureUamqp():
+class TestEnsureUamqp(object):
     @pytest.fixture()
     def uamqp_scenario(self, mocker):
-        get_uamqp = mocker.patch('azext_iot.common.deps.get_uamqp_ext_version')
-        update_uamqp = mocker.patch('azext_iot.common.deps.update_uamqp_ext_version')
-        installer = mocker.patch('azext_iot.common.deps.install')
+        get_uamqp = mocker.patch("azext_iot.common.deps.get_uamqp_ext_version")
+        update_uamqp = mocker.patch("azext_iot.common.deps.update_uamqp_ext_version")
+        installer = mocker.patch("azext_iot.common.deps.install")
         installer.return_value = True
         get_uamqp.return_value = EVENT_LIB[1]
-        test_import = mocker.patch('azext_iot.common.deps.test_import')
+        test_import = mocker.patch("azext_iot.common.deps.test_import")
         test_import.return_value = True
-        m_exit = mocker.patch('azext_iot.common.deps.sys.exit')
+        m_exit = mocker.patch("azext_iot.common.deps.sys.exit")
 
-        return {'get_uamqp': get_uamqp, 'update_uamqp': update_uamqp,
-                'installer': installer, 'test_import': test_import, 'exit': m_exit}
+        return {
+            "get_uamqp": get_uamqp,
+            "update_uamqp": update_uamqp,
+            "installer": installer,
+            "test_import": test_import,
+            "exit": m_exit,
+        }
 
-    @pytest.mark.parametrize("case, extra_input, external_input", [
-        ('importerror', None, 'y'),
-        ('importerror', None, 'n'),
-        ('importerror', 'yes;', None),
-        ('compatibility', None, 'y'),
-        ('compatibility', None, 'n'),
-        ('compatibility', 'yes;', None),
-        ('repair', 'repair;', 'y'),
-        ('repair', 'repair;yes;', None),
-        ('repair', 'repair;', 'n')
-    ])
-    def test_ensure_uamqp_version(self, mocker, uamqp_scenario,
-                                  case, extra_input, external_input):
-        if case == 'importerror':
-            uamqp_scenario['test_import'].return_value = False
-        elif case == 'compatibility':
-            uamqp_scenario['get_uamqp'].return_value = '0.0.0'
+    @pytest.mark.parametrize(
+        "case, extra_input, external_input",
+        [
+            ("importerror", None, "y"),
+            ("importerror", None, "n"),
+            ("importerror", "yes;", None),
+            ("compatibility", None, "y"),
+            ("compatibility", None, "n"),
+            ("compatibility", "yes;", None),
+            ("repair", "repair;", "y"),
+            ("repair", "repair;yes;", None),
+            ("repair", "repair;", "n"),
+        ],
+    )
+    def test_ensure_uamqp_version(
+        self, mocker, uamqp_scenario, case, extra_input, external_input
+    ):
+        if case == "importerror":
+            uamqp_scenario["test_import"].return_value = False
+        elif case == "compatibility":
+            uamqp_scenario["get_uamqp"].return_value = "0.0.0"
 
         from functools import partial
+
         kwargs = {}
         user_cancelled = True
-        if extra_input and 'yes;' in extra_input:
-            kwargs['yes'] = True
+        if extra_input and "yes;" in extra_input:
+            kwargs["yes"] = True
             user_cancelled = False
-        if extra_input and 'repair;' in extra_input:
-            kwargs['repair'] = True
+        if extra_input and "repair;" in extra_input:
+            kwargs["repair"] = True
         if external_input:
-            mocked_input = mocker.patch('azext_iot.common.deps.input')
+            mocked_input = mocker.patch("azext_iot.common.deps.input")
             mocked_input.return_value = external_input
-            if external_input.lower() == 'y':
+            if external_input.lower() == "y":
                 user_cancelled = False
 
         method = partial(ensure_uamqp, mocker.MagicMock(), **kwargs)
         method()
 
         if user_cancelled:
-            assert uamqp_scenario['exit'].call_args
+            assert uamqp_scenario["exit"].call_args
         else:
-            install_args = uamqp_scenario['installer'].call_args
+            install_args = uamqp_scenario["installer"].call_args
             assert install_args[0][0] == EVENT_LIB[0]
-            assert install_args[1]['custom_version'] == '>={},<{}'.format(EVENT_LIB[1], EVENT_LIB[2])
+            assert install_args[1]["custom_version"] == ">={},<{}".format(
+                EVENT_LIB[1], EVENT_LIB[2]
+            )
+
+
+class TestProcessJsonArg(object):
+    @pytest.mark.parametrize(
+        "content, argname", [('{"authenticationType": "sas"}', "myarg0")]
+    )
+    def test_inline_json(self, content, argname):
+        result = process_json_arg(content, argument_name=argname)
+        assert result == json.loads(content)
+
+    @pytest.mark.parametrize(
+        "content, argname",
+        [
+            ('}"authenticationType": "sas"{', "myarg0"),
+            ('{"authenticationType": }', "myarg1"),
+        ],
+    )
+    def test_inline_json_fail(self, content, argname):
+        with pytest.raises(CLIError) as exc_info:
+            process_json_arg(content, argument_name=argname)
+
+        assert str(exc_info.value).startswith(
+            "Failed to parse json for argument '{}' with exception:\n".format(argname)
+        )
+
+    @pytest.mark.parametrize(
+        "content, argname", [("test_config_device_content.json", "myarg0")]
+    )
+    def test_file_json(self, content, argname, set_cwd):
+        result = process_json_arg(content, argument_name=argname)
+        assert result == json.loads(read_file_content(content))
+
+    @pytest.mark.parametrize(
+        "content, argname", [("test_config_device_content_nothere.json", "myarg0")]
+    )
+    def test_file_json_fail_invalidpath(self, content, argname, set_cwd, mocker):
+        mocked_util_logger = mocker.patch.object(logger, "warning", autospec=True)
+
+        with pytest.raises(CLIError) as exc_info:
+            process_json_arg(content, argument_name=argname)
+
+        assert str(exc_info.value).startswith(
+            "Failed to parse json for argument '{}' with exception:\n".format(argname)
+        )
+        assert mocked_util_logger.call_count == 1
+        assert (
+            mocked_util_logger.call_args[0][0]
+            == "The json payload for argument '%s' looks like its intended from a file. Please ensure the file path is correct."
+        )
+        assert mocked_util_logger.call_args[0][1] == argname
+
+    @pytest.mark.parametrize("content, argname", [("generators.py", "myarg0")])
+    def test_file_json_fail_invalidcontent(self, content, argname, set_cwd, mocker):
+        mocked_util_logger = mocker.patch.object(logger, "warning", autospec=True)
+
+        with pytest.raises(CLIError) as exc_info:
+            process_json_arg(content, argument_name=argname)
+
+        assert str(exc_info.value).startswith(
+            "Failed to parse json from file: '{}' for argument '{}' with exception:\n".format(
+                content, argname
+            )
+        )
+        assert mocked_util_logger.call_count == 0

--- a/dev_requirements
+++ b/dev_requirements
@@ -7,3 +7,4 @@ flake8
 black;python_version>='3.6'
 wheel==0.30.0
 pre-commit
+six==1.12


### PR DESCRIPTION
+ supporting tests
+ various optimizations
+ increment version
+ fix pipeline issues
  - We currently support up to python 3.7 (one set of issues caused by release of 3.8)
  - Force install of six 1.12. six 1.13 was released, but a CLI core related package (asteroid) is pinned to 1.12.

This PR is focused on iot hub command improvements but has impact in other modules. Command bound modules for DT, PnP etc need further updates as well.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
