### PR TITLE
Add missing IoT Central list commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+0.10.16
++++++++++++++++
+
+**IoT Central updates**
+
+* Adds support for listing devices
+* Adds support for listing device templates
+
 0.10.15
 +++++++++++++++
 

--- a/azext_iot/central/_help.py
+++ b/azext_iot/central/_help.py
@@ -52,6 +52,18 @@ def _load_central_devices_help():
     """
 
     helps[
+        "iot central device list"
+    ] = """
+        type: command
+        short-summary: List devices in IoT Central.
+        examples:
+        - name: List all devices in an application, sorted by device Id (default)
+          text: >
+            az iot central device list
+            --app-id {appid}
+    """
+
+    helps[
         "iot central device create"
     ] = """
         type: command

--- a/azext_iot/central/_help.py
+++ b/azext_iot/central/_help.py
@@ -391,6 +391,18 @@ def _load_central_device_templates_help():
     """
 
     helps[
+        "iot central device-template list"
+    ] = """
+        type: command
+        short-summary: List device templates in IoT Central.
+        examples:
+        - name: List all device templates in an application, sorted by template Id (default)
+          text: >
+            az iot central device-template list
+            --app-id {appid}
+    """
+
+    helps[
         "iot central device-template create"
     ] = """
         type: command

--- a/azext_iot/central/command_map.py
+++ b/azext_iot/central/command_map.py
@@ -86,7 +86,7 @@ def load_central_commands(self, _):
     with self.command_group(
         "iot central device", command_type=central_device_ops,
     ) as cmd_group:
-        # cmd_group.command("list", "list_devices")
+        cmd_group.command("list", "list_devices")
         cmd_group.show_command("show", "get_device")
         cmd_group.command("create", "create_device")
         cmd_group.command("delete", "delete_device")
@@ -105,7 +105,7 @@ def load_central_commands(self, _):
     with self.command_group(
         "iot central device-template", command_type=central_device_templates_ops,
     ) as cmd_group:
-        # cmd_group.command("list", "list_device_templates")
+        cmd_group.command("list", "list_device_templates")
         # cmd_group.command("map", "map_device_templates")
         cmd_group.show_command("show", "get_device_template")
         cmd_group.command("create", "create_device_template")

