### PR TITLE
1797650: Remove '?view=azure-cli-latest' syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The resolution is to remove the deprecated `azure-cli-iot-ext` and install any v
 
 ## Commands
 
-Please refer to the official `az iot` reference on [Microsoft Docs](https://docs.microsoft.com/en-us/cli/azure/ext/azure-iot/iot?view=azure-cli-latest) for a complete list of supported commands.  You can also find IoT CLI usage tips on the [wiki](https://github.com/Azure/azure-iot-cli-extension/wiki/Tips).
+Please refer to the official `az iot` reference on [Microsoft Docs](https://docs.microsoft.com/en-us/cli/azure/ext/azure-iot/iot) for a complete list of supported commands.  You can also find IoT CLI usage tips on the [wiki](https://github.com/Azure/azure-iot-cli-extension/wiki/Tips).
 
 ## Installation
 

--- a/docs/install-help.md
+++ b/docs/install-help.md
@@ -23,7 +23,7 @@ After installing Azure CLI in my supported Linux environment, I try to install t
 
 Make sure you install the right distribution of Azure CLI that is compatible with your platform.
 
-For example using the recommended installation path of [Linux via apt](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest), validate that your `/etc/apt/sources.list.d/azure-cli.list` file has the proper distribution identifier.
+For example using the recommended installation path of [Linux via apt](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt), validate that your `/etc/apt/sources.list.d/azure-cli.list` file has the proper distribution identifier.
 
 On an Ubuntu 16.04 environment provided with the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) the sources list file should have an entry tagged with 'xenial':
 


### PR DESCRIPTION
No code changes. Part of an effort to remove unnecessary versioning link syntax.

See user story [1797650](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1797650) for more information.