### PR TITLE
Jobs v2 command set

### DIFF
--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -50,7 +50,7 @@ jobs:
   
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7.x'
+      pythonVersion: '3.x'
 
 - job: 'Run_Tests_Windows_Azure_CLI_Released_Version'
   dependsOn : [Build_Publish_Azure_CLI_Test_SDK, 'Build_Publish_Azure_IoT_CLI_Extension']
@@ -60,8 +60,8 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7.x'
-      runWithAzureCliReleased: 'true'
+      pythonVersion: '3.x'
+      runWithAzureCliReleased: 'false'
 
 - job: 'Run_Tests_Ubuntu'
   dependsOn: ['Build_Publish_Azure_CLI_Test_SDK','Build_Publish_Azure_IoT_CLI_Extension']
@@ -75,7 +75,9 @@ jobs:
         python.version: '3.6.x'
       Python37:
         python.version: '3.7.x'
-    maxParallel: 3
+      Python38:
+        python.version: '3.8.x'
+    maxParallel: 4
 
   steps:
   - bash: sudo rm -R -f /usr/local/lib/azureExtensionDir
@@ -92,7 +94,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7.x'
+      pythonVersion: '3.x'
 
 - job: 'Run_Style_Check'
   dependsOn: ['Build_Publish_Azure_CLI_Test_SDK','Build_Publish_Azure_IoT_CLI_Extension']
@@ -102,7 +104,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7.x'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-released.yml
@@ -125,7 +127,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7.x'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-released.yml

--- a/.azure-devops/templates/run-tests.yml
+++ b/.azure-devops/templates/run-tests.yml
@@ -40,6 +40,8 @@ steps:
       displayName: 'Execute IoT DigitalTwin unit tests'
     - script: pytest -v azext_iot/tests/configurations/test_iot_config_unit.py --junitxml "TEST-config-unit-results.xml"
       displayName: 'Execute IoT Configuration unit tests'
+    - script: pytest -v azext_iot/tests/jobs/test_iothub_jobs_unit.py --junitxml "TEST-jobs-unit-results.xml"
+      displayName: 'Execute IoT Hub job unit tests'
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.8.8
++++++++++++++++
+- Adds Jobs v2 command set.
+
 0.8.7
 +++++++++++++++
 - Support IoT Edge layered deployments.

--- a/azext_iot/__init__.py
+++ b/azext_iot/__init__.py
@@ -15,6 +15,10 @@ iothub_ops = CliCommandType(
     operations_tmpl='azext_iot.operations.hub#{}'
 )
 
+iothub_ops_job = CliCommandType(
+    operations_tmpl='azext_iot.iothub.job#{}'
+)
+
 iotdps_ops = CliCommandType(
     operations_tmpl='azext_iot.operations.dps#{}',
     client_factory=iot_service_provisioning_factory
@@ -41,6 +45,8 @@ class IoTExtCommandsLoader(AzCommandsLoader):
     def load_command_table(self, args):
         from azext_iot.commands import load_command_table
         load_command_table(self, args)
+        from azext_iot.iothub.commands import load_iothub_commands
+        load_iothub_commands(self, args)
         return self.command_table
 
     def load_arguments(self, command):

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -162,14 +162,16 @@ def load_arguments(self, _):
                          'If no start time is provided, the job is queued for asap execution.')
         context.argument('ttl', options_list=['--ttl'], type=int,
                          help='Max execution time in seconds, before job is terminated.')
