### PR TITLE
Align SSL verification options with core for Central commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.10.8
++++++++++++++++
+**IoT Central fixes**
+* Align SSL certificate verification with core behavior
+
+
 0.10.7
 +++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 0.10.8
 +++++++++++++++
 **IoT Central fixes**
-* Align SSL certificate verification with core behavior
+* Align SSL certificate verification with core behavior. "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION" environment variable is now honored.
 
 
 0.10.7

--- a/azext_iot/central/providers/device_template_provider.py
+++ b/azext_iot/central/providers/device_template_provider.py
@@ -55,7 +55,7 @@ class CentralDeviceTemplateProvider:
         self, central_dns_suffix=CENTRAL_ENDPOINT,
     ):
         templates = central_services.device_template.list_device_templates(
-            cmd=self._cmd, app_id=self._app_id, token=self._token
+            cmd=self._cmd, app_id=self._app_id, token=self._token, central_dns_suffix=central_dns_suffix
         )
 
         self._device_templates.update({template.id: template for template in templates})

--- a/azext_iot/central/services/api_token.py
+++ b/azext_iot/central/services/api_token.py
@@ -18,6 +18,7 @@ BASE_PATH = "api/preview/apiTokens"
 http = requests.Session()
 http.verify = not should_disable_connection_verify()
 