--- a/azext_iot/central/commands_device_template.py
+++ b/azext_iot/central/commands_device_template.py
@@ -50,7 +50,7 @@ def list_device_templates(
         provider = CentralDeviceTemplateProviderV1(cmd=cmd, app_id=app_id, token=token)
 
     templates = provider.list_device_templates(central_dns_suffix=central_dns_suffix)
-    return {template.id: template.raw_template for template in templates.values()}
+    return templates
 
 
 def map_device_templates(

--- a/azext_iot/central/models/templatepreview.py
+++ b/azext_iot/central/models/templatepreview.py
@@ -85,7 +85,7 @@ class TemplatePreview:
                 interfaces.extend(dcm.get("implements"))
 
             return {
-                (interface["schema"]["@id"] if interface.get("@type") else interface["@id"]): self._extract_schemas(interface)
+                self._get_interface_id(interface): self._extract_schemas(interface)
                 for interface in interfaces
             }
         except:
@@ -113,3 +113,6 @@ class TemplatePreview:
             for interface, schema in self.schema_names.items()
             if property_name in schema
         ]
+
+    def _get_interface_id(self, interface) -> list:
+        return interface["schema"]["@id"] if interface.get("@type") else interface["@id"]

--- a/azext_iot/central/models/templatepreview.py
+++ b/azext_iot/central/models/templatepreview.py
@@ -11,7 +11,7 @@ class TemplatePreview:
     def __init__(self, template: dict):
         self.raw_template = template
         try:
-            self.id = template.get("id")
+            self.id = template.get("@id")
             self.name = template.get("displayName")
             self.interfaces = self._extract_interfaces(template)
             self.schema_names = self._extract_schema_names(self.interfaces)

--- a/azext_iot/central/models/templatepreview.py
+++ b/azext_iot/central/models/templatepreview.py
@@ -11,7 +11,7 @@ class TemplatePreview:
     def __init__(self, template: dict):
         self.raw_template = template
         try:
-            self.id = template.get("@id")
+            self.id = template.get("id")
             self.name = template.get("displayName")
             self.interfaces = self._extract_interfaces(template)
             self.schema_names = self._extract_schema_names(self.interfaces)
@@ -20,7 +20,7 @@ class TemplatePreview:
                 self.component_schema_names = self._extract_schema_names(
                     self.components
                 )
-
+        
         except:
             raise CLIError("Could not parse iot central device template.")
 
@@ -77,7 +77,7 @@ class TemplatePreview:
 
             interfaces = []
             dcm = template.get("capabilityModel", {})
-
+            
             if dcm.get("contents"):
                 interfaces.append(self._extract_root_interface_contents(dcm))
 
@@ -85,10 +85,10 @@ class TemplatePreview:
                 interfaces.extend(dcm.get("implements"))
 
             return {
-                interface["@id"]: self._extract_schemas(interface)
+                (interface["schema"]["@id"] if interface.get("@type") else interface["@id"]): self._extract_schemas(interface)
                 for interface in interfaces
             }
-        except Exception:
+        except:
             details = "Unable to extract device schema from template '{}'.".format(
                 self.id
             )
@@ -97,6 +97,8 @@ class TemplatePreview:
     def _extract_schemas(self, entity: dict) -> dict:
         if entity.get("schema"):
             return {schema["name"]: schema for schema in entity["schema"]["contents"]}
+        else:
+            return {schema["name"]: schema for schema in entity["contents"]}
 
     def _extract_schema_names(self, entity: dict) -> dict:
         return {

--- a/azext_iot/central/models/templatepreview.py
+++ b/azext_iot/central/models/templatepreview.py
@@ -20,7 +20,7 @@ class TemplatePreview:
                 self.component_schema_names = self._extract_schema_names(
                     self.components
                 )
-        
+
         except:
             raise CLIError("Could not parse iot central device template.")
 
@@ -77,7 +77,7 @@ class TemplatePreview:
 
             interfaces = []
             dcm = template.get("capabilityModel", {})
-            
+
             if dcm.get("contents"):
                 interfaces.append(self._extract_root_interface_contents(dcm))
 

--- a/azext_iot/central/models/templatev1.py
+++ b/azext_iot/central/models/templatev1.py
@@ -12,7 +12,7 @@ class TemplateV1:
     def __init__(self, template: dict):
         self.raw_template = template
         try:
-            self.id = template.get("id")
+            self.id = template.get("@id")
             self.name = template.get("displayName")
             self.interfaces = self._extract_interfaces(template)
             self.schema_names = self._extract_schema_names(self.interfaces)

--- a/azext_iot/central/params.py
+++ b/azext_iot/central/params.py
@@ -92,7 +92,8 @@ def load_central_arguments(self, _):
         context.argument(
             "device_template_id",
             options_list=["--device-template-id", "--dtid"],
-            help="Unique ID for the Device template.",
+            help="Digital Twin Model Identifier of the device template."
+            " Learn more at https://aka.ms/iotcentraldtmi.",
         )
 
     with self.argument_context("iot central api-token") as context:

--- a/azext_iot/central/providers/preview/device_template_provider_preview.py
+++ b/azext_iot/central/providers/preview/device_template_provider_preview.py
@@ -66,7 +66,7 @@ class CentralDeviceTemplateProviderPreview:
             api_version=ApiVersion.preview.value,
         )
 
-        self._device_templates.update({template.id: template for template in templates})
+        self._device_templates.update({template.id: template.raw_template for template in templates})
 
         return self._device_templates
 

--- a/azext_iot/central/providers/v1/device_template_provider_v1.py
+++ b/azext_iot/central/providers/v1/device_template_provider_v1.py
@@ -64,8 +64,7 @@ class CentralDeviceTemplateProviderV1:
             api_version=ApiVersion.v1.value,
         )
 