-        context.argument('twin_patch', options_list=['--twin-patch'],
+        context.argument('twin_patch', options_list=['--twin-patch', '--patch'],
                          help='The desired twin patch. Provide file path or raw json.')
         context.argument('wait', options_list=['--wait', '-w'],
                          arg_type=get_three_state_flag(),
                          help='Block until the created job is in a completed, failed or cancelled state. '
                          'Will regularly poll on interval specified by --poll-interval.')
-        context.argument('poll_interval', options_list=['--poll-interval'], type=int,
+        context.argument('poll_interval', options_list=['--poll-interval', '--interval'], type=int,
                          help='Interval in seconds that job status will be checked if --wait flag is passed in.')
+        context.argument('poll_duration', options_list=['--poll-duration', '--duration'], type=int,
+                         help='Total duration in seconds where job status will be checked if --wait flag is passed in.')
 
     with self.argument_context('iot hub monitor-events') as context:
         context.argument('timeout', arg_type=event_timeout_type)

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -27,7 +27,9 @@ from azext_iot.common.shared import (
     ReprovisionType,
     AllocationType,
     DistributedTracingSamplingModeType,
-    ModelSourceType
+    ModelSourceType,
+    JobType,
+    JobStatusType
 )
 from azext_iot._validators import mode2_iot_login_handler
 from azext_iot.assets.user_messages import info_param_properties_device
@@ -91,7 +93,11 @@ def load_arguments(self, _):
         context.argument('method_payload', options_list=['--method-payload', '--mp'],
                          help='Json payload to be passed to method. Must be file path or raw json.')
         context.argument('timeout', options_list=['--timeout', '--to'], type=int,
-                         help='Maximum number of seconds to wait for method result.')
+                         help='Maximum number of seconds to wait for device method result.')
+        context.argument('method_connect_timeout', options_list=['--method-connect-timeout', '--mct'], type=int,
+                         help='Maximum number of seconds to wait on device connection.')
+        context.argument('method_response_timeout', options_list=['--method-response-timeout', '--mrt'], type=int,
+                         help='Maximum number of seconds to wait for device method result.')
         context.argument('auth_method', options_list=['--auth-method', '--am'],
                          arg_type=get_enum_type(DeviceAuthType),
                          help='The authorization type an entity is to be created with.')
@@ -137,6 +143,33 @@ def load_arguments(self, _):
         context.argument('output_dir', arg_group='X.509', options_list=['--output-dir', '--od'],
                          help='Generate self-signed cert and use its thumbprint. '
                          'Output to specified target directory')
+
+    with self.argument_context('iot hub job') as context:
+        context.argument('job_id', options_list=['--job-id'],
+                         help='IoT Hub job Id.')
+        context.argument('job_status', options_list=['--job-status', '--js'],
+                         help='The status of a scheduled job.',
+                         arg_type=get_enum_type(JobStatusType))
+        context.argument('job_type', options_list=['--job-type', '--jt'],
+                         help='The type of scheduled job.',
+                         arg_type=get_enum_type(JobType))
+        context.argument('query_condition', options_list=['--query-condition', '-q'],
+                         help='Condition for device query to get devices to execute the job on. '
+                         'Required if job type is scheduleDeviceMethod or scheduleUpdateTwin. '
+                         'Note: The service will prefix "SELECT * FROM devices WHERE " to the input')
+        context.argument('start_time', options_list=['--start-time', '--start'],
+                         help='The scheduled start of the job in ISO 8601 date time format. '
+                         'If no start time is provided, the job is queued for asap execution.')
+        context.argument('ttl', options_list=['--ttl'], type=int,
+                         help='Max execution time in seconds, before job is terminated.')
+        context.argument('twin_patch', options_list=['--twin-patch'],
+                         help='The desired twin patch. Provide file path or raw json.')
+        context.argument('wait', options_list=['--wait', '-w'],
+                         arg_type=get_three_state_flag(),
+                         help='Block until the created job is in a completed, failed or cancelled state. '
+                         'Will regularly poll on interval specified by --poll-interval.')
+        context.argument('poll_interval', options_list=['--poll-interval'], type=int,
+                         help='Interval in seconds that job status will be checked if --wait flag is passed in.')
 
     with self.argument_context('iot hub monitor-events') as context:
         context.argument('timeout', arg_type=event_timeout_type)

--- a/azext_iot/common/shared.py
+++ b/azext_iot/common/shared.py
@@ -170,3 +170,27 @@ class ConfigType(Enum):
     edge = "edge"
     layered = "layered"
     adm = "adm"
+
+
+class JobType(Enum):
+    """
+    Type of IoT Hub job
+    """
+
+    scheduleUpdateTwin = "scheduleUpdateTwin"
+    scheduleDeviceMethod = "scheduleDeviceMethod"
+
+
+class JobStatusType(Enum):
+    """
+    Type of IoT Hub job status.
+    """
+
+    unknown = "unknown"
+    enqueued = "enqueued"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+    scheduled = "scheduled"
+    queued = "queued"

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.8.7"
+VERSION = "0.8.8"
 EXTENSION_NAME = "azure-cli-iot-ext"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/iothub/__init__.py
+++ b/azext_iot/iothub/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from ._help import load_iothub_help
+
+load_iothub_help()

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -29,6 +29,12 @@ def load_iothub_help():
           text: >
             az iot hub job create --job-id {job_id} --job-type scheduleUpdateTwin -n {iothub_name} -q "*" --twin-patch '{"tags": {"deviceType": "Type1, Type2, Type3"}}'
 
+        examples:
+        - name: Schedule job and block for result of "completed", "failed" or "cancelled". Specify poll interval in seconds.
+          text: >
+            az iot hub job create --job-id {job_id} --job-type scheduleUpdateTwin -n {iothub_name} -q "*" --twin-patch '{"tags": {"deviceType": "Type1, Type2, Type3"}}'
+            --wait --poll-interval 30
+
         - name: Create a job to update a desired twin property on a subset of devices, scheduled to run at an arbitrary future time.
           text: >
             az iot hub job create --job-id {job_name} --job-type scheduleUpdateTwin -n {iothub_name} --twin-patch '{"properties":{"desired": {"temperatureF": 65}}}'

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+"""
+Help definitions for IoT Hub commands.
+"""
+
+from knack.help_files import helps
+
+
+def load_iothub_help():
+
+    helps["iot hub job"] = """
+        type: group
+        short-summary: Manage IoT Hub jobs (v2).
+    """
+
+    helps['iot hub job create'] = """
+        type: command
+        short-summary: Create and schedule an IoT Hub job for execution.
+        long-summary: |
+                      When scheduling a twin update job, the twin patch is a required argument.
+                      When scheduling a device method job, the method name and payload are required arguments.
+
+        examples:
+        - name: Create and schedule a job to update the twin tags of all devices.
+          text: >
+            az iot hub job create --job-id {job_id} --job-type scheduleUpdateTwin -n {iothub_name} -q "*" --twin-patch '{"tags": {"deviceType": "Type1, Type2, Type3"}}'
+
+        - name: Create a job to update a desired twin property on a subset of devices, scheduled to run at an arbitrary future time.
+          text: >
+            az iot hub job create --job-id {job_name} --job-type scheduleUpdateTwin -n {iothub_name} --twin-patch '{"properties":{"desired": {"temperatureF": 65}}}'
+            --start-time "2020-01-08T12:19:56.868Z" --query-condition "deviceId IN ['MyDevice1', 'MyDevice2', 'MyDevice3']"
+
+        - name: Create and schedule a job to invoke a device method for a set of devices meeting a query condition.
+          text: >
+            az iot hub job create --job-id {job_name} --job-type scheduleDeviceMethod -n {iothub_name} --method-name setSyncIntervalSec --method-payload 30
+            --query-condition "properties.reported.settings.syncIntervalSec != 30"
+    """
+
+    helps['iot hub job show'] = """
+        type: command
+        short-summary: Show details of an existing IoT Hub job.
+
+        examples:
+        - name: Show the details of a created job.
+          text: >
+            az iot hub job show --hub-name {iothub_name} --job-id {job_id}
+    """
+
+    helps['iot hub job list'] = """
+        type: command
+        short-summary: List the historical jobs of an IoT Hub.
+
+        examples:
+        - name: Show all properties of all archived jobs within retention period (max of 30 days).
+          text: >
+            az iot hub job list --hub-name {iothub_name}
+        - name: Show all archived jobs filtering on specific properties
+          text: >
+            az iot hub job list --hub-name {iothub_name} --query "[*].[jobId,type,status,startTime,endTime]"
+        - name: Show only update twin type jobs
+          text: >
+            az iot hub job list --hub-name {iothub_name} --job-type scheduleDeviceMethod
+        - name: Show device method jobs which have status "scheduled"
+          text: >
+            az iot hub job list --hub-name {iothub_name} --job-type scheduleDeviceMethod --job-status scheduled
+    """
+
+    helps['iot hub job cancel'] = """
+        type: command
+        short-summary: Cancel an IoT Hub job.
+
+        examples:
+        - name: Cancel an IoT Hub job.
+          text: >
+            az iot hub job cancel --hub-name {iothub_name} --job-id {job_id}
+    """

--- a/azext_iot/iothub/commands.py
+++ b/azext_iot/iothub/commands.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Load CLI commands
+"""
+
+from azext_iot import iothub_ops_job
+
+
+def load_iothub_commands(self, _):
+    """
+    Load CLI commands
+    """
+    with self.command_group("iot hub job", command_type=iothub_ops_job) as cmd_group:
+        cmd_group.command("create", "job_create")
+        cmd_group.command("show", "job_show")
+        cmd_group.command("list", "job_list")
+        cmd_group.command("cancel", "job_cancel")

--- a/azext_iot/iothub/job.py
+++ b/azext_iot/iothub/job.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from time import sleep
+from knack.log import get_logger
+from knack.util import CLIError
+from azext_iot._factory import _bind_sdk
+from azext_iot.common.shared import SdkType
+from azext_iot.common._azure import get_iot_hub_connection_string
+from azext_iot.common.utility import unpack_msrest_error, process_json_arg
+from azext_iot.operations.generic import _execute_query, _process_top
+
+
+logger = get_logger(__name__)
+
+
+def job_create(
+    cmd,
+    job_id,
+    job_type,
+    start_time=None,
+    query_condition=None,
+    twin_patch=None,
+    method_name=None,
+    method_payload=None,
+    method_connect_timeout=30,
+    method_response_timeout=30,
+    ttl=3600,
+    wait=False,
+    poll_interval=10,
+    hub_name=None,
+    resource_group_name=None,
+    login=None,
+):
+    from msrest.exceptions import SerializationError
+    from azext_iot.common.shared import JobType, JobStatusType
+    from azext_iot.sdk.service.models.cloud_to_device_method import CloudToDeviceMethod
+    from azext_iot.sdk.service.models.job_request import JobRequest
+
+    target = get_iot_hub_connection_string(
+        cmd, hub_name, resource_group_name, login=login
+    )
+    service_sdk, errors = _bind_sdk(target, SdkType.service_sdk)
+
+    if (
+        job_type in [JobType.scheduleUpdateTwin.name, JobType.scheduleDeviceMethod.name]
+        and not query_condition
+    ):
+        raise CLIError(
+            "The query condition is required when job type is {} or {}. "
+            "Use query condition '*' if you need to run job on all devices.".format(
+                JobType.scheduleUpdateTwin.name, JobType.scheduleDeviceMethod.name
+            )
+        )
+
+    job_request = JobRequest(
+        job_id=job_id,
+        type=job_type,
+        start_time=start_time,
+        max_execution_time_in_seconds=ttl,
+        query_condition=query_condition,
+    )
+
+    if job_type == JobType.scheduleUpdateTwin.name:
+        if not twin_patch:
+            raise CLIError(
+                "The {} job type requires --twin-patch.".format(
+                    JobType.scheduleUpdateTwin.name
+                )
+            )
+
+        twin_patch = process_json_arg(twin_patch, argument_name="twin-patch")
+        if not isinstance(twin_patch, dict):
+            raise CLIError(
+                "Twin patches must be objects. Received type: {}".format(
+                    type(twin_patch)
+                )
+            )
+
+        # scheduleUpdateTwin job type is a force update, which only accepts '*' as the Etag.
+        twin_patch["etag"] = "*"
+        job_request.update_twin = twin_patch
+    elif job_type == JobType.scheduleDeviceMethod.name:
+        if not method_name:
+            raise CLIError(
+                "The {} job type requires --method-name.".format(
+                    JobType.scheduleDeviceMethod.name
+                )
+            )
+
+        method_payload = process_json_arg(
+            method_payload, argument_name="method-payload"
+        )
+        job_request.cloud_to_device_method = CloudToDeviceMethod(
+            method_name=method_name,
+            connect_timeout_in_seconds=method_connect_timeout,
+            response_timeout_in_seconds=method_response_timeout,
+            payload=method_payload,
+        )
+
+    try:
+        job_result = service_sdk.create_job1(id=job_id, job_request=job_request)
+        if wait:
+            while True:
+                # Check prior to sleep rather than after as jobs may be immediately be in failed state after creation.
+                job_result = _job_show(target, job_id)
+                if "status" in job_result:
+                    if job_result["status"] in [
+                        JobStatusType.completed.name,
+                        JobStatusType.failed.name,
+                        JobStatusType.cancelled.name,
+                    ]:
+                        break
+                sleep(poll_interval)
+
+        return job_result
+    except errors.CloudError as e:
+        raise CLIError(unpack_msrest_error(e))
+    except SerializationError as se:
+        # ISO8601 parsing is handled by msrest
+        raise CLIError(se)
+
+
+def job_show(cmd, job_id, hub_name=None, resource_group_name=None, login=None):
+    target = get_iot_hub_connection_string(
+        cmd, hub_name, resource_group_name, login=login
+    )
+    return _job_show(target, job_id)
+
+
+def _job_show(target, job_id):
+    service_sdk, errors = _bind_sdk(target, SdkType.service_sdk)
+
+    try:
+        return service_sdk.get_job1(id=job_id)
+    except errors.CloudError as e:
+        raise CLIError(unpack_msrest_error(e))
+
+
+def job_list(
+    cmd,
+    job_type=None,
+    job_status=None,
+    top=None,
+    hub_name=None,
+    resource_group_name=None,
+    login=None,
+):
+    top = _process_top(top)
+
+    target = get_iot_hub_connection_string(
+        cmd, hub_name, resource_group_name, login=login
+    )
+    service_sdk, errors = _bind_sdk(target, SdkType.service_sdk)
+
+    try:
+        query = [job_type, job_status]
+        query_method = service_sdk.query_jobs
+
+        return _execute_query(query, query_method, top)
+    except errors.CloudError as e:
+        raise CLIError(unpack_msrest_error(e))
+
+
+def job_cancel(cmd, job_id, hub_name=None, resource_group_name=None, login=None):
+    target = get_iot_hub_connection_string(
+        cmd, hub_name, resource_group_name, login=login
+    )
+    service_sdk, errors = _bind_sdk(target, SdkType.service_sdk)
+
+    try:
+        return service_sdk.cancel_job1(id=job_id)
+    except errors.CloudError as e:
+        raise CLIError(unpack_msrest_error(e))

--- a/azext_iot/operations/_mqtt.py
+++ b/azext_iot/operations/_mqtt.py
@@ -9,7 +9,7 @@ import ssl
 import os
 import six
 
-from time import time, sleep
+from time import sleep
 from paho.mqtt import client as mqtt
 
 from azext_iot.constants import EXTENSION_ROOT, USER_AGENT, BASE_MQTT_API_VERSION
@@ -35,7 +35,7 @@ class mqtt_client_wrap(object):
             target["entity"],
             target["policy"],
             target["primarykey"],
-            time() + int(sas_duration),
+            sas_duration,
         ).generate_sas_token()
         cwd = EXTENSION_ROOT
         cert_path = os.path.join(cwd, "digicert.pem")

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -41,7 +41,7 @@ def iot_dps_device_enrollment_list(client, dps_name, resource_group_name, top=No
         m_sdk, errors = _bind_sdk(target, SdkType.dps_sdk)
 
         query_command = "SELECT *"
-        query = QuerySpecification(query_command)
+        query = [QuerySpecification(query_command)]
         return _execute_query(query, m_sdk.device_enrollment.query, top)
     except errors.ProvisioningServiceErrorDetailsException as e:
         raise CLIError(e)
@@ -210,7 +210,7 @@ def iot_dps_device_enrollment_group_list(client, dps_name, resource_group_name, 
         m_sdk, errors = _bind_sdk(target, SdkType.dps_sdk)
 
         query_command = "SELECT *"
-        query1 = QuerySpecification(query_command)
+        query1 = [QuerySpecification(query_command)]
         return _execute_query(query1, m_sdk.device_enrollment_group.query, top)
     except errors.ProvisioningServiceErrorDetailsException as e:
         raise CLIError(e)

--- a/azext_iot/operations/events3/_builders.py
+++ b/azext_iot/operations/events3/_builders.py
@@ -1,6 +1,5 @@
 import asyncio
 import uamqp
-from time import time
 
 from azext_iot.common.sas_token_auth import SasTokenAuthentication
 from azext_iot.common.utility import (parse_entity, unicode_binary_map, url_encode_str)
@@ -14,7 +13,7 @@ class AmqpBuilder():
         hub_name = target['entity'].split('.')[0]
         user = "{}@sas.root.{}".format(target['policy'], hub_name)
         sas_token = SasTokenAuthentication(target['entity'], target['policy'],
-                                           target['primarykey'], time() + duration).generate_sas_token()
+                                           target['primarykey'], duration).generate_sas_token()
         return url_encode_str(user) + ":{}@{}".format(url_encode_str(sas_token), target['entity'])
 
 

--- a/azext_iot/operations/generic.py
+++ b/azext_iot/operations/generic.py
@@ -8,13 +8,13 @@ from knack.util import CLIError
 from azext_iot.assets.user_messages import error_param_top_out_of_bounds
 
 
-def _execute_query(query, query_method, top=None):
+def _execute_query(query_args, query_method, top=None):
     payload = []
     headers = {"Cache-Control": "no-cache, must-revalidate"}
 
     if top:
         headers["x-ms-max-item-count"] = str(top)
-    result, token = query_method(query, custom_headers=headers)
+    result, token = query_method(*query_args, custom_headers=headers)
     payload.extend(result)
     while token:
         # In case requested count is > service max page size
@@ -26,7 +26,7 @@ def _execute_query(query, query_method, top=None):
             else:
                 break
         headers["x-ms-continuation"] = token
-        result, token = query_method(query, custom_headers=headers)
+        result, token = query_method(*query_args, custom_headers=headers)
         payload.extend(result)
     return payload[:top] if top else payload
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -950,7 +950,7 @@ def _iot_build_sas_token(cmd, hub_name=None, device_id=None, module_id=None, pol
         policy = target['policy']
         key = target['primarykey'] if key_type == 'primary' else target['secondarykey']
 
-    return SasTokenAuthentication(uri, policy, key, time() + int(duration))
+    return SasTokenAuthentication(uri, policy, key, duration)
 
 
 def _build_device_or_module_connection_string(entity, key_type='primary'):
@@ -1015,7 +1015,7 @@ def _iot_device_send_message(target, device_id, data, properties=None, msg_count
     if properties:
         properties = validate_key_value_pairs(properties)
 
-    sas = SasTokenAuthentication(target['entity'], target['policy'], target['primarykey'], time() + 360).generate_sas_token()
+    sas = SasTokenAuthentication(target['entity'], target['policy'], target['primarykey'], 360).generate_sas_token()
     cwd = EXTENSION_ROOT
     cert_path = os.path.join(cwd, 'digicert.pem')
     auth = {

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -45,7 +45,7 @@ def iot_query(cmd, query_command, hub_name=None, top=None, resource_group_name=N
     target = get_iot_hub_connection_string(cmd, hub_name, resource_group_name, login=login)
     service_sdk, errors = _bind_sdk(target, SdkType.service_sdk)
     try:
-        query = QuerySpecification(query_command)
+        query = [QuerySpecification(query_command)]
         query_method = service_sdk.query_iot_hub
 
         return _execute_query(query, query_method, top)
@@ -768,10 +768,10 @@ def iot_hub_configuration_metric_show(cmd, config_id, metric_id, metric_type='us
 
         metric_query = metric_collection[metric_id]
 
-        query = QuerySpecification(metric_query)
+        query_args = [QuerySpecification(metric_query)]
         query_method = service_sdk.query_iot_hub
 
-        metric_result = _execute_query(query, query_method, None)
+        metric_result = _execute_query(query_args, query_method, None)
 
         # 'Flattens' system metrics by putting device Id's in a single list
         if metric_type == MetricType.system.name:
@@ -847,7 +847,7 @@ def iot_device_twin_replace(cmd, device_id, target_json, hub_name=None, resource
 
 
 def iot_device_method(cmd, device_id, method_name, hub_name=None, method_payload="{}",
-                      timeout=60, resource_group_name=None, login=None):
+                      timeout=30, resource_group_name=None, login=None):
     from azext_iot.sdk.service.models.cloud_to_device_method import CloudToDeviceMethod
     from azext_iot.constants import METHOD_INVOKE_MAX_TIMEOUT_SEC, METHOD_INVOKE_MIN_TIMEOUT_SEC
 
@@ -872,7 +872,7 @@ def iot_device_method(cmd, device_id, method_name, hub_name=None, method_payload
 # Device Module Method Invoke
 
 def iot_device_module_method(cmd, device_id, module_id, method_name, hub_name=None, method_payload="{}",
-                             timeout=60, resource_group_name=None, login=None):
+                             timeout=30, resource_group_name=None, login=None):
     from azext_iot.sdk.service.models.cloud_to_device_method import CloudToDeviceMethod
     from azext_iot.constants import METHOD_INVOKE_MAX_TIMEOUT_SEC, METHOD_INVOKE_MIN_TIMEOUT_SEC
 

--- a/azext_iot/sdk/service/iot_hub_gateway_service_apis.py
+++ b/azext_iot/sdk/service/iot_hub_gateway_service_apis.py
@@ -667,6 +667,7 @@ class IotHubGatewayServiceAPIs(object):
 
         deserialized = None
 
+        # @digimaun - Changed from 'QueryResult' to [object]
         if response.status_code == 200:
             deserialized = self._deserialize('[object]', response)
 
@@ -1760,7 +1761,8 @@ class IotHubGatewayServiceAPIs(object):
         deserialized = None
 
         if response.status_code == 200:
-            deserialized = self._deserialize('JobResponse', response)
+            # @digimaun - altered from "JobResponse" to "{object}"
+            deserialized = self._deserialize('{object}', response)
 
         if raw:
             client_raw_response = ClientRawResponse(deserialized, response)
@@ -1823,8 +1825,9 @@ class IotHubGatewayServiceAPIs(object):
 
         deserialized = None
 
+        # @digimaun - changed from "JobResponse" to {object}
         if response.status_code == 200:
-            deserialized = self._deserialize('JobResponse', response)
+            deserialized = self._deserialize('{object}', response)
 
         if raw:
             client_raw_response = ClientRawResponse(deserialized, response)
@@ -1881,8 +1884,9 @@ class IotHubGatewayServiceAPIs(object):
 
         deserialized = None
 
+        # @digimaun - changed from "JobResponse" to {object}
         if response.status_code == 200:
-            deserialized = self._deserialize('JobResponse', response)
+            deserialized = self._deserialize('{object}', response)
 
         if raw:
             client_raw_response = ClientRawResponse(deserialized, response)
@@ -1942,14 +1946,17 @@ class IotHubGatewayServiceAPIs(object):
 
         deserialized = None
 
+        # @digimaun - changed from 'QueryResult' to [object]
         if response.status_code == 200:
-            deserialized = self._deserialize('QueryResult', response)
+            deserialized = self._deserialize('[object]', response)
 
         if raw:
             client_raw_response = ClientRawResponse(deserialized, response)
             return client_raw_response
 
-        return deserialized
+        # @digimaun - Added Custom
+        continuation = response.headers.get('x-ms-continuation')
+        return deserialized, continuation
     query_jobs.metadata = {'url': '/jobs/v2/query'}
 
     def get_modules_on_device(

--- a/azext_iot/sdk/service/models/job_request.py
+++ b/azext_iot/sdk/service/models/job_request.py
@@ -40,11 +40,12 @@ class JobRequest(Model):
     :type max_execution_time_in_seconds: long
     """
 
+    # @digimaun - altered update_twin type from Twin to {object}
     _attribute_map = {
         'job_id': {'key': 'jobId', 'type': 'str'},
         'type': {'key': 'type', 'type': 'str'},
         'cloud_to_device_method': {'key': 'cloudToDeviceMethod', 'type': 'CloudToDeviceMethod'},
-        'update_twin': {'key': 'updateTwin', 'type': 'Twin'},
+        'update_twin': {'key': 'updateTwin', 'type': '{object}'},
         'query_condition': {'key': 'queryCondition', 'type': 'str'},
         'start_time': {'key': 'startTime', 'type': 'iso-8601'},
         'max_execution_time_in_seconds': {'key': 'maxExecutionTimeInSeconds', 'type': 'long'},

--- a/azext_iot/tests/__init__.py
+++ b/azext_iot/tests/__init__.py
@@ -16,6 +16,7 @@ PREFIX_EDGE_DEVICE = "test-edge-device-"
 PREFIX_DEVICE_MODULE = "test-module-"
 PREFIX_CONFIG = "test-config-"
 PREFIX_EDGE_CONFIG = "test-edgedeploy-"
+PREFIX_JOB = "test-job-"
 
 
 @contextmanager
@@ -90,6 +91,12 @@ class IoTLiveScenarioTest(LiveScenarioTest):
         ]
         self.config_ids.extend(names)
         return names
+
+    def generate_job_names(self, count=1):
+        return [
+            self.create_random_name(prefix=PREFIX_JOB, length=32)
+            for i in range(count)
+        ]
 
     # TODO: @digimaun - Maybe put a helper like this in the shared lib, when you create it?
     def command_execute_assert(self, command, asserts):

--- a/azext_iot/tests/jobs/__init__.py
+++ b/azext_iot/tests/jobs/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/azext_iot/tests/jobs/conftest.py
+++ b/azext_iot/tests/jobs/conftest.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+import pytest
+
+from ..conftest import mock_target
+
+path_ghcs = "azext_iot.iothub.job.get_iot_hub_connection_string"
+
+
+@pytest.fixture()
+def fixture_ghcs(mocker):
+    ghcs = mocker.patch(path_ghcs)
+    ghcs.return_value = mock_target
+    return ghcs

--- a/azext_iot/tests/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/jobs/test_iothub_jobs_int.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import json
+
+from .. import IoTLiveScenarioTest
+from ..settings import DynamoSettings, ENV_SET_TEST_IOTHUB_BASIC
+
+
+settings = DynamoSettings(ENV_SET_TEST_IOTHUB_BASIC)
+LIVE_HUB = settings.env.azext_iot_testhub
+LIVE_RG = settings.env.azext_iot_testrg
+LIVE_HUB_CS = settings.env.azext_iot_testhub_cs
+
+
+class TestIoTHubJobs(IoTLiveScenarioTest):
+    def __init__(self, test_case):
+        super(TestIoTHubJobs, self).__init__(test_case, LIVE_HUB, LIVE_RG, LIVE_HUB_CS)
+
+    def test_job_create(self):
+        device_count = 3
+        device_ids = self.generate_device_names(device_count)
+
+        job_count = 3
+        job_ids = self.generate_job_names(job_count)
+
+        for device_id in device_ids:
+            self.cmd(
+                "iot hub device-identity create -d {} -n {} -g {}".format(
+                    device_id, LIVE_HUB, LIVE_RG
+                )
+            )
+
+        # Focus is on scheduleUpdateTwin jobs until we improve JIT device simulation
+
+        # Update twin tags scenario
+        self.kwargs["twin_patch_tags"] = '{"tags": {"deviceClass": "Class1, Class2, Class3"}}'
+        query_condition = "deviceId in ['{}']".format("','".join(device_ids))
+
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} -q \"{}\" --twin-patch '{}' -n {} -g {} --ttl 300 --wait".format(
+                job_ids[0],
+                "scheduleUpdateTwin",
+                query_condition,
+                "{twin_patch_tags}",
+                LIVE_HUB,
+                LIVE_RG,
+            ),
+            checks=[
+                self.check("jobId", job_ids[0]),
+                self.check("queryCondition", query_condition),
+                self.check("status", "completed"),
+                self.check("updateTwin.etag", "*"),
+                self.check("updateTwin.tags", json.loads(self.kwargs["twin_patch_tags"])["tags"]),
+                self.check("type", "scheduleUpdateTwin"),
+            ]
+        )
+
+        for device_id in device_ids:
+            self.cmd(
+                "iot hub device-twin show -d {} -n {} -g {}".format(
+                    device_id, LIVE_HUB, LIVE_RG
+                ),
+                checks=[
+                    self.check("tags", json.loads(self.kwargs["twin_patch_tags"])["tags"])
+                ],
+            )
+
+        # Update twin desired properties

