### PR TITLE
Add IoT Edge support for DPS individual enrollments

### DIFF
--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -16,6 +16,7 @@ from azext_iot.common.certops import open_certificate
 from azext_iot.operations.generic import _execute_query
 from azext_iot._factory import _bind_sdk
 from azext_iot.sdk.dps.models.individual_enrollment import IndividualEnrollment
+from azext_iot.sdk.dps.models.device_capabilities import DeviceCapabilities
 from azext_iot.sdk.dps.models.attestation_mechanism import AttestationMechanism
 from azext_iot.sdk.dps.models.tpm_attestation import TpmAttestation
 from azext_iot.sdk.dps.models.symmetric_key_attestation import SymmetricKeyAttestation
@@ -68,6 +69,7 @@ def iot_dps_device_enrollment_create(client,
                                      secondary_key=None,
                                      device_id=None,
                                      iot_hub_host_name=None,
+                                     iot_edge_enabled=False,
                                      initial_twin_tags=None,
                                      initial_twin_properties=None,
                                      provisioning_status=None,
@@ -96,9 +98,11 @@ def iot_dps_device_enrollment_create(client,
             allocation_policy = AllocationType.static.value
             iot_hub_list = iot_hub_host_name.split()
 
+        device_capabilities = DeviceCapabilities(iot_edge_enabled)
+
         enrollment = IndividualEnrollment(enrollment_id,
                                           attestation,
-                                          None,
+                                          device_capabilities,
                                           device_id,
                                           None,
                                           initial_twin,


### PR DESCRIPTION
Addresses #131 to allow individual enrollments to DPS to allow IoT Edge device capability.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
