### PR TITLE
Fix credscan CI config

### DIFF
--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -123,8 +123,30 @@ jobs:
   - template: templates/install-configure-azure-cli.yml
 
 - job: CredScan
-  displayName: "Credential Scan"
+  displayName: 'Credential Scan'
+  pool:
+    vmImage: 'vs2017-win2016'
+
   steps:
   - task: CredScan@3
     inputs:
+      outputFormat: 'pre'
       scanFolder: '$(Build.SourcesDirectory)'
+      suppressionsFile: '$(Build.SourcesDirectory)/CredScanSuppressions.json'
+
+  - task: PostAnalysis@1
+    inputs:
+      AllTools: false
+      APIScan: false
+      BinSkim: false
+      CodesignValidation: false
+      CredScan: true
+      FortifySCA: false
+      FxCop: false
+      ModernCop: false
+      PoliCheck: false
+      RoslynAnalyzers: false
+      SDLNativeRules: false
+      Semmle: false
+      TSLint: false
+      ToolLogsNotFoundAction: 'Standard'

--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -1,0 +1,37 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": "azext_iot\\operations\\_mqtt.py",
+            "placeholder": "password=sas",
+            "_justification": "Client device simulation requires a SAS key extracted from IoT Hub to be passed in MQTT lib."
+        },
+        {
+            "file": "azext_iot\\tests\\iothub\\test_iothub_discovery_unit.py",
+            "placeholder": "SharedAccessKey=AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj=",
+            "_justification": "Completely made up IoT Hub policy key for unit test."
+        },
+        {
+            "file": "azext_iot\\tests\\iothub\\configurations\\test_edge_deployment.json",
+            "_justification": "Completely made up deployment with fake container registry creds."
+        },
+        {
+            "file": "azext_iot\\tests\\conftest.py",
+            "_justification": "Completely made up keys for unit tests."
+        },
+        {
+            "file": "azext_iot\\tests\\test_iot_dps_int.py",
+            "placeholder": "cT/EXZvsplPEpT//p98Pc6sKh8mY3kYgSxavHwMkl7w=",
+            "_justification": "Ensure made up endorsement key evaluates to the expected device key."
+        },
+        {
+            "file": "azext_iot\\tests\\test_iot_dps_unit.py",
+            "_justification": "Completely made up keys for unit tests."
+        },
+        {
+            "file": "azext_iot\\tests\\test_iot_ext_unit.py",
+            "placeholder": "+XLy+MVZ+aTeOnVzN2kLeB16O+kSxmz6g3rS6fAf6rw=",
+            "_justification": "Ensure made up policy key generates the proper SAS token."
+        }
+    ]
+}

--- a/azext_iot/tests/test_iot_dps_int.py
+++ b/azext_iot/tests/test_iot_dps_int.py
@@ -9,6 +9,7 @@ from azure.cli.testsdk import LiveScenarioTest
 from azext_iot.common.shared import EntityStatusType, AttestationType, AllocationType
 from azext_iot.common.certops import create_self_signed_certificate
 from azext_iot.common import embedded_cli
+from azext_iot.common.utility import generate_key
 from azext_iot.iothub.providers.discovery import IotHubDiscovery
 from .settings import Setting
 
@@ -300,8 +301,8 @@ class TestDPSEnrollments(LiveScenarioTest):
         enrollment_id = self.create_random_name("enrollment-for-test", length=48)
         enrollment_id2 = self.create_random_name("enrollment-for-test", length=48)
         attestation_type = AttestationType.symmetricKey.value
-        primary_key = "x3XNu1HeSw93rmtDXduRUZjhqdGbcqR/zloWYiyPUzw="
-        secondary_key = "PahMnOSBblv9CRn5B765iK35jTvnjDUjYP9hKBZa4Ug="
+        primary_key = generate_key()
+        secondary_key = generate_key()
         device_id = self.create_random_name("device-id-for-test", length=48)
         reprovisionPolicy_reprovisionandresetdata = "reprovisionandresetdata"
         hub_host_name = "{}.azure-devices.net".format(hub)


### PR DESCRIPTION
- The CredScan CI task was not booting up correctly. This PR resolves the configuration issues, ensures CredScan evaluates correctly, and ensures the Pipeline gets interrupted via PostAnalysis.
- PostAnalysis will clearly show findings.
- This PR also introduces CredScan suppressions in the form of an additional JSON file.
  - Fortunately all the CredScan findings (except one) were around fake/made up keys for tests.
    - The one non-test finding was around paho mqtt attribute language `password=` in the operations/_mqtt.py module.
    - As a client tool, in order to simulate a device, we must retrieve and use a SAS key.


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
