### PR TITLE
DT resource Teardown to TeardownSuite

### DIFF
--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -8,6 +8,7 @@ from typing import List
 from collections import namedtuple
 from time import sleep
 from knack.log import get_logger
+import pytest
 from azext_iot.common.utility import unpack_msrest_error
 from azext_iot.digitaltwins.common import ADTEndpointAuthType, ADTEndpointType
 from . import DTLiveScenarioTest
@@ -37,8 +38,9 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         self.ensure_eventhub_resource()
         self.ensure_servicebus_resource()
 
-    def tearDown(self):
-        super().tearDown()
+    @pytest.fixture(scope='class', autouse=True)
+    def tearDownSuite(self):
+        yield None
         try:
             self.delete_eventhub_resources()
         except Exception as e:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/73560279/151446359-d07f8476-3358-4f3d-8dc3-90254a350262.png)



---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