-        self._device_templates.update({template.id: template for template in templates})
-
+        self._device_templates.update({template.id: template.raw_template for template in templates})
         return self._device_templates
 
     def map_device_templates(

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -102,7 +102,7 @@ def list_devices(
     )
 
     pages_processed = 0
-    while (max_pages == 0 or pages_processed <= max_pages) and url:
+    while (max_pages == 0 or pages_processed < max_pages) and url:
         response = requests.get(url, headers=headers, params=query_parameters if pages_processed == 0 else None)
         result = _utility.try_extract_result(response)
 
@@ -110,13 +110,13 @@ def list_devices(
             raise CLIError("Value is not present in body: {}".format(result))
 
         if api_version == ApiVersion.preview.value:
-            devices = devices + [
+            devices.extend([
                 central_models.DevicePreview(device) for device in result["value"]
-            ]
+            ])
         else:
-            devices = devices + [
+            devices.extend([
                 central_models.DeviceV1(device) for device in result["value"]
-            ]
+            ])
 
         url = result.get("nextLink", None)
         pages_processed = pages_processed + 1

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -70,7 +70,7 @@ def list_devices(
     cmd,
     app_id: str,
     token: str,
-    max_pages=1,
+    max_pages=0,
     central_dns_suffix=CENTRAL_ENDPOINT,
     api_version=ApiVersion.v1.value,
 ) -> List[Union[central_models.DevicePreview, central_models.DeviceV1]]:
@@ -97,9 +97,13 @@ def list_devices(
     query_parameters = {}
     query_parameters["api-version"] = api_version
 
+    logger.warning(
+        "This command may take a long time to complete if your app contains a lot of devices"
+    )
+
     pages_processed = 0
-    while (pages_processed <= max_pages) and url:
-        response = requests.get(url, headers=headers, params=query_parameters)
+    while (max_pages == 0 or pages_processed <= max_pages) and url:
+        response = requests.get(url, headers=headers, params=query_parameters if pages_processed == 0 else None)
         result = _utility.try_extract_result(response)
 
         if "value" not in result:
@@ -114,7 +118,7 @@ def list_devices(
                 central_models.DeviceV1(device) for device in result["value"]
             ]
 
-        url = result.get("nextLink", params=query_parameters)
+        url = result.get("nextLink", None)
         pages_processed = pages_processed + 1
 
     return devices

--- a/azext_iot/central/services/device_group.py
+++ b/azext_iot/central/services/device_group.py
@@ -25,7 +25,7 @@ def list_device_groups(
     cmd,
     app_id: str,
     token: str,
-    max_pages=1,
+    max_pages=0,
     central_dns_suffix=CENTRAL_ENDPOINT,
     api_version=ApiVersion.preview.value,
 ) -> List[central_models.DeviceGroupPreview]:
@@ -53,21 +53,18 @@ def list_device_groups(
     query_parameters["api-version"] = api_version
 
     pages_processed = 0
-    while (pages_processed <= max_pages) and url:
+    while (max_pages == 0 or pages_processed < max_pages) and url:
         response = requests.get(url, headers=headers, params=query_parameters)
         result = _utility.try_extract_result(response)
 
         if "value" not in result:
             raise CLIError("Value is not present in body: {}".format(result))
 
-        device_groups = device_groups + [
+        device_groups.extend([
             central_models.DeviceGroupPreview(device_group) for device_group in result["value"]
-        ]
+        ])
 
-        try:
-            url = result.get("nextLink", params=query_parameters)
-        except:
-            pass
+        url = result.get("nextLink", None)
         pages_processed = pages_processed + 1
 
     return device_groups

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -96,7 +96,7 @@ def list_device_templates(
     )
 
     pages_processed = 0
-    while (max_pages == 0 or pages_processed <= max_pages) and url:
+    while (max_pages == 0 or pages_processed < max_pages) and url:
         response = requests.get(url, headers=headers, params=query_parameters if pages_processed == 0 else None)
         result = _utility.try_extract_result(response)
 

--- a/azext_iot/central/services/device_template.py
+++ b/azext_iot/central/services/device_template.py
@@ -64,6 +64,7 @@ def list_device_templates(
     cmd,
     app_id: str,
     token: str,
+    max_pages=0,
     central_dns_suffix=CENTRAL_ENDPOINT,
     api_version=ApiVersion.v1.value,
 ) -> List[Union[central_models.TemplatePreview, central_models.TemplateV1]]:
@@ -78,8 +79,10 @@ def list_device_templates(
         central_dns_suffix: {centralDnsSuffixInPath} as found in docs
 
     Returns:
-        device: dict
+        device_templates: dict
     """
+
+    device_templates = []
 
     url = "https://{}.{}/{}".format(app_id, central_dns_suffix, BASE_PATH)
     headers = _utility.get_headers(token, cmd)
@@ -88,17 +91,31 @@ def list_device_templates(
     query_parameters = {}
     query_parameters["api-version"] = api_version
 
-    response = requests.get(url, headers=headers, params=query_parameters)
+    logger.warning(
+        "This command may take a long time to complete if your app contains a lot of device templates"
+    )
 
-    result = _utility.try_extract_result(response)
+    pages_processed = 0
+    while (max_pages == 0 or pages_processed <= max_pages) and url:
+        response = requests.get(url, headers=headers, params=query_parameters if pages_processed == 0 else None)
+        result = _utility.try_extract_result(response)
 
-    if "value" not in result:
-        raise CLIError("Value is not present in body: {}".format(result))
+        if "value" not in result:
+            raise CLIError("Value is not present in body: {}".format(result))
 
-    if api_version == ApiVersion.preview.value:
-        return [central_models.TemplatePreview(item) for item in result["value"]]
-    else:
-        return [central_models.TemplateV1(item) for item in result["value"]]
+        if api_version == ApiVersion.preview.value:
+            device_templates = device_templates + [
+                central_models.TemplatePreview(device_template) for device_template in result["value"]
+            ]
+        else:
+            device_templates = device_templates + [
+                central_models.TemplateV1(device_template) for device_template in result["value"]
+            ]
+
+        url = result.get("nextLink", None)
+        pages_processed = pages_processed + 1
+
+    return device_templates
 
 
 def create_device_template(

--- a/azext_iot/central/services/role.py
+++ b/azext_iot/central/services/role.py
@@ -68,7 +68,7 @@ def list_roles(
     cmd,
     app_id: str,
     token: str,
-    max_pages=1,
+    max_pages=0,
     central_dns_suffix=CENTRAL_ENDPOINT,
     api_version=ApiVersion.preview.value,
 ) -> List[central_models.RolePreview]:
@@ -96,7 +96,7 @@ def list_roles(
     query_parameters["api-version"] = api_version
 
     pages_processed = 0
-    while (pages_processed <= max_pages) and url:
+    while (max_pages == 0 or pages_processed < max_pages) and url:
         response = requests.get(
             url,
             headers=headers,
@@ -108,14 +108,11 @@ def list_roles(
         if "value" not in result:
             raise CLIError("Value is not present in body: {}".format(result))
 
-        roles = roles + [
+        roles.extend([
             central_models.RolePreview(role) for role in result["value"]
-        ]
+        ])
 
-        try:
-            url = result.get("nextLink", params=query_parameters)
-        except:
-            pass
+        url = result.get("nextLink", None)
         pages_processed = pages_processed + 1
 
     return roles

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.10.15"
+VERSION = "0.10.16"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/tests/central/test_iot_central_int.py
+++ b/azext_iot/tests/central/test_iot_central_int.py
@@ -265,6 +265,12 @@ class TestIotCentral(CaptureOutputLiveScenarioTest):
 
     def test_central_device_methods_CRD(self):
 
+        # list devices and get count
+        start_device_list = self.cmd(
+            "iot central device list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        start_dev_count = len(start_device_list)
         (device_id, device_name) = self._create_device()
 
         self.cmd(
@@ -277,7 +283,22 @@ class TestIotCentral(CaptureOutputLiveScenarioTest):
             ],
         )
 
+        created_device_list = self.cmd(
+            "iot central device list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        created_dev_count = len(created_device_list)
+        assert created_dev_count == (start_dev_count + 1)
+        assert device_id in created_device_list.keys()
         self._delete_device(device_id)
+
+        deleted_device_list = self.cmd(
+            "iot central device list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        deleted_dev_count = len(deleted_device_list)
+        assert deleted_dev_count == start_dev_count
+        assert device_id not in deleted_device_list.keys()
 
     def test_central_user_methods_CRD(self):
         users = self._create_users()
@@ -328,6 +349,13 @@ class TestIotCentral(CaptureOutputLiveScenarioTest):
 
     def test_central_device_template_methods_CRD(self):
         # currently: create, show, list, delete
+
+        # list device templates and get count
+        start_device_template_list = self.cmd(
+            "iot central device-template list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        start_dev_temp_count = len(start_device_template_list)
         (template_id, template_name) = self._create_device_template()
 
         result = self.cmd(
@@ -341,7 +369,22 @@ class TestIotCentral(CaptureOutputLiveScenarioTest):
 
         assert json_result["@id"] == template_id
 
+        created_device_template_list = self.cmd(
+            "iot central device-template list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        created_dev_temp_count = len(created_device_template_list)
+        assert created_dev_temp_count == (start_dev_temp_count + 1)
+        assert template_id in created_device_template_list.keys()
+
         self._delete_device_template(template_id)
+        deleted_device_template_list = self.cmd(
+            "iot central device-template list --app-id {}".format(APP_ID)
+        ).get_output_in_json()
+
+        deleted_dev_temp_count = len(deleted_device_template_list)
+        assert deleted_dev_temp_count == start_dev_temp_count
+        assert template_id not in deleted_device_template_list.keys()
 
     def test_central_device_groups_list(self):
         result = self._list_device_groups()

--- a/azext_iot/tests/central/test_iot_central_int.py
+++ b/azext_iot/tests/central/test_iot_central_int.py
@@ -374,7 +374,8 @@ class TestIotCentral(CaptureOutputLiveScenarioTest):
         ).get_output_in_json()
 
         created_dev_temp_count = len(created_device_template_list)
-        assert created_dev_temp_count == (start_dev_temp_count + 1)
+        # assert number of device templates changed by 1 or none in case template was already present in the application
+        assert (created_dev_temp_count == (start_dev_temp_count + 1)) or (created_dev_temp_count == start_dev_temp_count)
         assert template_id in created_device_template_list.keys()
 
         self._delete_device_template(template_id)


### PR DESCRIPTION
This adds device and device template listing to IoT Central commands in order to align with REST api offer.

- List devices
- List templates
- Updated "device-template create" help

### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [x] Have you made an entry in HISTORY.rst which concisely explains your feature or change?

![image](https://user-images.githubusercontent.com/2270242/129062730-bed15011-3c55-453c-ac5c-55912222335c.png)