--- a/azext_iot/tests/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/jobs/test_iothub_jobs_int.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------------------
 
 import json
-
+from datetime import datetime, timedelta
 from .. import IoTLiveScenarioTest
 from ..settings import DynamoSettings, ENV_SET_TEST_IOTHUB_BASIC
 
@@ -20,14 +20,15 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
     def __init__(self, test_case):
         super(TestIoTHubJobs, self).__init__(test_case, LIVE_HUB, LIVE_RG, LIVE_HUB_CS)
 
-    def test_job_create(self):
-        device_count = 3
-        device_ids = self.generate_device_names(device_count)
-
         job_count = 3
-        job_ids = self.generate_job_names(job_count)
+        self.job_ids = self.generate_job_names(job_count)
 
-        for device_id in device_ids:
+    def test_jobs(self):
+        device_count = 2
+        device_ids_twin_tags = self.generate_device_names(device_count)
+        device_ids_twin_props = self.generate_device_names(device_count)
+
+        for device_id in device_ids_twin_tags + device_ids_twin_props:
             self.cmd(
                 "iot hub device-identity create -d {} -n {} -g {}".format(
                     device_id, LIVE_HUB, LIVE_RG
@@ -37,12 +38,14 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
         # Focus is on scheduleUpdateTwin jobs until we improve JIT device simulation
 
         # Update twin tags scenario
-        self.kwargs["twin_patch_tags"] = '{"tags": {"deviceClass": "Class1, Class2, Class3"}}'
-        query_condition = "deviceId in ['{}']".format("','".join(device_ids))
+        self.kwargs[
+            "twin_patch_tags"
+        ] = '{"tags": {"deviceClass": "Class1, Class2, Class3"}}'
+        query_condition = "deviceId in ['{}']".format("','".join(device_ids_twin_tags))
 
         self.cmd(
             "iot hub job create --job-id {} --job-type {} -q \"{}\" --twin-patch '{}' -n {} -g {} --ttl 300 --wait".format(
-                job_ids[0],
+                self.job_ids[0],
                 "scheduleUpdateTwin",
                 query_condition,
                 "{twin_patch_tags}",
@@ -50,23 +53,167 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                 LIVE_RG,
             ),
             checks=[
-                self.check("jobId", job_ids[0]),
+                self.check("jobId", self.job_ids[0]),
                 self.check("queryCondition", query_condition),
                 self.check("status", "completed"),
                 self.check("updateTwin.etag", "*"),
-                self.check("updateTwin.tags", json.loads(self.kwargs["twin_patch_tags"])["tags"]),
+                self.check(
+                    "updateTwin.tags",
+                    json.loads(self.kwargs["twin_patch_tags"])["tags"],
+                ),
                 self.check("type", "scheduleUpdateTwin"),
-            ]
+            ],
         )
 
-        for device_id in device_ids:
+        for device_id in device_ids_twin_tags:
             self.cmd(
                 "iot hub device-twin show -d {} -n {} -g {}".format(
                     device_id, LIVE_HUB, LIVE_RG
                 ),
                 checks=[
-                    self.check("tags", json.loads(self.kwargs["twin_patch_tags"])["tags"])
+                    self.check(
+                        "tags", json.loads(self.kwargs["twin_patch_tags"])["tags"]
+                    )
                 ],
             )
 
-        # Update twin desired properties
+        # Update twin desired properties, using connection string
+        self.kwargs[
+            "twin_patch_props"
+        ] = '{"properties": {"desired": {"arbitrary": "value"}}}'
+        query_condition = "deviceId in ['{}']".format("','".join(device_ids_twin_props))
+
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} -q \"{}\" --twin-patch '{}' --login '{}' --ttl 300 --wait".format(
+                self.job_ids[1],
+                "scheduleUpdateTwin",
+                query_condition,
+                "{twin_patch_props}",
+                LIVE_HUB_CS,
+            ),
+            checks=[
+                self.check("jobId", self.job_ids[1]),
+                self.check("queryCondition", query_condition),
+                self.check("status", "completed"),
+                self.check("updateTwin.etag", "*"),
+                self.check(
+                    "updateTwin.properties",
+                    json.loads(self.kwargs["twin_patch_props"])["properties"],
+                ),
+                self.check("type", "scheduleUpdateTwin"),
+            ],
+        )
+
+        # Error - omit queryCondition when scheduleUpdateTwin or scheduleDeviceMethod
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} --twin-patch '{}' -n {}".format(
+                self.job_ids[1], "scheduleUpdateTwin", "{twin_patch_props}", LIVE_HUB
+            ),
+            expect_failure=True,
+        )
+
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} --twin-patch '{}' -n {}".format(
+                self.job_ids[1], "scheduleDeviceMethod", "{twin_patch_props}", LIVE_HUB
+            ),
+            expect_failure=True,
+        )
+
+        # Error - omit twin patch when scheduleUpdateTwin
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} -q '*' -n {}".format(
+                self.job_ids[1], "scheduleUpdateTwin", LIVE_HUB
+            ),
+            expect_failure=True,
+        )
+
+        # Error - omit method name when scheduleDeviceMethod
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} -q '*' -n {}".format(
+                self.job_ids[1], "scheduleDeviceMethod", LIVE_HUB
+            ),
+            expect_failure=True,
+        )
+
+        # Show Job tests
+        # Using --wait when creating effectively uses show
+        self.cmd(
+            "iot hub job show --job-id {} -n {} -g {}".format(
+                self.job_ids[0], LIVE_HUB, LIVE_RG
+            ),
+            checks=[
+                self.check("jobId", self.job_ids[0]),
+                self.check("type", "scheduleUpdateTwin"),
+            ],
+        )
+
+        # With connection string
+        self.cmd(
+            "iot hub job show --job-id {} --login {}".format(
+                self.job_ids[1], LIVE_HUB_CS
+            ),
+            checks=[
+                self.check("jobId", self.job_ids[1]),
+                self.check("type", "scheduleUpdateTwin"),
+            ],
+        )
+
+        # Interesting behavior - Show non-existant job
+        self.cmd(
+            "iot hub job show --job-id notarealjobid -n {} -g {}".format(
+                LIVE_HUB, LIVE_RG
+            ),
+            checks=[
+                self.check("jobId", "notarealjobid"),
+                self.check("type", "unknown"),
+                self.check("status", "unknown"),
+            ],
+        )
+
+        # Cancel Job test
+        # Create job to be cancelled - scheduled +1 hour from now.
+        scheduled_time_iso = (datetime.utcnow() + timedelta(days=7)).isoformat()
+
+        self.cmd(
+            "iot hub job create --job-id {} --job-type {} -q \"{}\" --twin-patch '{}' --start '{}' -n {} -g {}".format(
+                self.job_ids[2],
+                "scheduleUpdateTwin",
+                query_condition,
+                "{twin_patch_tags}",
+                scheduled_time_iso,
+                LIVE_HUB,
+                LIVE_RG,
+            ),
+            checks=[self.check("jobId", self.job_ids[2])],
+        )
+
+        self.cmd(
+            "iot hub job cancel --job-id {} -n {} -g {}".format(
+                self.job_ids[2], LIVE_HUB, LIVE_RG
+            ),
+            checks=[
+                self.check("jobId", self.job_ids[2]),
+                self.check("status", "cancelled"),
+            ],
+        )
+
+        # Error - Cancel non-existant job
+        self.cmd(
+            "iot hub job cancel --job-id notarealjobid -n {} -g {}".format(
+                LIVE_HUB, LIVE_RG
+            ),
+            expect_failure=True,
+        )
+
+        # List Job tests
+        # You can't explictly delete a job/job history so check for existance
+        job_result_set = self.cmd(
+            "iot hub job list -n {} -g {}".format(LIVE_HUB, LIVE_RG)
+        ).get_output_in_json()
+
+        filtered_job_ids_result = {}
+        for job in job_result_set:
+            filtered_job_ids_result[job["jobId"]] = True
+
+        for job_id in self.job_ids:
+            assert job_id in filtered_job_ids_result

