### PR TITLE
update to use new importlib

### DIFF
--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -313,7 +313,7 @@ def url_encode_str(s, plus=False):
 def test_import_and_version(package, expected_version):
     """ Used to determine if a dependency is loading correctly """
     import importlib
-    from importlib.metadata import version
+    from importlib_metadata import version
 
     try:
         importlib.import_module(package)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if not PACKAGE_NAME:
 # though that is installed out of band (managed by the extension)
 # for compatibility reasons.
 
-DEPENDENCIES = ["paho-mqtt==1.5.0", "jsonschema==3.2.0", "packaging"]
+DEPENDENCIES = ["paho-mqtt==1.5.0", "jsonschema==3.2.0", "packaging", "importlib_metadata==4.4"]
 EXTRAS = {"uamqp": ["uamqp~=1.2"]}
 
 CLASSIFIERS = [


### PR DESCRIPTION
Using a vanilla python 3.6 installation:
Successfully installed attrs-21.2.0 azure-iot-0.10.16 importlib-metadata-4.4.0 jsonschema-3.2.0 packaging-21.0 paho-mqtt-1.5.0 pyparsing-2.4.7 pyrsistent-0.18.0 setuptools-57.4.0 six-1.16.0 typing-extensions-3.10.0.0 zipp-3.5.0

uamqp is not installed by default so this happens:
![image](https://user-images.githubusercontent.com/73560279/129817313-1ef4018f-431d-4af0-906a-486ec4067b99.png)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
