### PR TITLE
Try parse payload as JSON even if its not JSON

### DIFF
--- a/azext_iot/central/commands_monitor.py
+++ b/azext_iot/central/commands_monitor.py
@@ -39,7 +39,9 @@ def validate_messages(
         repair=repair,
         yes=yes,
     )
-    common_parser_args = CommonParserArguments(properties=telemetry_args.properties)
+    common_parser_args = CommonParserArguments(
+        properties=telemetry_args.properties, content_type="application/json"
+    )
     common_handler_args = CommonHandlerArguments(
         output=telemetry_args.output,
         common_parser_args=common_parser_args,
@@ -82,7 +84,9 @@ def monitor_events(
         repair=repair,
         yes=yes,
     )
-    common_parser_args = CommonParserArguments(properties=telemetry_args.properties)
+    common_parser_args = CommonParserArguments(
+        properties=telemetry_args.properties, content_type="application/json"
+    )
     common_handler_args = CommonHandlerArguments(
         output=telemetry_args.output,
         common_parser_args=common_parser_args,

--- a/azext_iot/monitor/parsers/common_parser.py
+++ b/azext_iot/monitor/parsers/common_parser.py
@@ -162,7 +162,7 @@ class CommonParser(AbstractBaseParser):
 
         if data:
             payload = str(next(data), "utf8")
-            
+
         if "application/json" in content_type.lower():
             return self._try_parse_json(payload)
 

--- a/azext_iot/monitor/parsers/strings.py
+++ b/azext_iot/monitor/parsers/strings.py
@@ -39,9 +39,11 @@ def invalid_non_pnp_field_name_duplicate():
     raise NotImplementedError()
 
 
-def invalid_content_type(content_type: str):  # warning
+def content_type_mismatch(
+    actual_content_type: str, expected_content_type: str
+):  # warning
     return "Content type '{}' is not supported. Expected Content type is '{}'.".format(
-        content_type, SUPPORTED_CONTENT_TYPE
+        actual_content_type, expected_content_type
     )
 
 

--- a/azext_iot/tests/test_monitor_parsers_unit.py
+++ b/azext_iot/tests/test_monitor_parsers_unit.py
@@ -46,7 +46,7 @@ class TestCommonParser:
     content_type = "application/json"
 
     bad_encoding = "ascii"
-    bad_payload = "bad-payload"
+    bad_payload = "{bad-payload"
     bad_content_type = "bad-content-type"
 
     @pytest.mark.parametrize(
@@ -156,8 +156,36 @@ class TestCommonParser:
         expected_details_1 = strings.invalid_encoding_none_found()
         expected_details_2 = strings.invalid_content_type(self.bad_content_type)
         _validate_issues(
-            parser, Severity.warning, 2, 2, [expected_details_1, expected_details_2]
+            parser, Severity.warning, 2, 2, [expected_details_1, expected_details_2],
         )
+
+    def test_parse_bad_type_and_bad_payload_should_error(self):
+        # setup
+        encoded_payload = self.bad_payload.encode()
+        properties = MessageProperties(
+            content_type=self.bad_content_type, content_encoding=self.encoding
+        )
+        message = Message(
+            body=encoded_payload,
+            properties=properties,
+            annotations={common_parser.DEVICE_ID_IDENTIFIER: self.device_id.encode()},
+        )
+        args = CommonParserArguments()
+        parser = common_parser.CommonParser(message=message, common_parser_args=args)
+
+        # act
+        parsed_msg = parser.parse_message()
+
+        # verify
+        # since the content_encoding header is not present, just dump the raw payload
+        payload = str(encoded_payload, "utf8")
+        assert parsed_msg["event"]["payload"] == payload
+
+        expected_details_1 = strings.invalid_content_type(self.bad_content_type)
+        _validate_issues(parser, Severity.warning, 2, 1, [expected_details_1])
+
+        expected_details_2 = strings.invalid_json()
+        _validate_issues(parser, Severity.error, 2, 1, [expected_details_2])
 
     def test_parse_message_bad_encoding_should_warn(self):
         # setup

--- a/azext_iot/tests/test_monitor_parsers_unit.py
+++ b/azext_iot/tests/test_monitor_parsers_unit.py
@@ -142,19 +142,19 @@ class TestCommonParser:
             properties=properties,
             annotations={common_parser.DEVICE_ID_IDENTIFIER: self.device_id.encode()},
         )
-        args = CommonParserArguments()
+        args = CommonParserArguments(content_type="application/json")
         parser = common_parser.CommonParser(message=message, common_parser_args=args)
 
         # act
         parsed_msg = parser.parse_message()
 
         # verify
-        # since the content_encoding header is not present, just dump the raw payload
-        payload = str(encoded_payload, "utf8")
-        assert parsed_msg["event"]["payload"] == payload
+        assert parsed_msg["event"]["payload"] == self.payload
 
         expected_details_1 = strings.invalid_encoding_none_found()
-        expected_details_2 = strings.invalid_content_type(self.bad_content_type)
+        expected_details_2 = strings.content_type_mismatch(
+            self.bad_content_type, "application/json"
+        )
         _validate_issues(
             parser, Severity.warning, 2, 2, [expected_details_1, expected_details_2],
         )
@@ -170,7 +170,7 @@ class TestCommonParser:
             properties=properties,
             annotations={common_parser.DEVICE_ID_IDENTIFIER: self.device_id.encode()},
         )
-        args = CommonParserArguments()
+        args = CommonParserArguments(content_type="application/json")
         parser = common_parser.CommonParser(message=message, common_parser_args=args)
 
         # act
@@ -181,7 +181,9 @@ class TestCommonParser:
         payload = str(encoded_payload, "utf8")
         assert parsed_msg["event"]["payload"] == payload
 
-        expected_details_1 = strings.invalid_content_type(self.bad_content_type)
+        expected_details_1 = strings.content_type_mismatch(
+            self.bad_content_type, "application/json"
+        )
         _validate_issues(parser, Severity.warning, 2, 1, [expected_details_1])
 
         expected_details_2 = strings.invalid_json()


### PR DESCRIPTION
Issue:
Validator does not attempt to parse body if the content-header did not contain `application/json`.

Cause:
Initially assumed that parser should only try to parse body as JSON if specified in body. 

HOWEVER - IoT Central currently coerces/sniffs out that the data is JSON format even if the message header explicitly states otherwise.

Fix:
Update validation logic to also try attempt to parse JSON body out

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
