### PR TITLE
Device simulate command will send default props.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Release History
 - For IoTHub commands - improves json handling for arguments that require json.
 - Edge deployments support metric definitions at creation time (like device configurations)
 - Fixes issue with `az iot hub invoke-device-method` preventing primitive value payloads.
+- The `az iot device simulate` command will send default values for content-type and content-encoding. These values can be overriden.
 
 0.8.5
 +++++++++++++++

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -576,6 +576,9 @@ helps['iot device simulate'] = """
                    and acknowledge cloud-to-device (c2d) messages. For mqtt simulation, all c2d messages will
                    be acknowledged with completion. For http simulation c2d acknowledgement is based on user
                    selection which can be complete, reject or abandon.
+
+                   Note: The command by default will set content-type to application/json and content-encoding
+                   to utf-8. This can be overriden.
     examples:
     - name: Basic usage (mqtt)
       text: az iot device simulate -n {iothub_name} -d {device_id}

--- a/azext_iot/operations/_mqtt.py
+++ b/azext_iot/operations/_mqtt.py
@@ -27,12 +27,12 @@ connection_result = {
 
 
 class mqtt_client_wrap(object):
-    def __init__(self, target, device_id, properties=None):
+    def __init__(self, target, device_id, properties=None, sas_duration=3600):
         self.target = target
         self.device_id = device_id
 
         sas = SasTokenAuthentication(
-            target["entity"], target["policy"], target["primarykey"], time() + 360
+            target["entity"], target["policy"], target["primarykey"], time() + int(sas_duration)
         ).generate_sas_token()
         cwd = EXTENSION_ROOT
         cert_path = os.path.join(cwd, "digicert.pem")

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1169,7 +1169,7 @@ def iot_simulate_device(cmd, device_id, hub_name=None, receive_settle='complete'
         raise CLIError('msg count must be at least {}'.format(MIN_SIM_MSG_COUNT))
 
     properties_to_send = _iot_simulate_get_default_properties(protocol_type)
-    user_properties = (validate_key_value_pairs(properties) or {}) if properties else {}
+    user_properties = validate_key_value_pairs(properties) or {}
     properties_to_send.update(user_properties)
 
     target = get_iot_hub_connection_string(cmd, hub_name, resource_group_name, login=login)

--- a/azext_iot/tests/test_iot_ext_unit.py
+++ b/azext_iot/tests/test_iot_ext_unit.py
@@ -2507,18 +2507,14 @@ class TestDeviceSimulate:
     @pytest.mark.parametrize(
         "rs, mc, mi, protocol, properties",
         [
-            # ("complete", 1, 1, "http", None),
-            # ("reject", 1, 1, "http", None),
-            # ("abandon", 2, 1, "http", "iothub-app-myprop=myvalue;iothub-messageid=1"),
-            # ("complete", 1, 1, "http", "iothub-app-myprop=myvalue;content-type=application/text"),  # override default prop case
+            ("complete", 1, 1, "http", None),
+            ("reject", 1, 1, "http", None),
+            ("abandon", 2, 1, "http", "iothub-app-myprop=myvalue;iothub-messageid=1"),
+            ("complete", 1, 1, "http", "invalidprop;content-encoding=utf-16"),
+            ("complete", 1, 1, "http", "iothub-app-myprop=myvalue;content-type=application/text"),
             ("complete", 3, 1, "mqtt", None),
-            (
-                "complete",
-                2,
-                1,
-                "mqtt",
-                "myprop=myvalue;$.ct=application/json",
-            ),  # override default prop case
+            ("complete", 3, 1, "mqtt", "invalid"),
+            ("complete", 2, 1, "mqtt", "myprop=myvalue;$.ce=utf-16"),
             ("complete", 2, 1, "mqtt", "myinvalidprop;myvalidprop=myvalidpropvalue"),
         ],
     )


### PR DESCRIPTION
Resolves issue #117 

* content-type and content-encoding will be sent by default
* the property values can be overrided by the user

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
