### PR TITLE
More improvements for 0.8.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,8 +10,11 @@ Release History
 - Improved json schema validation error handling for edge deployments.
 - Update top maximum for hub config/edge deployment list to 100.
 - Metric evaluation for hub configuration and edge deployment via show-metric works exactly the same.
-- Add user agent to MQTT operations
-- Add QoS argument for `send-d2c-message`
+- Add user agent for MQTT & AMQP operations.
+- Add QoS argument for `send-d2c-message`.
+- Breaking Change: New result format for `az iot device c2d-message receive`. The command now shows all properties.
+- `az iot device c2d-message send` supports system properties.
+- Updated uAMQP version range.
 
 0.8.6
 +++++++++++++++

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -256,9 +256,22 @@ def load_arguments(self, _):
                          'Full: IoT Hub generates a feedback message in either case. '
                          'By default, no ack is requested.')
         context.argument('correlation_id', options_list=['--correlation-id', '--cid'],
-                         help='Correlation Id associated with message.')
+                         help='The correlation Id associated with the C2D message.')
+        context.argument('properties', options_list=['--properties', '--props', '-p'],
+                         help=info_param_properties_device(include_mqtt=False))
+        context.argument('expiry_time_utc', options_list=['--expiry-time-utc', '--expiry'], type=int,
+                         help='Units are milliseconds since unix epoch. '
+                         'If no time is indicated the default IoT Hub C2D message TTL is used.')
+        context.argument('message_id', options_list=['--message-id', '--mid'],
+                         help='The C2D message Id. If no message Id is provided a UUID will be generated.')
+        context.argument('user_id', options_list=['--user-id', '--uid'],
+                         help='The C2D message, user Id property.')
         context.argument('lock_timeout', options_list=['--lock-timeout', '--lt'], type=int,
                          help='Specifies the amount of time a message will be invisible to other receive calls.')