--- a/azext_iot/tests/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/jobs/test_iothub_jobs_int.py
@@ -171,7 +171,7 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
         )
 
         # Cancel Job test
-        # Create job to be cancelled - scheduled +1 hour from now.
+        # Create job to be cancelled - scheduled +7 days from now.
         scheduled_time_iso = (datetime.utcnow() + timedelta(days=7)).isoformat()
 
         self.cmd(

--- a/azext_iot/tests/jobs/test_iothub_jobs_unit.py
+++ b/azext_iot/tests/jobs/test_iothub_jobs_unit.py
@@ -1,0 +1,568 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+import pytest
+import json
+from random import randint
+from functools import partial
+from uuid import uuid4
+from knack.cli import CLIError
+from azext_iot.iothub import job as subject
+from azext_iot.common.shared import JobStatusType, JobType
+from ..conftest import build_mock_response, path_service_client, mock_target
+
+
+def generate_job_id():
+    return "myjob-{}".format(str(uuid4()).replace("-", ""))
+
+
+@pytest.fixture
+def sample_job_show():
+    return {
+        "createdTime": "2020-01-06T21:44:00.8884134Z",
+        "deviceJobStatistics": {
+            "deviceCount": 2,
+            "failedCount": 0,
+            "pendingCount": 0,
+            "runningCount": 0,
+            "succeededCount": 2,
+        },
+        "endTime": "2020-01-06T21:44:06.2536519Z",
+        "jobId": "test-job-wqcqw46tj6siwobiovgr4tv",
+        "maxExecutionTimeInSeconds": 300,
+        "queryCondition": "deviceId in ['test-device-h6fdugt36sp73msf3b5f','test-device-e226yjpant3k2g4fqqfx']",
+        "startTime": "2020-01-06T21:44:00.8884134Z",
+        "status": "completed",
+        "type": "scheduleUpdateTwin",
+        "updateTwin": {
+            "deviceId": None,
+            "etag": "*",
+            "tags": {"deviceClass": "Class1, Class2, Class3"},
+        },
+    }
+
+
+@pytest.fixture
+def sample_job_status():
+    return {"jobId": "test-job-wqcqw46tj6siwobiovgr4tv", "status": "cancelled"}
+
+
+@pytest.fixture(params=[5, 0])
+def sample_job_list(sample_job_show, request):
+    result = []
+    for _ in range(request.param):
+        result.append(sample_job_show)
+    return (result, request.param)
+
+
+class TestJobCreate:
+    @pytest.fixture(params=[200])
+    def serviceclient(self, mocker, fixture_ghcs, fixture_sas, request):
+        service_client = mocker.patch(path_service_client)
+        service_client.return_value = build_mock_response(mocker, request.param, {})
+        return service_client
+
+    # Simulate scenario where --wait is specified
+    @pytest.fixture(
+        params=[
+            (200, JobStatusType.completed.value),
+            (200, JobStatusType.failed.value),
+            (200, JobStatusType.cancelled.value),
+        ]
+    )
+    def serviceclient_test_wait(self, mocker, fixture_ghcs, fixture_sas, request):
+        service_client = mocker.patch(path_service_client)
+        test_side_effect = [
+            # Job Queued
+            build_mock_response(
+                mocker,
+                request.param[0],
+                {
+                    "jobId": "myjob",
+                    "status": JobStatusType.queued.value,
+                    "type": JobType.scheduleUpdateTwin.value,
+                },
+            ),
+            build_mock_response(
+                mocker,
+                request.param[0],
+                {
+                    "jobId": "myjob",
+                    "status": JobStatusType.running.value,
+                    "type": JobType.scheduleUpdateTwin.value,
+                },
+            ),
+            build_mock_response(
+                mocker,
+                request.param[0],
+                {
+                    "createdTime": "2020-01-01T01:06:38.2649798Z",
+                    "deviceJobStatistics": {
+                        "deviceCount": 6,
+                        "failedCount": 0,
+                        "pendingCount": 0,
+                        "runningCount": 0,
+                        "succeededCount": 6,
+                    },
+                    "endTime": "2020-01-01T01:06:42.4993645Z",
+                    "jobId": "myjob",
+                    "maxExecutionTimeInSeconds": 900,
+                    "queryCondition": "*",
+                    "startTime": "2020-01-01T01:06:38.2649798Z",
+                    "status": request.param[1],
+                    "type": "scheduleUpdateTwin",
+                    "updateTwin": {
+                        "deviceId": None,
+                        "etag": "*",
+                        "tags": {"deviceClass": "Class1, Class2"},
+                    },
+                },
+            ),
+        ]
+        service_client.side_effect = test_side_effect
+
+    @pytest.mark.parametrize(
+        "job_id, job_type, hub_name, start_time, query_condition, payload, ttl, method_name, mct, mrt",
+        [
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                None,
+                None,
+                None,
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleDeviceMethod.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                "mymethod",
+                randint(30, 90),
+                randint(30, 90),
+            ),
+        ],
+    )
+    def test_job_create(
+        self,
+        fixture_cmd2,
+        serviceclient,
+        job_id,
+        job_type,
+        hub_name,
+        start_time,
+        query_condition,
+        payload,
+        ttl,
+        method_name,
+        mct,
+        mrt,
+    ):
+        job_create = partial(
+            subject.job_create,
+            cmd=fixture_cmd2,
+            job_id=job_id,
+            job_type=job_type,
+            hub_name=hub_name,
+            start_time=start_time,
+            query_condition=query_condition,
+            ttl=ttl,
+        )
+
+        if job_type == JobType.scheduleUpdateTwin.value:
+            job_create(twin_patch=payload)
+        elif job_type == JobType.scheduleDeviceMethod.value:
+            job_create(
+                method_name=method_name,
+                method_payload=payload,
+                method_connect_timeout=mct,
+                method_response_timeout=mrt,
+            )
+
+        args = serviceclient.call_args
+        url = args[0][0].url
+        method = args[0][0].method
+        body = args[0][2]
+
+        assert "{}/jobs/v2/{}?".format(hub_name, job_id) in url
+        assert method == "PUT"
+        assert body["jobId"] == job_id
+        assert body["startTime"] == start_time
+        assert body["maxExecutionTimeInSeconds"] == ttl
+        assert body["queryCondition"] == query_condition
+
+        payload = json.loads(payload)
+
+        if job_type == JobType.scheduleUpdateTwin.value:
+            assert body["type"] == JobType.scheduleUpdateTwin.value
+            payload["etag"] = "*"
+            assert body["updateTwin"] == payload
+        elif job_type == JobType.scheduleDeviceMethod.value:
+            assert body["type"] == JobType.scheduleDeviceMethod.value
+            assert body["cloudToDeviceMethod"]["methodName"] == method_name
+            assert body["cloudToDeviceMethod"]["payload"] == payload
+            assert body["cloudToDeviceMethod"]["responseTimeoutInSeconds"] == mrt
+            assert body["cloudToDeviceMethod"]["connectTimeoutInSeconds"] == mct
+
+    @pytest.mark.parametrize(
+        "job_id, job_type, hub_name, start_time, query_condition, payload, ttl, wait, poll_interval",
+        [
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                True,
+                1
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                None,
+                10
+            )
+        ],
+    )
+    def test_job_create_wait(
+        self,
+        fixture_cmd2,
+        serviceclient_test_wait,
+        job_id,
+        job_type,
+        hub_name,
+        start_time,
+        query_condition,
+        payload,
+        ttl,
+        wait,
+        poll_interval
+    ):
+        job_create = partial(
+            subject.job_create,
+            cmd=fixture_cmd2,
+            job_id=job_id,
+            job_type=job_type,
+            hub_name=hub_name,
+            start_time=start_time,
+            query_condition=query_condition,
+            ttl=ttl,
+            wait=wait,
+            poll_interval=poll_interval,
+        )
+
+        result = None
+        if job_type == JobType.scheduleUpdateTwin.value:
+            result = job_create(twin_patch=payload)
+
+        assert isinstance(result, dict)
+
+        if not wait:
+            assert result["status"] == JobStatusType.queued.value
+
+    @pytest.mark.parametrize(
+        "job_id, job_type, hub_name, start_time, query_condition, payload, ttl, method_name, mct, mrt, expected_error",
+        [
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                None,
+                '{"key1":"value1"}',
+                randint(300, 900),
+                None,
+                None,
+                None,
+                "The query condition is required",
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleDeviceMethod.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                None,
+                '{"key1":"value1"}',
+                randint(300, 900),
+                "mymethod",
+                randint(30, 90),
+                randint(30, 90),
+                "The query condition is required",
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                None,
+                randint(300, 900),
+                None,
+                None,
+                None,
+                "job type requires --twin-patch",
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleDeviceMethod.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                None,
+                randint(30, 90),
+                randint(30, 90),
+                "job type requires --method-name",
+            ),
+        ],
+    )
+    def test_job_create_malformed(
+        self,
+        fixture_cmd2,
+        serviceclient,
+        job_id,
+        job_type,
+        hub_name,
+        start_time,
+        query_condition,
+        payload,
+        ttl,
+        method_name,
+        mct,
+        mrt,
+        expected_error,
+    ):
+        with pytest.raises(CLIError) as exc:
+            job_create = partial(
+                subject.job_create,
+                cmd=fixture_cmd2,
+                job_id=job_id,
+                job_type=job_type,
+                hub_name=hub_name,
+                start_time=start_time,
+                query_condition=query_condition,
+                ttl=ttl,
+            )
+
+            if job_type == JobType.scheduleUpdateTwin.value:
+                job_create(twin_patch=payload)
+            elif job_type == JobType.scheduleDeviceMethod.value:
+                job_create(
+                    method_name=method_name,
+                    method_payload=payload,
+                    method_connect_timeout=mct,
+                    method_response_timeout=mrt,
+                )
+
+        exception_obj = str(exc.value)
+
+        assert expected_error in exception_obj
+
+    @pytest.mark.parametrize(
+        "job_id, job_type, hub_name, start_time, query_condition, payload, ttl, method_name, mct, mrt",
+        [
+            (
+                generate_job_id(),
+                JobType.scheduleUpdateTwin.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                None,
+                None,
+                None,
+            ),
+            (
+                generate_job_id(),
+                JobType.scheduleDeviceMethod.value,
+                mock_target["entity"],
+                "2020-01-06T23:55:11.538201Z",
+                "*",
+                '{"key1":"value1"}',
+                randint(300, 900),
+                "mymethod",
+                randint(30, 90),
+                randint(30, 90),
+            ),
+        ],
+    )
+    def test_job_create_error(
+        self,
+        fixture_cmd2,
+        serviceclient_generic_error,
+        job_id,
+        job_type,
+        hub_name,
+        start_time,
+        query_condition,
+        payload,
+        ttl,
+        method_name,
+        mct,
+        mrt,
+    ):
+        with pytest.raises(CLIError):
+            job_create = partial(
+                subject.job_create,
+                cmd=fixture_cmd2,
+                job_id=job_id,
+                job_type=job_type,
+                hub_name=hub_name,
+                start_time=start_time,
+                query_condition=query_condition,
+                ttl=ttl,
+            )
+
+            if job_type == JobType.scheduleUpdateTwin.value:
+                job_create(twin_patch=payload)
+            elif job_type == JobType.scheduleDeviceMethod.value:
+                job_create(
+                    method_name=method_name,
+                    method_payload=payload,
+                    method_connect_timeout=mct,
+                    method_response_timeout=mrt,
+                )
+
+
+class TestJobShow:
+    @pytest.fixture(params=[200])
+    def serviceclient(
+        self, mocker, fixture_ghcs, fixture_sas, request, sample_job_show
+    ):
+        service_client = mocker.patch(path_service_client)
+        service_client.return_value = build_mock_response(
+            mocker, request.param, sample_job_show
+        )
+        return service_client
+
+    def test_job_show(self, fixture_cmd2, serviceclient, sample_job_show):
+        target_job_id = generate_job_id()
+        result = subject.job_show(
+            cmd=fixture_cmd2, job_id=target_job_id, hub_name=mock_target["entity"]
+        )
+
+        args = serviceclient.call_args
+        url = args[0][0].url
+        method = args[0][0].method
+
+        assert "{}/jobs/v2/{}?".format(mock_target["entity"], target_job_id) in url
+        assert method == "GET"
+        assert result == sample_job_show
+
+    def test_job_show_error(self, fixture_cmd2, serviceclient_generic_error):
+        target_job_id = generate_job_id()
+
+        with pytest.raises(CLIError):
+            subject.job_show(
+                cmd=fixture_cmd2, job_id=target_job_id, hub_name=mock_target["entity"]
+            )
+
+
+class TestJobCancel:
+    @pytest.fixture(params=[200])
+    def serviceclient(
+        self, mocker, fixture_ghcs, fixture_sas, request, sample_job_status
+    ):
+        service_client = mocker.patch(path_service_client)
+        service_client.return_value = build_mock_response(
+            mocker, request.param, sample_job_status
+        )
+        return service_client
+
+    def test_job_cancel(self, fixture_cmd2, serviceclient, sample_job_status):
+        target_job_id = generate_job_id()
+        result = subject.job_cancel(
+            cmd=fixture_cmd2, job_id=target_job_id, hub_name=mock_target["entity"]
+        )
+
+        args = serviceclient.call_args
+        url = args[0][0].url
+        method = args[0][0].method
+
+        assert (
+            "{}/jobs/v2/{}/cancel?".format(mock_target["entity"], target_job_id) in url
+        )
+        assert method == "POST"
+        assert result == sample_job_status
+
+    def test_job_cancel_error(self, fixture_cmd2, serviceclient_generic_error):
+        target_job_id = generate_job_id()
+
+        with pytest.raises(CLIError):
+            subject.job_cancel(
+                cmd=fixture_cmd2, job_id=target_job_id, hub_name=mock_target["entity"]
+            )
+
+
+class TestJobList:
+    @pytest.fixture(params=[200])
+    def serviceclient(
+        self, mocker, fixture_ghcs, fixture_sas, request, sample_job_list
+    ):
+        service_client = mocker.patch(path_service_client)
+        service_client.return_value = build_mock_response(
+            mocker, request.param, sample_job_list[0], {"x-ms-continuation": None}
+        )
+        # Hack - for ease of access to expected count
+        setattr(service_client, "expected_count", sample_job_list[1])
+
+        return service_client
+
+    @pytest.mark.parametrize(
+        "job_type, job_status, top",
+        [
+            (JobType.scheduleUpdateTwin.value, JobStatusType.completed.value, 3),
+            (JobType.scheduleDeviceMethod.value, JobStatusType.queued.value, 6),
+            (None, None, None),
+        ],
+    )
+    def test_job_list(self, fixture_cmd2, serviceclient, job_type, job_status, top):
+        result = subject.job_list(
+            cmd=fixture_cmd2,
+            job_type=job_type,
+            job_status=job_status,
+            top=top,
+            hub_name=mock_target["entity"],
+        )
+
+        args = serviceclient.call_args
+        url = args[0][0].url
+        method = args[0][0].method
+
+        assert "{}/jobs/v2/query?".format(mock_target["entity"]) in url
+
+        if job_type:
+            assert "jobType={}".format(job_type)
+
+        if job_status:
+            assert "jobStatus={}".format(job_status)
+
+        assert method == "GET"
+
+        if serviceclient.expected_count:
+            if top and top <= serviceclient.expected_count:
+                assert len(result) == top
+            else:
+                assert len(result) == serviceclient.expected_count
+        else:
+            assert not len(result)