+
 def add_api_token(
     cmd,
     app_id: str,

--- a/azext_iot/central/services/api_token.py
+++ b/azext_iot/central/services/api_token.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------------------
 
 
-from requests import Session
+import requests
 from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
 from azext_iot.central.services import _utility
@@ -15,8 +15,6 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/apiTokens"
-http = Session()
-http.verify = not should_disable_connection_verify()
 
 
 def add_api_token(
@@ -50,7 +48,7 @@ def add_api_token(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = http.put(url, headers=headers, json=payload)
+    response = requests.put(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -74,7 +72,7 @@ def get_api_token_list(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -99,7 +97,7 @@ def get_api_token(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -124,5 +122,5 @@ def delete_api_token(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/api_token.py
+++ b/azext_iot/central/services/api_token.py
@@ -10,11 +10,13 @@ from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
 from azext_iot.central.services import _utility
 from azext_iot.central.models.enum import Role
+from azure.cli.core.util import should_disable_connection_verify
 
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/apiTokens"
-
+http = requests.Session()
+http.verify = not should_disable_connection_verify()
 
 def add_api_token(
     cmd,
@@ -47,7 +49,7 @@ def add_api_token(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = requests.put(url, headers=headers, json=payload)
+    response = http.put(url, headers=headers, json=payload)
     return _utility.try_extract_result(response)
 
 
@@ -71,7 +73,7 @@ def get_api_token_list(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
     return _utility.try_extract_result(response)
 
 
@@ -96,7 +98,7 @@ def get_api_token(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
     return _utility.try_extract_result(response)
 
 
@@ -121,5 +123,5 @@ def delete_api_token(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.delete(url, headers=headers)
+    response = http.delete(url, headers=headers)
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/api_token.py
+++ b/azext_iot/central/services/api_token.py
@@ -4,8 +4,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import requests
 
+from requests import Session
 from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
 from azext_iot.central.services import _utility
@@ -15,7 +15,7 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/apiTokens"
-http = requests.Session()
+http = Session()
 http.verify = not should_disable_connection_verify()
 
 

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------------------
 # This is largely derived from https://docs.microsoft.com/en-us/rest/api/iotcentral/devices
 
-import requests
+from requests import Session
 
 from knack.util import CLIError
 from knack.log import get_logger
@@ -21,7 +21,7 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/devices"
-http = requests.Session()
+http = Session()
 http.verify = not should_disable_connection_verify()
 
 

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------------------
 # This is largely derived from https://docs.microsoft.com/en-us/rest/api/iotcentral/devices
 
-from requests import Session
+import requests
 
 from knack.util import CLIError
 from knack.log import get_logger
@@ -21,8 +21,6 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/devices"
-http = Session()
-http.verify = not should_disable_connection_verify()
 
 
 def get_device(
@@ -46,7 +44,7 @@ def get_device(
     url = "https://{}.{}/{}/{}".format(app_id, central_dns_suffix, BASE_PATH, device_id)
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     result = _utility.try_extract_result(response)
     return Device(result)
 
@@ -75,7 +73,7 @@ def list_devices(
 
     pages_processed = 0
     while (pages_processed <= max_pages) and url:
-        response = http.get(url, headers=headers)
+        response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
         result = _utility.try_extract_result(response)
 
         if "value" not in result:
@@ -114,7 +112,7 @@ def get_device_registration_summary(
         "This command may take a long time to complete if your app contains a lot of devices"
     )
     while url:
-        response = http.get(url, headers=headers)
+        response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
         result = _utility.try_extract_result(response)
 
         if "value" not in result:
@@ -170,7 +168,7 @@ def create_device(
     if instance_of:
         payload["instanceOf"] = instance_of
 
-    response = http.put(url, headers=headers, json=payload)
+    response = requests.put(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
     result = _utility.try_extract_result(response)
     return Device(result)
 
@@ -196,7 +194,7 @@ def delete_device(
     url = "https://{}.{}/{}/{}".format(app_id, central_dns_suffix, BASE_PATH, device_id)
     headers = _utility.get_headers(token, cmd)
 
-    response = http.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -222,7 +220,7 @@ def get_device_credentials(
     )
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -258,7 +256,7 @@ def run_component_command(
     )
     headers = _utility.get_headers(token, cmd)
 
-    response = http.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
 
     # execute command response has caveats in it due to Async/Sync device methods
     # return the response if we get 201, otherwise try to apply generic logic
@@ -298,5 +296,5 @@ def get_component_command_history(
     )
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -24,6 +24,7 @@ BASE_PATH = "api/preview/devices"
 http = requests.Session()
 http.verify = not should_disable_connection_verify()
 
+
 def get_device(
     cmd, app_id: str, device_id: str, token: str, central_dns_suffix=CENTRAL_ENDPOINT,
 ) -> Device:

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -14,11 +14,14 @@ from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
 from azext_iot.central.services import _utility
 from azext_iot.central.models.template import Template
+from azure.cli.core.util import should_disable_connection_verify
+
 
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/deviceTemplates"
-
+http = requests.Session()
+http.verify = not should_disable_connection_verify()
 
 def get_device_template(
     cmd,
@@ -45,7 +48,6 @@ def get_device_template(
         app_id, central_dns_suffix, BASE_PATH, device_template_id
     )
     headers = _utility.get_headers(token, cmd)
-
     response = requests.get(url, headers=headers)
     return Template(_utility.try_extract_result(response))
 
@@ -70,7 +72,7 @@ def list_device_templates(
     url = "https://{}.{}/{}".format(app_id, central_dns_suffix, BASE_PATH)
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
 
     result = _utility.try_extract_result(response)
 
@@ -112,7 +114,7 @@ def create_device_template(
     )
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = requests.put(url, headers=headers, json=payload)
+    response = http.put(url, headers=headers, json=payload)
     return Template(_utility.try_extract_result(response))
 
 
@@ -142,5 +144,5 @@ def delete_device_template(
     )
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.delete(url, headers=headers)
+    response = http.delete(url, headers=headers)
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -6,7 +6,7 @@
 # This is largely derived from https://docs.microsoft.com/en-us/rest/api/iotcentral/devicetemplates
 
 from typing import List
-from requests import Session
+import requests
 
 from knack.util import CLIError
 from knack.log import get_logger
@@ -19,8 +19,6 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/deviceTemplates"
-http = Session()
-http.verify = not should_disable_connection_verify()
 
 
 def get_device_template(
@@ -48,7 +46,7 @@ def get_device_template(
         app_id, central_dns_suffix, BASE_PATH, device_template_id
     )
     headers = _utility.get_headers(token, cmd)
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return Template(_utility.try_extract_result(response))
 
 
@@ -72,7 +70,7 @@ def list_device_templates(
     url = "https://{}.{}/{}".format(app_id, central_dns_suffix, BASE_PATH)
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
 
     result = _utility.try_extract_result(response)
 
@@ -114,7 +112,7 @@ def create_device_template(
     )
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = http.put(url, headers=headers, json=payload)
+    response = requests.put(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
     return Template(_utility.try_extract_result(response))
 
 
@@ -144,5 +142,5 @@ def delete_device_template(
     )
     headers = _utility.get_headers(token, cmd)
 
-    response = http.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -23,6 +23,7 @@ BASE_PATH = "api/preview/deviceTemplates"
 http = requests.Session()
 http.verify = not should_disable_connection_verify()
 
+
 def get_device_template(
     cmd,
     app_id: str,

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -5,9 +5,8 @@
 # --------------------------------------------------------------------------------------------
 # This is largely derived from https://docs.microsoft.com/en-us/rest/api/iotcentral/devicetemplates
 
-import requests
-
 from typing import List
+from requests import Session
 
 from knack.util import CLIError
 from knack.log import get_logger
@@ -20,7 +19,7 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/deviceTemplates"
-http = requests.Session()
+http = Session()
 http.verify = not should_disable_connection_verify()
 
 
@@ -49,7 +48,7 @@ def get_device_template(
         app_id, central_dns_suffix, BASE_PATH, device_template_id
     )
     headers = _utility.get_headers(token, cmd)
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
     return Template(_utility.try_extract_result(response))
 
 

--- a/azext_iot/central/services/user.py
+++ b/azext_iot/central/services/user.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from requests import Session
+import requests
 
 from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
@@ -15,8 +15,6 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/users"
-http = Session()
-http.verify = not should_disable_connection_verify()
 
 
 def add_service_principal(
@@ -55,7 +53,7 @@ def add_service_principal(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = http.put(url, headers=headers, json=payload)
+    response = requests.put(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -92,7 +90,7 @@ def add_email(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = http.put(url, headers=headers, json=payload)
+    response = requests.put(url, headers=headers, json=payload, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -116,7 +114,7 @@ def get_user_list(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -141,7 +139,7 @@ def get_user(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)
 
 
@@ -166,5 +164,5 @@ def delete_user(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = http.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, verify=not should_disable_connection_verify())
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/user.py
+++ b/azext_iot/central/services/user.py
@@ -10,11 +10,13 @@ from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
 from azext_iot.central.services import _utility
 from azext_iot.central.models.enum import Role, UserType
+from azure.cli.core.util import should_disable_connection_verify
 
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/users"
-
+http = requests.Session()
+http.verify = not should_disable_connection_verify()
 
 def add_service_principal(
     cmd,
@@ -52,7 +54,7 @@ def add_service_principal(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = requests.put(url, headers=headers, json=payload)
+    response = http.put(url, headers=headers, json=payload)
     return _utility.try_extract_result(response)
 
 
@@ -89,7 +91,7 @@ def add_email(
 
     headers = _utility.get_headers(token, cmd, has_json_payload=True)
 
-    response = requests.put(url, headers=headers, json=payload)
+    response = http.put(url, headers=headers, json=payload)
     return _utility.try_extract_result(response)
 
 
@@ -113,7 +115,7 @@ def get_user_list(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
     return _utility.try_extract_result(response)
 
 
@@ -138,7 +140,7 @@ def get_user(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.get(url, headers=headers)
+    response = http.get(url, headers=headers)
     return _utility.try_extract_result(response)
 
 
@@ -163,5 +165,5 @@ def delete_user(
 
     headers = _utility.get_headers(token, cmd)
 
-    response = requests.delete(url, headers=headers)
+    response = http.delete(url, headers=headers)
     return _utility.try_extract_result(response)

--- a/azext_iot/central/services/user.py
+++ b/azext_iot/central/services/user.py
@@ -18,6 +18,7 @@ BASE_PATH = "api/preview/users"
 http = requests.Session()
 http.verify = not should_disable_connection_verify()
 
+
 def add_service_principal(
     cmd,
     app_id: str,

--- a/azext_iot/central/services/user.py
+++ b/azext_iot/central/services/user.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import requests
+from requests import Session
 
 from knack.log import get_logger
 from azext_iot.constants import CENTRAL_ENDPOINT
@@ -15,7 +15,7 @@ from azure.cli.core.util import should_disable_connection_verify
 logger = get_logger(__name__)
 
 BASE_PATH = "api/preview/users"
-http = requests.Session()
+http = Session()
 http.verify = not should_disable_connection_verify()
 
 

--- a/azext_iot/common/_azure.py
+++ b/azext_iot/common/_azure.py
@@ -123,7 +123,6 @@ def get_iot_central_tokens(cmd, app_id, token, central_dns_suffix):
     from requests import post
     from azure.cli.core.util import should_disable_connection_verify
 
-
     if not token:
         aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
             "accessToken"
@@ -133,7 +132,7 @@ def get_iot_central_tokens(cmd, app_id, token, central_dns_suffix):
     url = "https://{}.{}/system/iothubs/generateSasTokens".format(
         app_id, central_dns_suffix
     )
-    response = post(url, headers={"Authorization": token}, verify = not should_disable_connection_verify())
+    response = post(url, headers={"Authorization": token}, verify=not should_disable_connection_verify())
     tokens = response.json()
 
     additional_help = (

--- a/azext_iot/common/_azure.py
+++ b/azext_iot/common/_azure.py
@@ -120,7 +120,9 @@ def get_iot_dps_connection_string(
 
 
 def get_iot_central_tokens(cmd, app_id, token, central_dns_suffix):
-    import requests
+    from requests import post
+    from azure.cli.core.util import should_disable_connection_verify
+
 
     if not token:
         aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
@@ -131,7 +133,7 @@ def get_iot_central_tokens(cmd, app_id, token, central_dns_suffix):
     url = "https://{}.{}/system/iothubs/generateSasTokens".format(
         app_id, central_dns_suffix
     )
-    response = requests.post(url, headers={"Authorization": token})
+    response = post(url, headers={"Authorization": token}, verify = not should_disable_connection_verify())
     tokens = response.json()
 
     additional_help = (

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.10.7"
+VERSION = "0.10.8"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"


### PR DESCRIPTION
IoT Central commands don't follow CLI core settings for SSL certificate validation

- Added code to handle "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION" environment variable
- Use of "Session" for request module to share options between requests

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [x] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