+        context.argument('content_type', options_list=['--content-type', '--ct'],
+                         help='The content type associated with the C2D message.')
+        context.argument('content_encoding', options_list=['--content-encoding', '--ce'],
+                         help='The content encoding associated with the C2D message.')
 
     with self.argument_context('iot device c2d-message send') as context:
         context.argument('wait_on_feedback', options_list=['--wait', '-w'],

--- a/azext_iot/assets/user_messages.py
+++ b/azext_iot/assets/user_messages.py
@@ -17,17 +17,21 @@ def error_param_top_out_of_bounds(upper_limit=None):
     return "top must be > 0 {}".format(ul_suffix if upper_limit else "")
 
 
-def info_param_properties_device(include_http=False):
+def info_param_properties_device(include_mqtt=True, include_http=False):
     http_content = (
         "For http messaging - application properties are sent using iothub-app-<name>=value, for instance "
         "iothub-app-myprop=myvalue. System properties are generally prefixed with iothub-<name> like iothub-correlationid "
-        "but there are exceptions such as content-type and content-encoding."
+        "but there are exceptions such as content-type and content-encoding.  "
+    )
+
+    mqtt_content = (
+        "For mqtt messaging - you are able to send system properties using "
+        "$.<name>=value. For instance $.cid=12345 sets the system correlation Id property. "
+        "Other system property identifier examples include $.ct for content type, "
+        "$.mid for message Id and $.ce for content encoding.  "
     )
 
     return (
         "Message property bag in key-value pairs with the following format: a=b;c=d. "
-        "For mqtt messaging - you are able to send system properties using "
-        "$.<name>=value. For instance $.cid=12345 sets the system correlation Id property. "
-        "Other system property identifier examples include $.ct for content type, "
-        "$.mid for message Id and $.ce for content encoding. {}".format(http_content if include_http else "")
+        "{}{}".format(mqtt_content if include_mqtt else "", http_content if include_http else "")
     )

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -11,9 +11,24 @@ VERSION = "0.8.7"
 EXTENSION_NAME = "azure-cli-iot-ext"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"
-EDGE_DEPLOYMENT_SCHEMA_2_PATH = os.path.join(EXTENSION_ROOT, 'assets', 'edge-deploy-2.0.schema.json')
+EDGE_DEPLOYMENT_SCHEMA_2_PATH = os.path.join(
+    EXTENSION_ROOT, "assets", "edge-deploy-2.0.schema.json"
+)
 BASE_API_VERSION = "2018-08-30-preview"
 BASE_MQTT_API_VERSION = "2018-06-30"
+MESSAGING_HTTP_C2D_SYSTEM_PROPERTIES = [
+    "iothub-messageid",
+    "iothub-correlationid",
+    "iothub-sequencenumber",
+    "iothub-to",
+    "iothub-userid",
+    "iothub-ack",
+    "iothub-expiry",
+    "iothub-deliverycount",
+    "iothub-enqueuedtime",
+    "ContentType",
+    "ContentEncoding",
+]
 METHOD_INVOKE_MAX_TIMEOUT_SEC = 300
 METHOD_INVOKE_MIN_TIMEOUT_SEC = 10
 MIN_SIM_MSG_INTERVAL = 1
@@ -29,7 +44,7 @@ TRACING_ALLOWED_FOR_SKU = "standard"
 USER_AGENT = "IoTPlatformCliExtension/{}".format(VERSION)
 
 # (Lib name, minimum version (including), maximum version (excluding))
-EVENT_LIB = ("uamqp", "1.0.3", "1.1")
+EVENT_LIB = ("uamqp", "1.1.0", "1.2.5")
 
 # Config Key's
 CONFIG_KEY_UAMQP_EXT_VERSION = "uamqp_ext_version"

--- a/azext_iot/operations/events3/_events.py
+++ b/azext_iot/operations/events3/_events.py
@@ -8,20 +8,19 @@ import asyncio
 import json
 import re
 import sys
-from uuid import uuid4
 import six
-
-import uamqp
 import yaml
+import uamqp
 
-from azext_iot.constants import VERSION
-from azext_iot.common.utility import parse_entity, unicode_binary_map
+from uuid import uuid4
 from knack.log import get_logger
+from azext_iot.constants import VERSION, USER_AGENT
+from azext_iot.common.utility import parse_entity, unicode_binary_map, process_json_arg
 from azext_iot.operations.events3._builders import AmqpBuilder
 
-logger = get_logger(__name__)
 
 DEBUG = True
+logger = get_logger(__name__)
 
 
 def executor(
@@ -110,7 +109,7 @@ async def initiate_event_monitor(
 ):
     def _get_conn_props():
         properties = {}
-        properties["product"] = "az.cli.iot.extension"
+        properties["product"] = USER_AGENT
         properties["version"] = VERSION
         properties["framework"] = "Python {}.{}.{}".format(*sys.version_info[0:3])
         properties["platform"] = sys.platform
@@ -126,7 +125,7 @@ async def initiate_event_monitor(
         target["endpoint"],
         sasl=target["auth"],
         debug=DEBUG,
-        container_id=str(uuid4()),
+        container_id=_get_container_id(),
         properties=_get_conn_props(),
     ) as conn:
         for p in target["partitions"]:
@@ -284,7 +283,17 @@ async def monitor_events(
 
 
 def send_c2d_message(
-    target, device_id, data, properties=None, correlation_id=None, ack=None
+    target,
+    device_id,
+    data,
+    message_id=None,
+    correlation_id=None,
+    ack=None,
+    content_type=None,
+    user_id=None,
+    content_encoding="utf-8",
+    expiry_time_utc=None,
+    properties=None,
 ):
     app_props = {}
     if properties:
@@ -294,26 +303,46 @@ def send_c2d_message(
 
     msg_props = uamqp.message.MessageProperties()
     msg_props.to = "/devices/{}/messages/devicebound".format(device_id)
-    msg_id = str(uuid4())
-    msg_props.message_id = msg_id
+
+    target_msg_id = message_id if message_id else str(uuid4())
+    msg_props.message_id = target_msg_id
 
     if correlation_id:
         msg_props.correlation_id = correlation_id
 
-    msg_content = str.encode(data)
+    if user_id:
+        msg_props.user_id = user_id
+
+    if content_type:
+        msg_props.content_type = content_type
+
+        # Ensures valid json when content_type is application/json
+        content_type = content_type.lower()
+        if content_type == "application/json":
+            data = json.dumps(process_json_arg(data, "data"))
+
+    if content_encoding:
+        msg_props.content_encoding = content_encoding
+
+    if expiry_time_utc:
+        msg_props.absolute_expiry_time = int(expiry_time_utc)
+
+    msg_body = str.encode(data)
 
     message = uamqp.Message(
-        msg_content, properties=msg_props, application_properties=app_props
+        body=msg_body, properties=msg_props, application_properties=app_props
     )
 
     operation = "/messages/devicebound"
     endpoint = AmqpBuilder.build_iothub_amqp_endpoint_from_target(target)
-    endpoint = endpoint + operation
-    client = uamqp.SendClient("amqps://" + endpoint, debug=DEBUG)
+    endpoint_with_op = endpoint + operation
+    client = uamqp.SendClient(
+        target="amqps://" + endpoint_with_op, client_name=_get_container_id(), debug=DEBUG
+    )
     client.queue_message(message)
     result = client.send_all_messages()
     errors = [m for m in result if m == uamqp.constants.MessageState.SendFailed]
-    return msg_id, errors
+    return target_msg_id, errors
 
 
 def monitor_feedback(target, device_id, wait_on_id=None, token_duration=3600):
@@ -354,15 +383,21 @@ def monitor_feedback(target, device_id, wait_on_id=None, token_duration=3600):
     )
 
     try:
-        client = uamqp.ReceiveClient("amqps://" + endpoint, debug=DEBUG)
+        client = uamqp.ReceiveClient(
+            "amqps://" + endpoint, client_name=_get_container_id(), debug=DEBUG
+        )
         message_generator = client.receive_messages_iter()
         for msg in message_generator:
             match = handle_msg(msg)
             if match:
-                logger.info("requested msg id has been matched...")
+                logger.info("Requested message Id has been matched...")
                 msg.accept()
                 return match
     except uamqp.errors.AMQPConnectionError:
-        logger.debug("amqp connection has expired...")
+        logger.debug("AMQPS connection has expired...")
     finally:
         client.close()
+
+
+def _get_container_id():
+    return "{}/{}".format(USER_AGENT, str(uuid4()))

--- a/azext_iot/sdk/device/iot_hub_gateway_device_apis.py
+++ b/azext_iot/sdk/device/iot_hub_gateway_device_apis.py
@@ -17,7 +17,7 @@ from msrestazure.azure_exceptions import CloudError
 import uuid
 from . import models
 from azext_iot.constants import USER_AGENT
-from azext_iot.constants import BASE_API_VERSION
+from azext_iot.constants import BASE_MQTT_API_VERSION
 
 
 class IotHubGatewayDeviceAPIsConfiguration(AzureConfiguration):
@@ -41,7 +41,7 @@ class IotHubGatewayDeviceAPIsConfiguration(AzureConfiguration):
 
         super(IotHubGatewayDeviceAPIsConfiguration, self).__init__(base_url)
 
-        self.add_user_agent('iothubgatewaydeviceapi/{}'.format(BASE_API_VERSION))
+        self.add_user_agent('iothubgatewaydeviceapi/{}'.format(BASE_MQTT_API_VERSION))
         self.add_user_agent(USER_AGENT)
 
         self.credentials = credentials
@@ -66,7 +66,7 @@ class IotHubGatewayDeviceAPIs(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
-        self.api_version = BASE_API_VERSION
+        self.api_version = BASE_MQTT_API_VERSION
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/azext_iot/tests/conftest.py
+++ b/azext_iot/tests/conftest.py
@@ -72,6 +72,18 @@ def fixture_cmd(mocker):
     return cmd
 
 
+@pytest.fixture()
+def fixture_events_uamqp_sendclient(mocker):
+    from azext_iot.operations.events3._events import uamqp
+    return mocker.patch.object(uamqp, "SendClient", autospec=True)
+
+
+@pytest.fixture()
+def fixture_service_client_generic(mocker, fixture_ghcs, fixture_sas):
+    service_client = mocker.patch(path_service_client)
+    return service_client
+
+
 @pytest.fixture(params=[400, 401, 500])
 def serviceclient_generic_error(mocker, fixture_ghcs, fixture_sas, request):
     service_client = mocker.patch(path_service_client)

--- a/azext_iot/tests/generators.py
+++ b/azext_iot/tests/generators.py
@@ -4,6 +4,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from uuid import uuid4
+
 
 def create_req_monitor_events(
     device_id=None,
@@ -35,3 +37,32 @@ def create_req_monitor_events(
         "repair": repair,
         "login": login,
     }
+
+
+def create_c2d_receive_response(minimum=False):
+    baseline = {
+        "headers": {
+            "iothub-ack": "none",
+            "iothub-correlationid": "",
+            "iothub-deliverycount": "0",
+            "iothub-enqueuedtime": "12/09/2019 12:00:00 PM",
+            "etag": '"{}"'.format(str(uuid4())),
+            "iothub-expiry": "",
+            "iothub-messageid": "{}".format(str(uuid4())),
+            "iothub-sequencenumber": "1",
+            "iothub-to": "/devices/sensor1/messages/deviceBound",
+            "iothub-userid": "",
+        },
+        "body": None,
+    }
+
+    if not minimum:
+        baseline["headers"]["iothub-ack"] = "full"
+        baseline["headers"]["iothub-app-propKey0"] = str(uuid4())
+        baseline["headers"]["iothub-app-propKey1"] = str(uuid4())
+        baseline["headers"]["iothub-correlationid"] = str(uuid4())
+        baseline["headers"]["iothub-expiry"] = "12/09/2019 12:10:00 PM"
+        baseline["headers"]["iothub-userid"] = str(uuid4())
+        baseline["body"] = str(uuid4())
+
+    return baseline

--- a/azext_iot/tests/test_iot_messaging_int.py
+++ b/azext_iot/tests/test_iot_messaging_int.py
@@ -6,7 +6,9 @@
 
 import os
 import pytest
+import json
 
+from time import time
 from uuid import uuid4
 from . import IoTLiveScenarioTest, PREFIX_DEVICE
 
@@ -15,6 +17,7 @@ from azext_iot.common.utility import (
     validate_min_python_version,
     execute_onthread,
     calculate_millisec_since_unix_epoch_utc,
+    validate_key_value_pairs
 )
 
 # Set these to the proper IoT Hub, IoT Hub Cstring and Resource Group for Live Integration Tests.
@@ -47,19 +50,36 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         device_ids = self.generate_device_names(device_count)
 
         self.cmd(
-            "iot hub device-identity create -d {} -n {} -g {} --ee".format(
+            "iot hub device-identity create -d {} -n {} -g {}".format(
                 device_ids[0], LIVE_HUB, LIVE_RG
             ),
             checks=[self.check("deviceId", device_ids[0])],
         )
 
         test_body = str(uuid4())
-        test_props = "key0=value0;key1=value1"
+        test_props = "key0={};key1={}".format(str(uuid4()), str(uuid4()))
         test_cid = str(uuid4())
+        test_mid = str(uuid4())
+        test_ct = "text/plain"
+        test_et = int((time() + 3600) * 1000)  # milliseconds since epoch
+        test_ce = "utf8"
 
+        self.kwargs["c2d_json_send_data"] = json.dumps({"data": str(uuid4())})
+
+        # Send C2D message
         self.cmd(
-            "iot device c2d-message send -d {} --hub-name {} -g {} --data {} --cid {}".format(
-                device_ids[0], LIVE_HUB, LIVE_RG, test_body, test_cid
+            """iot device c2d-message send -d {} -n {} -g {} --data '{}' --cid {} --mid {} --ct {} --expiry {}
+            --ce {} --props {}""".format(
+                device_ids[0],
+                LIVE_HUB,
+                LIVE_RG,
+                test_body,
+                test_cid,
+                test_mid,
+                test_ct,
+                test_et,
+                test_ce,
+                test_props,
             ),
             checks=self.is_empty(),
         )
@@ -71,8 +91,24 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         ).get_output_in_json()
 
         assert result["data"] == test_body
-        assert result["correlationId"] == test_cid
-        assert result["ack"] == "none"
+
+        system_props = result["properties"]["system"]
+        assert system_props["ContentEncoding"] == test_ce
+        assert system_props["ContentType"] == test_ct
+        assert system_props["iothub-correlationid"] == test_cid
+        assert system_props["iothub-messageid"] == test_mid
+        assert system_props["iothub-expiry"]
+        assert system_props["iothub-to"] == "/devices/{}/messages/devicebound".format(
+            device_ids[0]
+        )
+
+        # Ack is tested in message feedback tests
+        assert system_props["iothub-ack"] == "none"
+
+        app_props = result["properties"]["app"]
+        assert app_props == validate_key_value_pairs(test_props)
+
+        # Implicit etag assertion
         etag = result["etag"]
 
         self.cmd(
@@ -82,13 +118,23 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             checks=self.is_empty(),
         )
 
-        test_body = str(uuid4())
-        test_cid = str(uuid4())
+        # Send C2D message via --login + application/json content ype
 
-        # With connection string
+        test_ct = "application/json"
+        test_mid = str(uuid4())
+
         self.cmd(
-            "iot device c2d-message send -d {} --data {} --props {} --cid {} --ack {} --login {}".format(
-                device_ids[0], test_body, test_props, test_cid, "positive", LIVE_HUB_CS
+            """iot device c2d-message send -d {} --login {} --data '{}' --cid {} --mid {} --ct {} --expiry {}
+            --ce {} --ack positive --props {}""".format(
+                device_ids[0],
+                LIVE_HUB_CS,
+                "{c2d_json_send_data}",
+                test_cid,
+                test_mid,
+                test_ct,
+                test_et,
+                test_ce,
+                test_props,
             ),
             checks=self.is_empty(),
         )
@@ -99,9 +145,23 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             )
         ).get_output_in_json()
 
-        assert result["data"] == test_body
-        assert result["correlationId"] == test_cid
-        assert result["ack"] == "positive"
+        assert result["data"] == self.kwargs["c2d_json_send_data"]
+
+        system_props = result["properties"]["system"]
+        assert system_props["ContentEncoding"] == test_ce
+        assert system_props["ContentType"] == test_ct
+        assert system_props["iothub-correlationid"] == test_cid
+        assert system_props["iothub-messageid"] == test_mid
+        assert system_props["iothub-expiry"]
+        assert system_props["iothub-to"] == "/devices/{}/messages/devicebound".format(
+            device_ids[0]
+        )
+
+        assert system_props["iothub-ack"] == "positive"
+
+        app_props = result["properties"]["app"]
+        assert app_props == validate_key_value_pairs(test_props)
+
         etag = result["etag"]
 
         self.cmd(
@@ -131,7 +191,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 5,
                 "http",
             ],
-            max_runs=5,
+            max_runs=4,
             return_handle=True,
         )
 
@@ -151,12 +211,20 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             expect_failure=True,
         )
 
+        # Error - content-type is application/json but data is not.
+        self.cmd(
+            "iot device c2d-message send -d {} --login {} --ct application/json --data notjson".format(
+                device_ids[0], LIVE_HUB_CS
+            ),
+            expect_failure=True,
+        )
+
     def test_device_messaging(self):
         device_count = 1
         device_ids = self.generate_device_names(device_count)
 
         self.cmd(
-            "iot hub device-identity create -d {} -n {} -g {} --ee".format(
+            "iot hub device-identity create -d {} -n {} -g {}".format(
                 device_ids[0], LIVE_HUB, LIVE_RG
             ),
             checks=[self.check("deviceId", device_ids[0])],
@@ -264,7 +332,12 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         # Send arbitrary properties with device simulation - mqtt
         self.cmd(
             "iot device simulate -d {} -n {} -g {} --mc {} --mi {} --properties '{}'".format(
-                device_ids[0], LIVE_HUB, LIVE_RG, 2, 1, 'myprop=myvalue;$.ct=application/json'
+                device_ids[0],
+                LIVE_HUB,
+                LIVE_RG,
+                2,
+                1,
+                "myprop=myvalue;$.ct=application/json",
             ),
             checks=self.is_empty(),
         )
@@ -272,7 +345,12 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         # Send arbitrary properties with device simulation - http
         self.cmd(
             "iot device simulate -d {} -n {} -g {} --mc {} --mi {} --proto http -p '{}'".format(
-                device_ids[0], LIVE_HUB, LIVE_RG, 2, 1, "iothub-app-myprop=myvalue;iothub-messageid=1"
+                device_ids[0],
+                LIVE_HUB,
+                LIVE_RG,
+                2,
+                1,
+                "iothub-app-myprop=myvalue;iothub-messageid=1",
             ),
             checks=self.is_empty(),
         )
@@ -351,7 +429,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                     1,
                     LIVE_RG,
                     None,
-                    0
+                    0,
                 ],
                 max_runs=1,
             )
@@ -443,7 +521,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 1,
                 LIVE_RG,
                 None,
-                1
+                1,
             ],
             max_runs=1,
         )
@@ -559,9 +637,12 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 device_ids[0], LIVE_HUB, LIVE_RG
             )
         ).get_output_in_json()
