### PR TITLE
Remove `encoding` param from binary file reads

### DIFF
--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -77,7 +77,7 @@ def open_certificate(certificate_path):
     """
     certificate = ""
     if certificate_path.endswith('.pem') or certificate_path.endswith('.cer'):
-        with open(certificate_path, "rb", encoding="utf-8") as cert_file:
+        with open(certificate_path, "rb") as cert_file:
             certificate = cert_file.read()
             try:
                 certificate = certificate.decode("utf-8")

--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -180,7 +180,7 @@ def read_file_content(file_path, allow_binary=False):
 
     if allow_binary:
         try:
-            with open(file_path, "rb", encoding="utf-8") as input_file:
+            with open(file_path, "rb") as input_file:
                 logger.debug("Attempting to read file %s as binary", file_path)
                 return base64.b64encode(input_file.read()).decode("utf-8")
         except Exception:  # pylint: disable=broad-except

--- a/azext_iot/product/test/command_tests.py
+++ b/azext_iot/product/test/command_tests.py
@@ -275,7 +275,7 @@ def _process_models_directory(from_directory):
 
 
 def _read_certificate_from_file(certificate_path):
-    with open(file=certificate_path, mode="rb", encoding="utf-8") as f:
+    with open(file=certificate_path, mode="rb") as f:
         data = f.read()
 
         from base64 import b64encode  # pylint: disable=no-name-in-module


### PR DESCRIPTION
Linter fixes for ` W1514: Using open without explicitly specifying an encoding (unspecified-encoding)`  throw a `ValueError` when using the `b` binary read type.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`
- [ ] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [ ] Have you made an entry in HISTORY.rst which concisely explains your feature or change?
