### PR TITLE
Add ADM module config target condition validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Release History
 +++++++++++++++
 * Breaking change: Evaluating an edge deployment/hub configuration SYSTEM metric (via show-metric) will return non-manipulated query output.
   This means the result is always a collection of objects.
+* Breaking change: (second attempt) Remove long since deprecated parameter `--config-id` from edge deployments.
+  Use `--deployment-id` or `-d` instead.
+* When creating ADM module configurations, the target condition starting with 'from devices.modules where' is enforced.
 * SDK refresh. IoT Hub service calls (except for 'az iot dt' commands) point to api-version 2019-10-01.
 * Extension package name has been changed to 'azure-iot'.
 * Help text for ADM module configurations has been updated with proper target condition syntax for module criteria.

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -439,13 +439,13 @@ helps['iot hub configuration create'] = """
       text: >
         az iot hub configuration create -c {config_name} -n {iothub_name} --content module_content.json
         --target-condition "from devices.modules where tags.building=9" --labels "{\\"key0\\":\\"value0\\", \\"key1\\":\\"value1\\"}"
-        --metrics "{\\"metrics\\": {\\"queries\\": {\\"mymetric\\": \\"select deviceId from devices where tags.location='US'\\"}}}"
+        --metrics "{\\"metrics\\": {\\"queries\\": {\\"mymetric\\": \\"select moduleId from devices.modules where tags.location='US'\\"}}}"
     - name: Create a module configuration with content and user metrics inline (powershell syntax example)
       text: >
         az iot hub configuration create -c {config_name} -n {iothub_name}
         --content '{\\"moduleContent\\": {\\"properties.desired.chillerWaterSettings\\": {\\"temperature\\": 38, \\"pressure\\": 78}}}'
         --target-condition "from devices.modules where tags.building=9" --priority 1
-        --metrics '{\\"metrics\\": {\\"queries\\": {\\"mymetric\\":\\"select deviceId from devices where tags.location=''US''\\"}}}'
+        --metrics '{\\"metrics\\": {\\"queries\\": {\\"mymetric\\":\\"select moduleId from devices.modules where tags.location=''US''\\"}}}'
 """
 
 helps['iot hub configuration show'] = """

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -343,9 +343,8 @@ def load_arguments(self, _):
                          help='Maximum number of configurations to return.')
 
     with self.argument_context('iot edge') as context:
-        context.argument('config_id', options_list=['--deployment-id', '-d', '--config-id', '-c'],
-                         help="Target deployment name. Option '--config-id' has been deprecated and will be "
-                         "removed in a future release. Use '--deployment-id' instead.")
+        context.argument('config_id', options_list=['--deployment-id', '-d'],
+                         help='Target deployment name.')
         context.argument('target_condition', options_list=['--target-condition', '--tc', '-t'],
                          help='Target condition in which an Edge deployment applies to.')
         context.argument('priority', options_list=['--priority', '--pri'],

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -627,12 +627,17 @@ def _iot_hub_configuration_create(cmd, config_id, content, config_type, hub_name
 
     content = process_json_arg(content, argument_name="content")
     processed_content = _process_config_content(content, config_type)
+    if "module_content" in processed_content:
+        required_target_prefix = "from devices.modules where"
+        lower_target_condition = target_condition.lower()
+        if not lower_target_condition.startswith(required_target_prefix):
+            raise CLIError("The target condition for a module configuration must start with '{}'".format(required_target_prefix))
 
     if metrics:
         metrics = process_json_arg(metrics, argument_name="metrics")
 
         if "metrics" in metrics:
-            metrics = metrics['metrics']
+            metrics = metrics["metrics"]
         if metrics_key not in metrics:
             raise CLIError("metrics json must include the '{}' property".format(metrics_key))
         metrics = metrics[metrics_key]


### PR DESCRIPTION
* Add ADM module config target condition validation.
* Second attempt at removing "--config-id" from edge deployments.
  * This should be safe since we renamed the extension.


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
