### PR TITLE
Remove packaging import from version check for azure-mgmt-iothub

### DIFF
--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -23,6 +23,7 @@ from threading import Event, Thread
 from datetime import datetime
 from knack.log import get_logger
 from knack.util import CLIError
+from azext_iot.constants import IOTHUB_MGMT_SDK_PACKAGE_NAME
 
 logger = get_logger(__name__)
 
@@ -446,14 +447,7 @@ class ISO8601Validator:
 
 
 def ensure_iothub_sdk_min_version(min_ver):
-    from packaging import version
-
-    try:
-        from azure.mgmt.iothub import __version__ as iot_sdk_version
-    except ImportError:
-        from azure.mgmt.iothub._configuration import VERSION as iot_sdk_version
-
-    return version.parse(iot_sdk_version) >= version.parse(min_ver)
+    return test_import_and_version(IOTHUB_MGMT_SDK_PACKAGE_NAME, min_ver)
 
 
 def scantree(path):

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -51,4 +51,5 @@ PNP_DTDLV2_COMPONENT_MARKER = "__t"
 CONFIG_KEY_UAMQP_EXT_VERSION = "uamqp_ext_version"
 
 # Initial Track 2 SDK version
+IOTHUB_MGMT_SDK_PACKAGE_NAME = 'azure-mgmt-iothub'
 IOTHUB_TRACK_2_SDK_MIN_VERSION = '2.0.0'

--- a/azext_iot/tests/utility/test_iot_utility_unit.py
+++ b/azext_iot/tests/utility/test_iot_utility_unit.py
@@ -288,7 +288,14 @@ class TestVersionComparison(object):
         ],
     )
     def test_ensure_iothub_sdk_min_version(self, mocker, current, minimum, expected):
-        mocker.patch("importlib.metadata.version", lambda version: current)
+        def get_version(package):
+            return current
+
+        try:
+            mocker.patch("importlib.metadata.version", get_version)
+        except ModuleNotFoundError:
+            mocker.patch("importlib_metadata.version", get_version)
+
         assert ensure_iothub_sdk_min_version(minimum) == expected
 
 

--- a/azext_iot/tests/utility/test_iot_utility_unit.py
+++ b/azext_iot/tests/utility/test_iot_utility_unit.py
@@ -288,11 +288,7 @@ class TestVersionComparison(object):
         ],
     )
     def test_ensure_iothub_sdk_min_version(self, mocker, current, minimum, expected):
-        try:
-            mocker.patch("azure.mgmt.iothub.__version__", current)
-        except:
-            mocker.patch("azure.mgmt.iothub._configuration.VERSION", current)
-
+        mocker.patch("importlib.metadata.version", lambda version: current)
         assert ensure_iothub_sdk_min_version(minimum) == expected
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ DEPENDENCIES = [
     "paho-mqtt==1.5.0",
     "jsonschema==3.2.0",
     "importlib_metadata;python_version<'3.8'",
-    "packaging",
 ]
 EXTRAS = {"uamqp": ["uamqp~=1.2"]}
 

--- a/thirdpartynotice
+++ b/thirdpartynotice
@@ -29,10 +29,3 @@ License notice for paho-mqtt v1.5.0, obtained from https://github.com/eclipse/pa
 
 This project is dual licensed under the Eclipse Public License 1.0 and the
 Eclipse Distribution License 1.0 as described in the epl-v10 and edl-v10 files.
-
------------------------------------------------------------------------------------------------------------------------
-License notice for packaging, obtained from https://github.com/pypa/packaging/blob/main/LICENSE
-
-This software is made available under the terms of *either* of the licenses
-found in LICENSE.APACHE or LICENSE.BSD. Contributions to this software is made
-under the terms of *both* these licenses.


### PR DESCRIPTION
Removes the `packaging` check from our IoT Hub SDK version check and instead uses `importlib.metadata` from our `test_import_and_version` method.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
