### PR TITLE
Fix tests for central and python 3.9

### DIFF
--- a/azext_iot/tests/central/test_iot_central_devices_int.py
+++ b/azext_iot/tests/central/test_iot_central_devices_int.py
@@ -99,9 +99,12 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
             checks=[self.check("deviceId", device_id)],
         )
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
     @pytest.mark.skipif(
         not APP_SCOPE_ID, reason="empty azext_iot_central_scope_id env var"
@@ -204,6 +207,7 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
         ).get_output_in_json()
 
         start_dev_temp_count = len(start_device_template_list)
+
         (template_id, template_name) = self._create_device_template(
             api_version=self._api_version
         )
@@ -244,10 +248,12 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
             )
             is not None
         )
-
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         # template can't be deleted if any device exists for it. Assert accordingly
 
@@ -288,7 +294,7 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
     def test_central_device_groups_list(self):
         result = self._list_device_groups()
         # assert object is empty or populated but not null
-        assert result is not None and (result == {} or bool(result) is True)
+        assert result is not None and (result == [] or bool(result) is True)
 
     def test_central_device_registration_info_registered(self):
         (template_id, _) = self._create_device_template(api_version=self._api_version)
@@ -303,9 +309,12 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
         result = self.cmd(command, api_version=self._api_version)
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         json_result = result.get_output_in_json()
 
@@ -463,9 +472,12 @@ class TestIotCentralDevices(CentralLiveScenarioTest):
 
         # Cleanup
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         assert len(hubIdentifierOriginal) > 0
         assert len(hubIdentifierFailOver) > 0

--- a/azext_iot/tests/central/test_iot_central_int.py
+++ b/azext_iot/tests/central/test_iot_central_int.py
@@ -78,9 +78,12 @@ class TestIotCentral(CentralLiveScenarioTest):
         )
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
         assert '"Bool": true' in output
         assert device_id in output
 
@@ -109,9 +112,12 @@ class TestIotCentral(CentralLiveScenarioTest):
         output = self._get_validate_messages_output(device_id, enqueued_time)
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         assert output
         assert "Successfully parsed 1 message(s)" in output
@@ -184,9 +190,12 @@ class TestIotCentral(CentralLiveScenarioTest):
         )
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         assert output
 
@@ -273,9 +282,12 @@ class TestIotCentral(CentralLiveScenarioTest):
         show_command_result = self.cmd(command, api_version=self._api_version)
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id, api_version=self._api_version
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id, api_version=self._api_version
+            )
+        except:
+            pass
 
         run_result = run_command_result.get_output_in_json()
         show_result = show_command_result.get_output_in_json()
@@ -309,10 +321,13 @@ class TestIotCentral(CentralLiveScenarioTest):
         show_command_result = self.cmd(command, api_version=self._api_version)
 
         self._delete_device(device_id=device_id, api_version=self._api_version)
-        self._delete_device_template(
-            template_id=template_id,
-            api_version=self._api_version,
-        )
+        try:
+            self._delete_device_template(
+                template_id=template_id,
+                api_version=self._api_version,
+            )
+        except:
+            pass
 
         run_result = run_command_result.get_output_in_json()
         show_result = show_command_result.get_output_in_json()


### PR DESCRIPTION
### General Guidelines

- [x] If introducing new functionality or modified behavior, are they backed by unit and integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** unit **and** integration tests passed locally? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of integration tests.
- [x] Have static checks passed using the .pylintrc and .flake8 rules? Look at the CI scripts for example usage.
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Fixes minor bugs in central tests where it assumes device templates can always be deleted while this can't happen if there are associated devices.
Also align with python 3.9 changes in asyncio.
