### PR TITLE
Fix for device-identity update ignoring key/thumbprint values

### DIFF
--- a/azext_iot/tests/iothub/test_iot_ext_unit.py
+++ b/azext_iot/tests/iothub/test_iot_ext_unit.py
@@ -520,6 +520,20 @@ class TestDeviceUpdate:
                 ),
             ),
             (generate_device_show(), device_update_con_arg(auth_method="x509_ca",)),
+            (generate_device_show(), device_update_con_arg(primary_key="secondary_key", secondary_key="primary_key")),
+            (
+                generate_device_show(
+                    authentication={
+                        "type": "selfSigned",
+                        "symmetricKey": {"primaryKey": None, "secondaryKey": None},
+                        "x509Thumbprint": {
+                            "primaryThumbprint": "123",
+                            "secondaryThumbprint": "321",
+                        },
+                    }
+                ),
+                device_update_con_arg(primary_thumbprint="321", secondary_thumbprint="123")
+            )
         ],
     )
     def test_iot_device_custom(self, fixture_cmd, serviceclient, req, arg):
@@ -583,6 +597,25 @@ class TestDeviceUpdate:
                 device_update_con_arg(auth_method="Unknown",),
                 ValueError,
             ),
+            (
+                generate_device_show(),
+                device_update_con_arg(primary_thumbprint="newThumbprint",),
+                ValueError,
+            ),
+            (
+                generate_device_show(
+                    authentication={
+                        "type": "selfSigned",
+                        "symmetricKey": {"primaryKey": None, "secondaryKey": None},
+                        "x509Thumbprint": {
+                            "primaryThumbprint": "123",
+                            "secondaryThumbprint": "321",
+                        },
+                    }
+                ),
+                device_update_con_arg(primary_key='updated_key'),
+                ValueError
+            )
         ],
     )
     def test_iot_device_custom_invalid_args(self, serviceclient, req, arg, exp):


### PR DESCRIPTION
Adds a clause to `device-identity update` that allows user to update `primary-key` / `secondary-key` and `primary-thumbprint` / `secondary-thumbprint` values (respectively, per auth method) without needing to specify the `auth_method` in the update command.

Updated unit tests to verify.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
