### PR TITLE
Adds --device-scope on device identity create /refresh nested edge --help

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,14 +6,20 @@ Release History
 0.11.1
 +++++++++++++++
 
-**IoT DPS changes**
+**IoT DPS updates**
+
 * DPS now supports auto resource and policy discovery. Resource group is no longer a
   required parameter for az iot dps commands. Auto policy discovery ensures that a policy
   with all the correct permissions is available and is used by the IoT extension for all
   DPS operations.
-* az iot dps compute-device-key now supports enrollment group identifiers in addition to
-  enrollment group symmetric key. Please take a look at the --help docs for functionality
+
+* `az iot dps compute-device-key` now supports enrollment group identifiers in addition to
+  enrollment group symmetric key. Please take a look at the `--help` docs for functionality
   and usage highlights.
+
+**IoT Hub updates**
+
+* `az iot hub device-identity create` supports a device scope argument via `--device-scope` parameter.
 
 0.11.0
 +++++++++++++++

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -144,6 +144,9 @@ helps[
     long-summary: |
                   When using the auth method of shared_private_key (also known as symmetric keys),
                   if no custom keys are provided the service will generate them for the device.
+
+                  If a device scope is provided for an edge device, the value will automatically be
+                  converted to a parent scope.
     examples:
     - name: Create an edge enabled IoT device with default authorization (shared private key).
       text: >
@@ -163,10 +166,13 @@ helps[
       text: >
         az iot hub device-identity create -n {iothub_name} -d {device_id} --am x509_thumbprint
         --ptp {thumbprint_1} --stp {thumbprint_2}
-    - name: Create an IoT device with root CA authorization with disabled status and reason
+    - name: Create an IoT device with root CA authorization with disabled status and reason.
       text: >
         az iot hub device-identity create -n {iothub_name} -d {device_id} --am x509_ca
         --status disabled --status-reason 'for reasons'
+    - name: Create an IoT device with a device scope.
+      text: >
+        az iot hub device-identity create -n {iothub_name} -d {device_id} --device-scope 'ms-azure-iot-edge://edge0-123456789123456789'
 """
 
 helps[
@@ -302,16 +308,16 @@ helps[
     "iot hub device-identity parent"
 ] = """
     type: group
-    short-summary: Manage IoT device\'s parent device.
+    short-summary: Manage parent device relationships for IoT devices.
 """
 
 helps[
     "iot hub device-identity parent show"
 ] = """
     type: command
-    short-summary: Get the parent device of the specified device.
+    short-summary: Get the parent device of a target device.
     examples:
-    - name: Get the parent device of the specified device.
+    - name: Get the parent device of a target device.
       text: >
         az iot hub device-identity parent show -d {device_id} -n {iothub_name}
 """
@@ -320,37 +326,36 @@ helps[
     "iot hub device-identity parent set"
 ] = """
     type: command
-    short-summary: Set the parent device of the specified device.
+    short-summary: Set the parent device of a target device.
     examples:
-    - name: Set the parent device of the specified device.
+    - name: Set the parent device of a target device.
       text: >
         az iot hub device-identity parent set -d {device_id} --pd {edge_device_id} -n {iothub_name}
-    - name: Set the parent device of the specified device and overwrites its original parent.
+    - name: Set the parent device of a target device and overwrite the existing parent.
       text: >
-        az iot hub device-identity parent set -d {device_id} --pd {edge_device_id} --force -n {iothub_name}
+        az iot hub device-identity parent set -d {device_id} --pd {edge_device_id} -n {iothub_name} --force
 """
 
 helps[
     "iot hub device-identity children"
 ] = """
     type: group
-    short-summary: Manage IoT device\'s children device.
+    short-summary: Manage children device relationships for IoT edge devices.
 """
 
 helps[
     "iot hub device-identity children add"
 ] = """
     type: command
-    short-summary: Add specified space-separated list of device ids as children of specified edge device.
+    short-summary: Add devices as children to a target edge device.
     examples:
-    - name: Add devices as a children to the edge device.
+    - name: Add a space-separated list of device Ids as children to the target edge device.
       text: >
-        az iot hub device-identity children add -d {edge_device_id} --child-list {space_separated_device_id}
+        az iot hub device-identity children add -d {edge_device_id} --child-list {child_device_id_1} {child_device_id_2}
         -n {iothub_name}
-    - name: Add devices as children to the edge device and overwrites children devices'
-            original parent.
+    - name: Add devices as children to the edge device and overwrite the children devices' existing parent.
       text: >
-        az iot hub device-identity children add -d {edge_device_id} --child-list {space_separated_device_id}
+        az iot hub device-identity children add -d {edge_device_id} --child-list {child_device_id_1} {child_device_id_2}
         -n {iothub_name} -f
 """
 
@@ -358,12 +363,12 @@ helps[
     "iot hub device-identity children list"
 ] = """
     type: command
-    short-summary: Outputs list of assigned child devices.
+    short-summary: Outputs the collection of assigned child devices.
     examples:
-    - name: Show all assigned children devices as list.
+    - name: List all assigned children devices.
       text: >
         az iot hub device-identity children list -d {edge_device_id} -n {iothub_name}
-    - name: Show all assigned children devices as list whose device ID contains substring of 'test'.
+    - name: List all assigned children devices whose device Id contains a substring of 'test'.
       text: >
         az iot hub device-identity children list -d {edge_device_id} -n {iothub_name} --query "[?contains(@,'test')]"
 """
@@ -372,13 +377,13 @@ helps[
     "iot hub device-identity children remove"
 ] = """
     type: command
-    short-summary: Remove devices as children from specified edge device.
+    short-summary: Remove child devices from a target edge device.
     examples:
-    - name: Remove all mentioned devices as children of specified device.
+    - name: Remove a space-seperated list of child devices from a target parent device.
       text: >
         az iot hub device-identity children remove -d {edge_device_id} --child-list {space_separated_device_id}
         -n {iothub_name}
-    - name: Remove all devices as children specified edge device.
+    - name: Remove all child devices from a target parent device.
       text: >
         az iot hub device-identity children remove -d {edge_device_id} --remove-all
 """

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -405,6 +405,14 @@ def load_arguments(self, _):
             options_list=["--status-reason", "--star"],
             help="Description for device status.",
         )
+        context.argument(
+            "device_scope",
+            options_list=["--device-scope"],
+            help="The scope of the device. "
+            "For edge devices, this is auto-generated and immutable. "
+            "For leaf devices, set this to create child/parent relationship.",
+            arg_group="Device Scope"
+        )
 
     with self.argument_context("iot hub device-identity renew-key") as context:
         context.argument(

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -157,6 +157,7 @@ def iot_device_create(
     status_reason=None,
     valid_days=None,
     output_dir=None,
+    device_scope=None,
     resource_group_name=None,
     login=None,
     auth_type_dataplane=None,
@@ -184,14 +185,15 @@ def iot_device_create(
 
     try:
         device = _assemble_device(
-            False,
-            device_id,
-            auth_method,
-            edge_enabled,
-            primary_thumbprint if auth_method == DeviceAuthType.x509_thumbprint.value else primary_key,
-            secondary_thumbprint if auth_method == DeviceAuthType.x509_thumbprint.value else secondary_key,
-            status,
-            status_reason,
+            is_update=False,
+            device_id=device_id,
+            auth_method=auth_method,
+            edge_enabled=edge_enabled,
+            pk=primary_thumbprint if auth_method == DeviceAuthType.x509_thumbprint.value else primary_key,
+            sk=secondary_thumbprint if auth_method == DeviceAuthType.x509_thumbprint.value else secondary_key,
+            status=status,
+            status_reason=status_reason,
+            device_scope=device_scope,
         )
         output = service_sdk.devices.create_or_update_identity(
             id=device_id, device=device
@@ -230,16 +232,16 @@ def _assemble_device(
         )
         return device
     if edge_enabled:
-        parent_scope = []
+        parent_scopes = []
         if device_scope:
-            parent_scope = [device_scope]
+            parent_scopes = [device_scope]
         device = Device(
             device_id=device_id,
             authentication=auth,
             capabilities=cap,
             status=status,
             status_reason=status_reason,
-            parent_scopes=parent_scope,
+            parent_scopes=parent_scopes,
         )
         return device
     else:

--- a/azext_iot/tests/iothub/core/test_iot_ext_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_ext_unit.py
@@ -62,6 +62,7 @@ def generate_device_create_req(
     status_reason=None,
     valid_days=None,
     output_dir=None,
+    device_scope=None,
 ):
     return {
         "client": None,
@@ -76,7 +77,8 @@ def generate_device_create_req(
         "status": status,
         "status_reason": status_reason,
         "valid_days": valid_days,
-        "output_dir": output_dir
+        "output_dir": output_dir,
+        "device_scope": device_scope
     }
 
 
@@ -105,6 +107,7 @@ class TestDeviceCreate:
                 )
             ),
             (generate_device_create_req(status="disabled", status_reason="reasons")),
+            (generate_device_create_req(device_scope=generate_generic_id()))
         ],
     )
     def test_device_create(self, serviceclient, req):
@@ -122,6 +125,7 @@ class TestDeviceCreate:
             req["status_reason"],
             req["valid_days"],
             req["output_dir"],
+            req["device_scope"]
         )
 
         args = serviceclient.call_args
@@ -135,6 +139,9 @@ class TestDeviceCreate:
         if req.get("status_reason"):
             assert body["statusReason"] == req["status_reason"]
         assert body["capabilities"]["iotEdge"] == req["ee"]
+
+        if req.get("device_scope"):
+            assert body["deviceScope"] == req["device_scope"]
 
         if req["auth"] == "shared_private_key":
             assert body["authentication"]["type"] == DeviceAuthApiType.sas.value


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
