### PR TITLE
Extend generate-sas-token to take a device connection string

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -97,6 +97,12 @@ def load_arguments(self, _):
             "module_id", options_list=["--module-id", "-m"], help="Target Module."
         )
         context.argument(
+            "device_connection_string", 
+            options_list=["--device-connection-string", "--dcs"], 
+            help="Target device connection string."
+            "This bypasses the IoT Hub registry and generates the SAS token directly from the supplied symmetric key without further validation."
+        )
+        context.argument(
             "key_type",
             options_list=["--key-type", "--kt"],
             arg_type=get_enum_type(KeyType),

--- a/azext_iot/_validators.py
+++ b/azext_iot/_validators.py
@@ -17,12 +17,14 @@ def mode2_iot_login_handler(cmd, namespace):
             iot_cmd_type = None
             entity_value = None
 
-            if 'hub_name' in args:
+            if 'device_connection_string' in args:
+                entity_value = 'NA'
+            elif 'hub_name' in args:
                 iot_cmd_type = 'IoT Hub'
                 entity_value = args['hub_name']
             elif 'dps_name' in args:
                 iot_cmd_type = 'DPS'
-                entity_value = args['dps_name']
+                entity_value = args['dps_name']            
 
             if not any([login_value, entity_value]):
                 raise CLIError(error_no_hub_or_login_on_input(iot_cmd_type))


### PR DESCRIPTION
New feature: generate a SAS token based on only device connection string.

This extends the az iot cli to provide the functionality we already have in VS Code and as basic scripts in samples. We can directly generate a SAS token based only on the supplied device connection string without a requirement for any IoT Hub authentication. This is particularly useful for customers wanting to connect devices directly over MQTT to IoT Central since in this case you are not able to get an IoT Hub connection string.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