--- a/azext_iot/tests/test_iot_ext_unit.py
+++ b/azext_iot/tests/test_iot_ext_unit.py
@@ -1760,7 +1760,7 @@ class TestSasTokenAuth:
 
         # Action
         sas_auth = SasTokenAuthentication(uri, None, access_key, expiry)
-        token = sas_auth.generate_sas_token()
+        token = sas_auth.generate_sas_token(absolute=True)
 
         # Assertion
         assert "SharedAccessSignature " in token
@@ -1777,7 +1777,7 @@ class TestSasTokenAuth:
 
         # Action
         sas_auth = SasTokenAuthentication(uri, policy_name, access_key, expiry)
-        token = sas_auth.generate_sas_token()
+        token = sas_auth.generate_sas_token(absolute=True)
 
         # Assertion
         assert "SharedAccessSignature " in token
@@ -1791,7 +1791,7 @@ class TestSasTokenAuth:
 
         # Action
         sas_auth = SasTokenAuthentication(uri, policy_name, access_key, expiry)
-        token = sas_auth.generate_sas_token()
+        token = sas_auth.generate_sas_token(absolute=True)
 
         # Assertion
         assert "SharedAccessSignature " in token

--- a/pytest.ini.example
+++ b/pytest.ini.example
@@ -1,4 +1,5 @@
 [pytest]
+junit_family = legacy
 addopts =
     -v
     -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "License :: OSI Approved :: MIT License",
 ]
 
@@ -92,4 +93,5 @@ setup(
         ]
     },
     install_requires=DEPENDENCIES,
+    zip_safe=False
 )


### PR DESCRIPTION
The PR has 2 main components

- Adds the Jobs v2 command set
- Refactors `SasTokenAuthentication` behavior to be a bit easier to use and to support session injection.
- Also, CI runs unit tests on Python 3.8.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