-        msg_id = result["messageId"]
+
+        system_props = result["properties"]["system"]
+        msg_id = system_props["iothub-messageid"]
+
         etag = result["etag"]
-        assert result["ack"] == ack
+        assert system_props["iothub-ack"] == ack
 
         self.cmd(
             "iot device c2d-message complete -d {} --hub-name {} -g {} -e {}".format(
@@ -590,9 +671,12 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 device_ids[0], LIVE_HUB_CS
             )
         ).get_output_in_json()
-        msg_id = result["messageId"]
+
+        system_props = result["properties"]["system"]
+        msg_id = system_props["iothub-messageid"]
+
         etag = result["etag"]
-        assert result["ack"] == ack
+        assert system_props["iothub-ack"] == ack
 
         self.cmd(
             "iot device c2d-message complete -d {} --login {} -e {}".format(
@@ -623,6 +707,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             )
         ).get_output_in_json()
         etag = result["etag"]
+
         self.cmd(
             "iot device c2d-message reject -d {} --login {} -e {}".format(
                 device_ids[0], LIVE_HUB_CS, etag
@@ -642,9 +727,12 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 device_ids[0], LIVE_HUB_CS
             )
         ).get_output_in_json()
-        msg_id = result["messageId"]
+
+        system_props = result["properties"]["system"]
+        msg_id = system_props["iothub-messageid"]
+
         etag = result["etag"]
-        assert result["ack"] == ack
+        assert system_props["iothub-ack"] == ack
 
         self.cmd(
             "iot device c2d-message reject -d {} --login {} -e {}".format(


### PR DESCRIPTION
* User agent for AMQP ops.
* C2D Send supports system properties.
* C2D Receieve has new format and shows all props.
* Refactored get-connection-string for Device/Module.
* Updated uAMQP version range.
* Tests

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
