### PR TITLE
[DPS] Resolves issue where usage of `--login` with connection string still required `az login`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+0.12.1
++++++++++++++++
+
+**IoT DPS updates**
+
+* Resolves issue where usage of `--login` with connection string still required `az login`.
+
+
 0.12.0
 +++++++++++++++
 
@@ -16,7 +24,7 @@ Release History
   - Destination (az iot central export destination)
   - Export (az iot central export)
 
-** General Updates **
+**General Updates**
 
 * The IoT extension officially supports Python 3.10.
 

--- a/azext_iot/__init__.py
+++ b/azext_iot/__init__.py
@@ -6,17 +6,13 @@
 
 from azure.cli.core import AzCommandsLoader
 from azure.cli.core.commands import CliCommandType
-from azext_iot._factory import iot_service_provisioning_factory
 from azext_iot.constants import VERSION
 import azext_iot._help  # noqa: F401
 from azext_iot.product.command_map import load_product_commands
 
 
 iothub_ops = CliCommandType(operations_tmpl="azext_iot.operations.hub#{}")
-iotdps_ops = CliCommandType(
-    operations_tmpl="azext_iot.operations.dps#{}",
-    client_factory=iot_service_provisioning_factory,
-)
+iotdps_ops = CliCommandType(operations_tmpl="azext_iot.operations.dps#{}")
 
 
 class IoTExtCommandsLoader(AzCommandsLoader):

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.12.0"
+VERSION = "0.12.1"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"


### PR DESCRIPTION
Test run
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=4214&view=results

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
