### PR TITLE
Remove universal wheel config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [flake8]
 max-complexity = 10
 max-line-length = 130


### PR DESCRIPTION
We don't officially support Py 2.7 anymore.

Package name would look like this after removal:

![image](https://user-images.githubusercontent.com/28658112/91614944-5fec0d80-e937-11ea-8573-48106effc1ce.png)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
