### PR TITLE
Support edgeHub 1.1 routes.

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -755,6 +755,12 @@ def load_arguments(self, _):
             "deployment will merge with routes of the base deployment. Routes with the same name will be "
             "overwritten based on deployment priority.",
         )
+        context.argument(
+            "no_validation",
+            options_list=["--no-validation"],
+            arg_type=get_three_state_flag(),
+            help="Disables client side schema validation for edge deployment creation.",
+        )
 
     with self.argument_context("iot dps") as context:
         context.argument(

--- a/azext_iot/assets/edge-deploy-2.0.schema.json
+++ b/azext_iot/assets/edge-deploy-2.0.schema.json
@@ -33,7 +33,8 @@
                                 "schemaVersion": {
                                     "type": "string",
                                     "examples": [
-                                        "1.0"
+                                        "1.0",
+                                        "1.1"
                                     ]
                                 },
                                 "runtime": {
@@ -162,6 +163,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -209,6 +213,9 @@
                                                 },
                                                 "imagePullPolicy": {
                                                     "$ref": "#/definitions/imagePullPolicy"
+                                                },
+                                                "startupOrder": {
+                                                    "$ref": "#/definitions/startupOrder"
                                                 }
                                             },
                                             "patternProperties": {
@@ -249,18 +256,49 @@
                                 "schemaVersion": {
                                     "type": "string",
                                     "examples": [
-                                        "1.0"
+                                        "1.0",
+                                        "1.1"
                                     ]
                                 },
                                 "routes": {
                                     "type": "object",
                                     "patternProperties": {
                                         "^[^\\.\\$# ]+$": {
-                                            "type": "string",
-                                            "examples": [
-                                                "FROM /* INTO $upstream"
-                                            ],
-                                            "pattern": "^.+$"
+                                            "anyOf": [
+                                                {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "route"
+                                                    ],
+                                                    "properties": {
+                                                        "route": {
+                                                            "type": "string",
+                                                            "examples": [
+                                                                "FROM /* INTO $upstream"
+                                                            ],
+                                                            "pattern": "^.+$"
+                                                        },
+                                                        "priority": {
+                                                            "type": "integer",
+                                                            "minimum": 0,
+                                                            "maximum": 9
+                                                        },
+                                                        "timeToLiveSecs": {
+                                                            "type": "integer",
+                                                            "minimum": 0,
+                                                            "maximum": 4294967295
+                                                        }
+                                                    },
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "examples": [
+                                                        "FROM /* INTO $upstream"
+                                                    ],
+                                                    "pattern": "^.+$"
+                                                }
+                                            ]
                                         }
                                     },
                                     "additionalProperties": false
@@ -340,6 +378,11 @@
                 "never",
                 "on-create"
             ]
