### PR TITLE
DT Resource creation during tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+0.13.1
++++++++++++++++
+
+**DT Updates**
+
+* Enable routing tests to create the resources needed during the test run.
+
+
 0.13.0
 +++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,14 +3,6 @@
 Release History
 ===============
 
-0.13.1
-+++++++++++++++
-
-**DT Updates**
-
-* Enable routing tests to create the resources needed during the test run.
-
-
 0.13.0
 +++++++++++++++
 

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.13.0"
+VERSION = "0.13.1"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -42,21 +42,21 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         try:
             self.delete_eventhub_resources()
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Failed to delete the EventHub resources. Additional details: " +
                 unpack_msrest_error(e)
             )
         try:
             self.delete_eventgrid_resources()
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Failed to delete the Event Grid resources. Additional details: " +
                 unpack_msrest_error(e)
             )
         try:
             self.delete_servicebus_resources()
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Failed to delete the ServiceBus resources. Additional details: " +
                 unpack_msrest_error(e))
 

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -8,6 +8,7 @@ from typing import List
 from collections import namedtuple
 from time import sleep
 from knack.log import get_logger
+from azext_iot.common.utility import unpack_msrest_error
 from azext_iot.digitaltwins.common import ADTEndpointAuthType, ADTEndpointType
 from . import DTLiveScenarioTest
 from . import (
@@ -40,16 +41,24 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         super().tearDown()
         try:
             self.delete_eventhub_resources()
-        except Exception:
-            logger.info("The EventHub resources have already been deleted.")
+        except Exception as e:
+            logger.warn(
+                "Failed to delete the EventHub resources. Additional details: " +
+                unpack_msrest_error(e)
+            )
         try:
             self.delete_eventgrid_resources()
-        except Exception:
-            logger.info("The Event Grid resources have already been deleted.")
+        except Exception as e:
+            logger.warn(
+                "Failed to delete the Event Grid resources. Additional details: " +
+                unpack_msrest_error(e)
+            )
         try:
             self.delete_servicebus_resources()
-        except Exception:
-            logger.info("The ServiceBus resources have already been deleted.")
+        except Exception as e:
+            logger.warn(
+                "Failed to delete the ServiceBus resources. Additional details: " +
+                unpack_msrest_error(e))
 
     def test_dt_resource(self):
         self.wait_for_capacity(capacity=3)


### PR DESCRIPTION
Enable JIT resource creation during tests. For the routing tests (within test_dt_resouce_lifecycle_int.py), if the resource names are not provided in the pytest.ini file, the required event hub, event grid and service bus resources will be automatically created before the test run and deleted after the test run. If the resource names are provided, those resources will be used instead.

endpoint tests:
![image](https://user-images.githubusercontent.com/73560279/150611464-5dbbf57c-b376-4924-bd50-a7701baa37c9.png)

all dt int tests
![image](https://user-images.githubusercontent.com/73560279/150614539-f70e3416-6a1b-4a0e-97c6-406554c30cda.png)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
~- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?~
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
