### PR TITLE
Deprecate 'iotcentral' and being using 'iot central'

### DIFF
--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -117,11 +117,11 @@ def load_command_table(self, _):
         cmd_group.command('list', 'iot_dps_registration_list')
         cmd_group.command('show', 'iot_dps_registration_get')
         cmd_group.command('delete', 'iot_dps_registration_delete')
-        
+
     with self.command_group('iotcentral', command_type=iotcentral_ops,
-                            deprecate_info=self.deprecate(redirect= 'iot central app')) as cmd_group:
-        pass  
-    
+                            deprecate_info=self.deprecate(redirect='iot central app')) as cmd_group:
+        pass
+
     with self.command_group('iotcentral app', command_type=iotcentral_ops) as cmd_group:
         cmd_group.command('monitor-events', 'iot_central_monitor_events')
 
@@ -129,7 +129,7 @@ def load_command_table(self, _):
         cmd_group.command('show', 'iot_central_device_show')
 
     with self.command_group('iot central app', command_type=iotcentral_ops) as cmd_group:
-            cmd_group.command('monitor-events', 'iot_central_monitor_events')
+        cmd_group.command('monitor-events', 'iot_central_monitor_events')
 
     with self.command_group('iot central device-twin', command_type=iotcentral_ops) as cmd_group:
         cmd_group.command('show', 'iot_central_device_show')

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -117,17 +117,19 @@ def load_command_table(self, _):
         cmd_group.command('list', 'iot_dps_registration_list')
         cmd_group.command('show', 'iot_dps_registration_get')
         cmd_group.command('delete', 'iot_dps_registration_delete')
-
+        
+    with self.command_group('iotcentral', command_type=iotcentral_ops,
+                            deprecate_info=self.deprecate(redirect= 'iot central app')) as cmd_group:
+        pass  
+    
     with self.command_group('iotcentral app', command_type=iotcentral_ops) as cmd_group:
-        cmd_group.command('monitor-events', 'iot_central_monitor_events',
-                          deprecate_info='az iot central app monitor-events')
+        cmd_group.command('monitor-events', 'iot_central_monitor_events')
 
     with self.command_group('iotcentral device-twin', command_type=iotcentral_ops) as cmd_group:
-        cmd_group.command('show', 'iot_central_device_show',
-                          deprecate_info='az iot central device-twin')
+        cmd_group.command('show', 'iot_central_device_show')
 
     with self.command_group('iot central app', command_type=iotcentral_ops) as cmd_group:
-        cmd_group.command('monitor-events', 'iot_central_monitor_events')
+            cmd_group.command('monitor-events', 'iot_central_monitor_events')
 
     with self.command_group('iot central device-twin', command_type=iotcentral_ops) as cmd_group:
         cmd_group.command('show', 'iot_central_device_show')

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.9.1"
+VERSION = "0.9.2"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [] Have **all** unit **and** integration tests passed locally? i.e. `pytest -s <project root>/azext_iot/tests`
- [] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