+        },
+        "startupOrder": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
         },
         "moduleSettings": {
             "type": "object",

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -929,10 +929,12 @@ def iot_edge_deployment_create(
     labels=None,
     metrics=None,
     layered=False,
+    no_validation=False,
     resource_group_name=None,
     login=None,
 ):
-    config_type = ConfigType.layered if layered else ConfigType.edge
+    # Short-term fix for --no-validation
+    config_type = ConfigType.layered if layered or no_validation else ConfigType.edge
     return _iot_hub_configuration_create(
         cmd=cmd,
         config_id=config_id,

--- a/azext_iot/tests/iothub/configurations/test_edge_deployment_v11.json
+++ b/azext_iot/tests/iothub/configurations/test_edge_deployment_v11.json
@@ -1,0 +1,91 @@
+{
+    "modulesContent": {
+        "$edgeAgent": {
+            "properties.desired": {
+                "schemaVersion": "1.1",
+                "runtime": {
+                    "type": "docker",
+                    "settings": {
+                        "minDockerVersion": "v1.25",
+                        "loggingOptions": "",
+                        "registryCredentials": {
+                            "ContosoRegistry": {
+                                "username": "myacr",
+                                "password": "<password>",
+                                "address": "myacr.azurecr.io"
+                            }
+                        }
+                    }
+                },
+                "systemModules": {
+                    "edgeAgent": {
+                        "type": "docker",
+                        "settings": {
+                            "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+                            "createOptions": ""
+                        }
+                    },
+                    "edgeHub": {
+                        "type": "docker",
+                        "status": "running",
+                        "restartPolicy": "always",
+                        "startupOrder": 0,
+                        "settings": {
+                            "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+                            "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}]}}}"
+                        }
+                    }
+                },
+                "modules": {
+                    "SimulatedTemperatureSensor": {
+                        "version": "1.0",
+                        "type": "docker",
+                        "status": "running",
+                        "restartPolicy": "always",
+                        "startupOrder": 2,
+                        "settings": {
+                            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
+                            "createOptions": "{}"
+                        }
+                    },
+                    "filtermodule": {
+                        "version": "1.0",
+                        "type": "docker",
+                        "status": "running",
+                        "restartPolicy": "always",
+                        "startupOrder": 1,
+                        "env": {
+                            "tempLimit": {
+                                "value": "100"
+                            }
+                        },
+                        "settings": {
+                            "image": "myacr.azurecr.io/filtermodule:latest",
+                            "createOptions": "{}"
+                        }
+                    }
+                }
+            }
+        },
+        "$edgeHub": {
+            "properties.desired": {
+                "schemaVersion": "1.1",
+                "routes": {
+                    "sensorToFilter": {
+                        "route": "FROM /messages/modules/SimulatedTemperatureSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/filtermodule/inputs/input1\")",
+                        "priority": 0,
+                        "timeToLiveSecs": 1800
+                    },
+                    "filterToIoTHub": {
+                        "route": "FROM /messages/modules/filtermodule/outputs/output1 INTO $upstream",
+                        "priority": 1,
+                        "timeToLiveSecs": 1800
+                    }
+                },
+                "storeAndForwardConfiguration": {
+                    "timeToLiveSecs": 100
+                }
+            }
+        }
+    }
+}

--- a/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
@@ -32,11 +32,12 @@ def sample_config_edge_malformed(set_cwd):
     return result
 
 
-@pytest.fixture(params=["file", "inlineA", "inlineB", "layered", "v1"])
+@pytest.fixture(params=["file", "inlineA", "inlineB", "layered", "v1", "v11"])
 def sample_config_edge(set_cwd, request):
     path = "test_edge_deployment.json"
     layered_path = "test_edge_deployment_layered.json"
     v1_path = "test_edge_deployment_v1.json"
+    v11_path = "test_edge_deployment_v11.json"
 
     payload = None
     if request.param == "inlineA":
@@ -49,6 +50,8 @@ def sample_config_edge(set_cwd, request):
         payload = json.dumps(json.loads(read_file_content(layered_path)))
     elif request.param == "v1":
         payload = json.dumps(json.loads(read_file_content(v1_path)))
+    elif request.param == "v11":
+        payload = json.dumps(json.loads(read_file_content(v11_path)))
 
     return (request.param, payload)
 
@@ -289,7 +292,7 @@ class TestConfigCreate:
         assert body.get("priority") == priority
         assert body.get("labels") == evaluate_literal(labels, dict)
 
-        if sample_config_edge[0] == "inlineB":
+        if sample_config_edge[0] == "inlineB" or sample_config_edge[0] == "v11":
             assert (
                 body["content"]["modulesContent"]
                 == json.loads(sample_config_edge[1])["modulesContent"]
@@ -792,7 +795,7 @@ class TestConfigApply:
             in url
         )
 
-        if sample_config_edge[0] == "inlineB":
+        if sample_config_edge[0] == "inlineB" or sample_config_edge[0] == "v11":
             assert (
                 body["modulesContent"]
                 == json.loads(sample_config_edge[1])["modulesContent"]


### PR DESCRIPTION
Updates json schema to support 1.1 routes. This is still in the mono schema direction. Moving foward the edgeHub / edgeAgent schemas have been split so the CLI needs to handle.

![image](https://user-images.githubusercontent.com/28658112/97224485-6d364480-178e-11eb-9211-ad020de0f7a1.png)
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
