### PR TITLE
Dt no wait

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,19 +4,6 @@ Release History
 ===============
 
 
-
-0.14.1
-+++++++++++++++
-
-**Digital Twin updates**
-
-* Added `--no-wait` parameter to the following functions:
-
-  - az dt create
-  - az dt endpoint create
-  - az dt private-endpoint create
-
-
 0.14.0
 +++++++++++++++
 
@@ -26,6 +13,12 @@ Release History
   add a custom timestamp to the sent telemetry.
 
 * Updated both controlplane and dataplane SDKs to now use the newer 2021-06-30-preview API version.
+
+* Added `--no-wait` parameter to the following functions:
+
+  - az dt create
+  - az dt endpoint create
+  - az dt private-endpoint create
 
 
 0.13.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,19 @@ Release History
 ===============
 
 
+
+0.14.1
++++++++++++++++
+
+**Digital Twin updates**
+
+* Added `--no-wait` parameter to the following functions:
+
+  - az dt create
+  - az dt endpoint create
+  - az dt private-endpoint create
+
+
 0.14.0
 +++++++++++++++
 

--- a/azext_iot/digitaltwins/command_map.py
+++ b/azext_iot/digitaltwins/command_map.py
@@ -42,7 +42,7 @@ def load_digitaltwins_commands(self, _):
         "dt",
         command_type=digitaltwins_resource_ops,
     ) as cmd_group:
-        cmd_group.command("create", "create_instance")
+        cmd_group.command("create", "create_instance", supports_no_wait=True)
         cmd_group.show_command("show", "show_instance")
         cmd_group.command("list", "list_instances")
         cmd_group.command("delete", "delete_instance", confirmation=True, supports_no_wait=True)
@@ -102,9 +102,9 @@ def load_digitaltwins_commands(self, _):
     with self.command_group(
         "dt endpoint create", command_type=digitaltwins_resource_ops
     ) as cmd_group:
-        cmd_group.command("eventgrid", "add_endpoint_eventgrid")
-        cmd_group.command("servicebus", "add_endpoint_servicebus")
-        cmd_group.command("eventhub", "add_endpoint_eventhub")
+        cmd_group.command("eventgrid", "add_endpoint_eventgrid", supports_no_wait=True)
+        cmd_group.command("servicebus", "add_endpoint_servicebus", supports_no_wait=True)
+        cmd_group.command("eventhub", "add_endpoint_eventhub", supports_no_wait=True)
 
     with self.command_group(
         "dt route", command_type=digitaltwins_route_ops
@@ -199,7 +199,7 @@ def load_digitaltwins_commands(self, _):
         "dt network private-endpoint connection",
         command_type=digitaltwins_resource_ops,
     ) as cmd_group:
-        cmd_group.command("set", "set_private_endpoint_conn")
+        cmd_group.command("set", "set_private_endpoint_conn", supports_no_wait=True)
         cmd_group.show_command("show", "show_private_endpoint_conn")
         cmd_group.command("list", "list_private_endpoint_conns")
         cmd_group.command("delete", "delete_private_endpoint_conn", confirmation=True, supports_no_wait=True)

--- a/azext_iot/digitaltwins/commands_resource.py
+++ b/azext_iot/digitaltwins/commands_resource.py
@@ -12,8 +12,8 @@ from azext_iot.digitaltwins.common import (
     ADTEndpointAuthType,
     ADTPublicNetworkAccessType,
 )
+from azure.cli.core.azclierror import MutuallyExclusiveArgumentError
 from knack.log import get_logger
-from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -31,7 +31,7 @@ def create_instance(
     no_wait=False,
 ):
     if no_wait and scopes:
-        raise CLIError(
+        raise MutuallyExclusiveArgumentError(
             "Cannot assign scopes in a no wait operation. Please run the command without --no-wait."
         )
     rp = ResourceProvider(cmd)

--- a/azext_iot/digitaltwins/commands_resource.py
+++ b/azext_iot/digitaltwins/commands_resource.py
@@ -13,6 +13,7 @@ from azext_iot.digitaltwins.common import (
     ADTPublicNetworkAccessType,
 )
 from knack.log import get_logger
+from knack.util import CLIError
 
 logger = get_logger(__name__)
 
@@ -27,7 +28,12 @@ def create_instance(
     scopes=None,
     role_type="Contributor",
     public_network_access=ADTPublicNetworkAccessType.enabled.value,
+    no_wait=False,
 ):
+    if no_wait and scopes:
+        raise CLIError(
+            "Cannot assign scopes in a no wait operation. Please run the command without --no-wait."
+        )
     rp = ResourceProvider(cmd)
     return rp.create(
         name=name,

--- a/azext_iot/digitaltwins/params.py
+++ b/azext_iot/digitaltwins/params.py
@@ -133,7 +133,7 @@ def load_digitaltwins_arguments(self, _):
             arg_group="Managed Service Identity",
             nargs="+",
             options_list=["--scopes"],
-            help="Space-seperated scopes the system assigned identity can access. Cannot be used with --no-wait.",
+            help="Space-separated scopes the system assigned identity can access. Cannot be used with --no-wait.",
         )
         context.argument(
             "role_type",

--- a/azext_iot/digitaltwins/params.py
+++ b/azext_iot/digitaltwins/params.py
@@ -133,7 +133,7 @@ def load_digitaltwins_arguments(self, _):
             arg_group="Managed Service Identity",
             nargs="+",
             options_list=["--scopes"],
-            help="Space-seperated scopes the system assigned identity can access.",
+            help="Space-seperated scopes the system assigned identity can access. Cannot be used with --no-wait.",
         )
         context.argument(
             "role_type",

--- a/azext_iot/tests/digitaltwins/test_dt_privatelinks_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_privatelinks_lifecycle_int.py
@@ -168,22 +168,13 @@ class TestDTPrivateLinksLifecycle(DTLiveScenarioTest):
         random_desc_rejected = "{} {}".format(
             generate_generic_id(), generate_generic_id()
         )
-        set_connection_output = self.cmd(
-            "dt network private-endpoint connection set -n {} -g {} --cn {} --status Rejected --desc '{}'".format(
+        self.cmd(
+            "dt network private-endpoint connection set -n {} -g {} --cn {} --status Rejected --desc '{}' --no-wait".format(
                 instance_name, self.rg, instance_connection_id, random_desc_rejected
             )
-        ).get_output_in_json()
-
-        assert (
-            set_connection_output["properties"]["privateLinkServiceConnectionState"]["status"]
-            == "Rejected"
-        )
-        assert (
-            set_connection_output["properties"]["privateLinkServiceConnectionState"]["description"]
-            == random_desc_rejected
         )
 
-        self.cmd("dt network private-endpoint connection wait -n {} -g {} --cn {} --updated --interval 1 --timeout 30".format(
+        self.cmd("dt network private-endpoint connection wait -n {} -g {} --cn {} --updated --interval 3 --timeout 30".format(
             instance_name, self.rg, instance_connection_id
         ))
 

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -176,10 +176,10 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         updated_tags = "env=test tier=premium"
         updated_tags_dict = {"env": "test", "tier": "premium"}
         self.cmd(
-            "dt create -n {} -g {} --assign-identity false --tags {}".format(
+            "dt create -n {} -g {} --assign-identity false --tags {} --no-wait".format(
                 instance_names[1], self.rg, updated_tags
             )
-        ).get_output_in_json()
+        )
 
         self.cmd(
             "dt wait -n {} -g {} --custom \"{}\" --interval {} --timeout {}".format(
@@ -371,6 +371,371 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         eventgrid_endpoint = "myeventgridendpoint"
 
         logger.debug("Adding key based eventgrid endpoint...")
+        self.cmd(
+            "dt endpoint create eventgrid -n {} -g {} --egg {} --egt {} --en {} --dsu {} --no-wait".format(
+                endpoints_instance_name,
+                self.rg,
+                EP_RG,
+                EP_EVENTGRID_TOPIC,
+                eventgrid_endpoint,
+                MOCK_DEAD_LETTER_SECRET,
+            )
+        )
+
+        # self.cmd(
+        #     "dt endpoint wait --created -n {} -g {} --en {}".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         eventgrid_endpoint
+        #     )
+        # )
+
+        # show_ep_output = self.cmd(
+        #     "dt endpoint show -n {} -g {} --en {}".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         eventgrid_endpoint
+        #     )
+        # ).get_output_in_json()
+
+        # assert_common_endpoint_attributes(
+        #     show_ep_output,
+        #     eventgrid_endpoint,
+        #     ADTEndpointType.eventgridtopic,
+        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+        # )
+
+        endpoint_tuple_collection.append(
+            EndpointTuple(
+                eventgrid_endpoint,
+                ADTEndpointType.eventgridtopic,
+                ADTEndpointAuthType.keybased,
+            )
+        )
+
+        servicebus_endpoint = "myservicebusendpoint"
+        servicebus_endpoint_msi = "{}identity".format(servicebus_endpoint)
+
+        logger.debug("Adding key based servicebus topic endpoint...")
+        self.cmd(
+            "dt endpoint create servicebus -n {} --sbg {} --sbn {} --sbp {} --sbt {} --en {} --dsu {} --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_SERVICEBUS_NAMESPACE,
+                EP_SERVICEBUS_POLICY,
+                EP_SERVICEBUS_TOPIC,
+                servicebus_endpoint,
+                MOCK_DEAD_LETTER_SECRET,
+            )
+        )
+
+        # self.cmd(
+        #     "dt endpoint wait --created -n {} -g {} --en {}".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         servicebus_endpoint
+        #     )
+        # )
+
+        # show_ep_sb_key_output = self.cmd(
+        #     "dt endpoint show -n {} -g {} --en {}".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         servicebus_endpoint
+        #     )
+        # ).get_output_in_json()
+
+        # assert_common_endpoint_attributes(
+        #     show_ep_sb_key_output,
+        #     servicebus_endpoint,
+        #     endpoint_type=ADTEndpointType.servicebus,
+        #     auth_type=ADTEndpointAuthType.keybased,
+        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+        # )
+        endpoint_tuple_collection.append(
+            EndpointTuple(
+                servicebus_endpoint,
+                ADTEndpointType.servicebus,
+                ADTEndpointAuthType.keybased,
+            )
+        )
+
+        logger.debug("Adding identity based servicebus topic endpoint...")
+        self.cmd(
+            "dt endpoint create servicebus -n {} --sbg {} --sbn {} --sbt {} --en {} --du {} "
+            "--auth-type IdentityBased --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_SERVICEBUS_NAMESPACE,
+                EP_SERVICEBUS_TOPIC,
+                servicebus_endpoint_msi,
+                MOCK_DEAD_LETTER_ENDPOINT,
+            )
+        )
+
+        # self.cmd(
+        #     "dt endpoint wait --created -n {} -g {} --en {} --interval 1".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         servicebus_endpoint_msi,
+        #     )
+        # )
+
+        # assert_common_endpoint_attributes(
+        #     add_ep_sb_identity_output,
+        #     servicebus_endpoint_msi,
+        #     endpoint_type=ADTEndpointType.servicebus,
+        #     auth_type=ADTEndpointAuthType.identitybased,
+        #     dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+        # )
+        endpoint_tuple_collection.append(
+            EndpointTuple(
+                servicebus_endpoint_msi,
+                ADTEndpointType.servicebus,
+                ADTEndpointAuthType.identitybased,
+            )
+        )
+
+        eventhub_endpoint = "myeventhubendpoint"
+        eventhub_endpoint_msi = "{}identity".format(eventhub_endpoint)
+
+        logger.debug("Adding key based eventhub endpoint...")
+        self.cmd(
+            "dt endpoint create eventhub -n {} --ehg {} --ehn {} --ehp {} --eh {} --ehs {} --en {} "
+            "--dsu '{}' --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_EVENTHUB_NAMESPACE,
+                EP_EVENTHUB_POLICY,
+                EP_EVENTHUB_TOPIC,
+                self.current_subscription,
+                eventhub_endpoint,
+                MOCK_DEAD_LETTER_SECRET,
+            )
+        )
+
+        # self.cmd(
+        #     "dt endpoint wait --created -n {} -g {} --en {} --interval 1".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         eventhub_endpoint,
+        #     )
+        # )
+
+        # assert_common_endpoint_attributes(
+        #     add_ep_output,
+        #     eventhub_endpoint,
+        #     ADTEndpointType.eventhub,
+        #     auth_type=ADTEndpointAuthType.keybased,
+        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+        # )
+        endpoint_tuple_collection.append(
+            EndpointTuple(
+                eventhub_endpoint,
+                ADTEndpointType.eventhub,
+                ADTEndpointAuthType.keybased,
+            )
+        )
+
+        logger.debug("Adding identity based eventhub endpoint...")
+        self.cmd(
+            "dt endpoint create eventhub -n {} --ehg {} --ehn {} --eh {} --ehs {} --en {} --du {} "
+            "--auth-type IdentityBased --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_EVENTHUB_NAMESPACE,
+                EP_EVENTHUB_TOPIC,
+                self.current_subscription,
+                eventhub_endpoint_msi,
+                MOCK_DEAD_LETTER_ENDPOINT,
+            )
+        )
+
+        # wait for the last endpoint to create, just in case
+        self.cmd(
+            "dt endpoint wait -n {} -g {} --en {} --created".format(
+                endpoints_instance_name,
+                self.rg,
+                eventhub_endpoint_msi,
+            )
+        )
+
+        # show_ep_output = self.cmd(
+        #     "dt endpoint show -n {} -g {} --en {}".format(
+        #         endpoints_instance_name,
+        #         self.rg,
+        #         eventhub_endpoint_msi,
+        #     )
+        # ).get_output_in_json()
+
+        # assert_common_endpoint_attributes(
+        #     show_ep_output,
+        #     eventhub_endpoint_msi,
+        #     endpoint_type=ADTEndpointType.eventhub,
+        #     auth_type=ADTEndpointAuthType.identitybased,
+        #     dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+        # )
+        endpoint_tuple_collection.append(
+            EndpointTuple(
+                eventhub_endpoint_msi,
+                ADTEndpointType.eventhub,
+                ADTEndpointAuthType.identitybased,
+            )
+        )
+
+        for ep in endpoint_tuple_collection:
+            is_last = ep.endpoint_name == endpoint_tuple_collection[-1].endpoint_name
+            show_ep_output = self.cmd(
+                "dt endpoint show -n {} --en {} {}".format(
+                    endpoints_instance_name,
+                    ep.endpoint_name,
+                    "-g {}".format(self.rg) if is_last else "",
+                )
+            ).get_output_in_json()
+
+            assert_common_endpoint_attributes(
+                show_ep_output,
+                ep.endpoint_name,
+                endpoint_type=ep.endpoint_type,
+                auth_type=ep.auth_type,
+            )
+
+        list_ep_output = self.cmd(
+            "dt endpoint list -n {} -g {}".format(endpoints_instance_name, self.rg)
+        ).get_output_in_json()
+        assert len(list_ep_output) == 5
+
+        endpoint_names = [eventgrid_endpoint, servicebus_endpoint, eventhub_endpoint]
+        filter_values = ["", "false", "type = Microsoft.DigitalTwins.Twin.Create"]
+
+        # Test Routes
+        list_routes_output = self.cmd(
+            "dt route list -n {}".format(endpoints_instance_name)
+        ).get_output_in_json()
+        assert len(list_routes_output) == 0
+
+        for endpoint_name in endpoint_names:
+            is_last = endpoint_name == endpoint_names[-1]
+            route_name = "routefor{}".format(endpoint_name)
+            filter_value = filter_values.pop()
+            add_route_output = self.cmd(
+                "dt route create -n {} --rn {} --en {} --filter '{}' {}".format(
+                    endpoints_instance_name,
+                    route_name,
+                    endpoint_name,
+                    filter_value,
+                    "-g {}".format(self.rg) if is_last else "",
+                )
+            ).get_output_in_json()
+
+            assert_common_route_attributes(
+                add_route_output, route_name, endpoint_name, filter_value
+            )
+
+            show_route_output = self.cmd(
+                "dt route show -n {} --rn {} {}".format(
+                    endpoints_instance_name,
+                    route_name,
+                    "-g {}".format(self.rg) if is_last else "",
+                )
+            ).get_output_in_json()
+
+            assert_common_route_attributes(
+                show_route_output, route_name, endpoint_name, filter_value
+            )
+
+        list_routes_output = self.cmd(
+            "dt route list -n {} -g {}".format(endpoints_instance_name, self.rg)
+        ).get_output_in_json()
+        assert len(list_routes_output) == 3
+
+        for endpoint_name in endpoint_names:
+            is_last = endpoint_name == endpoint_names[-1]
+            route_name = "routefor{}".format(endpoint_name)
+            self.cmd(
+                "dt route delete -n {} --rn {} {}".format(
+                    endpoints_instance_name,
+                    route_name,
+                    "-g {}".format(self.rg) if is_last else "",
+                )
+            )
+
+        list_routes_output = self.cmd(
+            "dt route list -n {} -g {}".format(endpoints_instance_name, self.rg)
+        ).get_output_in_json()
+        assert len(list_routes_output) == 0
+
+        for ep in endpoint_tuple_collection:
+            logger.debug("Deleting endpoint {}...".format(ep.endpoint_name))
+            is_last = ep.endpoint_name == endpoint_tuple_collection[-1].endpoint_name
+            self.cmd(
+                "dt endpoint delete -y -n {} --en {} --no-wait {}".format(
+                    endpoints_instance_name,
+                    ep.endpoint_name,
+                    "-g {}".format(self.rg) if is_last else "",
+                )
+            )
+
+        list_endpoint_output = self.cmd(
+            "dt endpoint list -n {} -g {}".format(endpoints_instance_name, self.rg)
+        ).get_output_in_json()
+        assert (
+            len(list_endpoint_output) == 0
+            or len(
+                [
+                    ep
+                    for ep in list_endpoint_output
+                    if ep["properties"]["provisioningState"].lower() != "deleting"
+                ]
+            )
+            == 0
+        )
+
+    def test_dt_endpoints(self):
+        self.wait_for_capacity()
+        endpoints_instance_name = generate_resource_id()
+        target_scope_role = "Contributor"
+
+        sb_topic_resource_id = self.embedded_cli.invoke(
+            "servicebus topic show --namespace-name {} -n {} -g {}".format(
+                EP_SERVICEBUS_NAMESPACE,
+                EP_SERVICEBUS_TOPIC,
+                EP_RG,
+            )
+        ).as_json()["id"]
+
+        eh_resource_id = self.embedded_cli.invoke(
+            "eventhubs eventhub show --namespace-name {} -n {} -g {}".format(
+                EP_EVENTHUB_NAMESPACE,
+                EP_EVENTHUB_TOPIC,
+                EP_RG,
+            )
+        ).as_json()["id"]
+
+        endpoint_instance = self.cmd(
+            "dt create -n {} -g {} -l {} --assign-identity --scopes {} {} --role {}".format(
+                endpoints_instance_name,
+                self.rg,
+                self.region,
+                sb_topic_resource_id,
+                eh_resource_id,
+                target_scope_role,
+            )
+        ).get_output_in_json()
+        self.track_instance(endpoint_instance)
+
+        EndpointTuple = namedtuple(
+            "endpoint_tuple", ["endpoint_name", "endpoint_type", "auth_type"]
+        )
+        endpoint_tuple_collection: List[EndpointTuple] = []
+        list_ep_output = self.cmd(
+            "dt endpoint list -n {}".format(endpoints_instance_name)
+        ).get_output_in_json()
+        assert len(list_ep_output) == 0
+
+        eventgrid_endpoint = "myeventgridendpoint"
+
+        logger.debug("Adding key based eventgrid endpoint...")
         add_ep_output = self.cmd(
             "dt endpoint create eventgrid -n {} -g {} --egg {} --egt {} --en {} --dsu {}".format(
                 endpoints_instance_name,
@@ -392,6 +757,49 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
 
         assert_common_endpoint_attributes(
             add_ep_output,
+            eventgrid_endpoint,
+            ADTEndpointType.eventgridtopic,
+            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+        )
+
+        # Delete and re-add endpoint with no wait
+        self.cmd(
+            "dt endpoint delete -n {} -g {} --en {} -y".format(
+                endpoints_instance_name,
+                self.rg,
+                eventgrid_endpoint
+            )
+        )
+
+        self.cmd(
+            "dt endpoint create eventgrid -n {} -g {} --egg {} --egt {} --en {} --dsu {} --no-wait".format(
+                endpoints_instance_name,
+                self.rg,
+                EP_RG,
+                EP_EVENTGRID_TOPIC,
+                eventgrid_endpoint,
+                MOCK_DEAD_LETTER_SECRET,
+            )
+        )
+
+        self.cmd(
+            "dt endpoint wait --created -n {} -g {} --en {}".format(
+                endpoints_instance_name,
+                self.rg,
+                eventgrid_endpoint
+            )
+        )
+
+        show_ep_output = self.cmd(
+            "dt endpoint show -n {} -g {} --en {}".format(
+                endpoints_instance_name,
+                self.rg,
+                eventgrid_endpoint
+            )
+        ).get_output_in_json()
+
+        assert_common_endpoint_attributes(
+            show_ep_output,
             eventgrid_endpoint,
             ADTEndpointType.eventgridtopic,
             dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
@@ -431,6 +839,51 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
 
         assert_common_endpoint_attributes(
             add_ep_sb_key_output,
+            servicebus_endpoint,
+            endpoint_type=ADTEndpointType.servicebus,
+            auth_type=ADTEndpointAuthType.keybased,
+            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+        )
+
+        # Delete and re-add endpoint with no wait
+        self.cmd(
+            "dt endpoint delete -n {} -g {} --en {} -y".format(
+                endpoints_instance_name,
+                self.rg,
+                servicebus_endpoint
+            )
+        )
+
+        self.cmd(
+            "dt endpoint create servicebus -n {} --sbg {} --sbn {} --sbp {} --sbt {} --en {} --dsu {} --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_SERVICEBUS_NAMESPACE,
+                EP_SERVICEBUS_POLICY,
+                EP_SERVICEBUS_TOPIC,
+                servicebus_endpoint,
+                MOCK_DEAD_LETTER_SECRET,
+            )
+        )
+
+        self.cmd(
+            "dt endpoint wait --created -n {} -g {} --en {}".format(
+                endpoints_instance_name,
+                self.rg,
+                servicebus_endpoint
+            )
+        )
+
+        show_ep_sb_key_output = self.cmd(
+            "dt endpoint show -n {} -g {} --en {}".format(
+                endpoints_instance_name,
+                self.rg,
+                servicebus_endpoint
+            )
+        ).get_output_in_json()
+
+        assert_common_endpoint_attributes(
+            show_ep_sb_key_output,
             servicebus_endpoint,
             endpoint_type=ADTEndpointType.servicebus,
             auth_type=ADTEndpointAuthType.keybased,
@@ -548,6 +1001,52 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             auth_type=ADTEndpointAuthType.identitybased,
             dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
         )
+
+        # Delete and re-add endpoint with no wait
+        self.cmd(
+            "dt endpoint delete -n {} -g {} --en {} -y".format(
+                endpoints_instance_name,
+                self.rg,
+                eventhub_endpoint_msi,
+            )
+        )
+
+        self.cmd(
+            "dt endpoint create eventhub -n {} --ehg {} --ehn {} --eh {} --ehs {} --en {} --du {} "
+            "--auth-type IdentityBased --no-wait".format(
+                endpoints_instance_name,
+                EP_RG,
+                EP_EVENTHUB_NAMESPACE,
+                EP_EVENTHUB_TOPIC,
+                self.current_subscription,
+                eventhub_endpoint_msi,
+                MOCK_DEAD_LETTER_ENDPOINT,
+            )
+        )
+
+        self.cmd(
+            "dt endpoint wait -n {} -g {} --en {} --created".format(
+                endpoints_instance_name,
+                self.rg,
+                eventhub_endpoint_msi,
+            )
+        )
+
+        show_ep_output = self.cmd(
+            "dt endpoint show -n {} -g {} --en {}".format(
+                endpoints_instance_name,
+                self.rg,
+                eventhub_endpoint_msi,
+            )
+        ).get_output_in_json()
+
+        assert_common_endpoint_attributes(
+            show_ep_output,
+            eventhub_endpoint_msi,
+            endpoint_type=ADTEndpointType.eventhub,
+            auth_type=ADTEndpointAuthType.identitybased,
+            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+        )
         endpoint_tuple_collection.append(
             EndpointTuple(
                 eventhub_endpoint_msi,
@@ -577,66 +1076,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             "dt endpoint list -n {} -g {}".format(endpoints_instance_name, self.rg)
         ).get_output_in_json()
         assert len(list_ep_output) == 5
-
-        endpoint_names = [eventgrid_endpoint, servicebus_endpoint, eventhub_endpoint]
-        filter_values = ["", "false", "type = Microsoft.DigitalTwins.Twin.Create"]
-
-        # Test Routes
-        list_routes_output = self.cmd(
-            "dt route list -n {}".format(endpoints_instance_name)
-        ).get_output_in_json()
-        assert len(list_routes_output) == 0
-
-        for endpoint_name in endpoint_names:
-            is_last = endpoint_name == endpoint_names[-1]
-            route_name = "routefor{}".format(endpoint_name)
-            filter_value = filter_values.pop()
-            add_route_output = self.cmd(
-                "dt route create -n {} --rn {} --en {} --filter '{}' {}".format(
-                    endpoints_instance_name,
-                    route_name,
-                    endpoint_name,
-                    filter_value,
-                    "-g {}".format(self.rg) if is_last else "",
-                )
-            ).get_output_in_json()
-
-            assert_common_route_attributes(
-                add_route_output, route_name, endpoint_name, filter_value
-            )
-
-            show_route_output = self.cmd(
-                "dt route show -n {} --rn {} {}".format(
-                    endpoints_instance_name,
-                    route_name,
-                    "-g {}".format(self.rg) if is_last else "",
-                )
-            ).get_output_in_json()
-
-            assert_common_route_attributes(
-                show_route_output, route_name, endpoint_name, filter_value
-            )
-
-        list_routes_output = self.cmd(
-            "dt route list -n {} -g {}".format(endpoints_instance_name, self.rg)
-        ).get_output_in_json()
-        assert len(list_routes_output) == 3
-
-        for endpoint_name in endpoint_names:
-            is_last = endpoint_name == endpoint_names[-1]
-            route_name = "routefor{}".format(endpoint_name)
-            self.cmd(
-                "dt route delete -n {} --rn {} {}".format(
-                    endpoints_instance_name,
-                    route_name,
-                    "-g {}".format(self.rg) if is_last else "",
-                )
-            )
-
-        list_routes_output = self.cmd(
-            "dt route list -n {} -g {}".format(endpoints_instance_name, self.rg)
-        ).get_output_in_json()
-        assert len(list_routes_output) == 0
 
         for ep in endpoint_tuple_collection:
             logger.debug("Deleting endpoint {}...".format(ep.endpoint_name))

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -124,6 +124,14 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             expect_failure=True,
         )
 
+        # Assert that --no-wait and --scopes will not work
+        self.cmd(
+            "dt create -n {} -g {} --assign-identity --scopes {} --no-wait".format(
+                instance_names[1], self.rg, " ".join(scope_ids)
+            ),
+            expect_failure=True,
+        )
+
         # No location specified. Use the resource group location.
         create_msi_output = self.cmd(
             "dt create -n {} -g {} --assign-identity --scopes {}".format(

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -381,30 +381,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 MOCK_DEAD_LETTER_SECRET,
             )
         )
-
-        # self.cmd(
-        #     "dt endpoint wait --created -n {} -g {} --en {}".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         eventgrid_endpoint
-        #     )
-        # )
-
-        # show_ep_output = self.cmd(
-        #     "dt endpoint show -n {} -g {} --en {}".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         eventgrid_endpoint
-        #     )
-        # ).get_output_in_json()
-
-        # assert_common_endpoint_attributes(
-        #     show_ep_output,
-        #     eventgrid_endpoint,
-        #     ADTEndpointType.eventgridtopic,
-        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
-        # )
-
         endpoint_tuple_collection.append(
             EndpointTuple(
                 eventgrid_endpoint,
@@ -428,30 +404,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 MOCK_DEAD_LETTER_SECRET,
             )
         )
-
-        # self.cmd(
-        #     "dt endpoint wait --created -n {} -g {} --en {}".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         servicebus_endpoint
-        #     )
-        # )
-
-        # show_ep_sb_key_output = self.cmd(
-        #     "dt endpoint show -n {} -g {} --en {}".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         servicebus_endpoint
-        #     )
-        # ).get_output_in_json()
-
-        # assert_common_endpoint_attributes(
-        #     show_ep_sb_key_output,
-        #     servicebus_endpoint,
-        #     endpoint_type=ADTEndpointType.servicebus,
-        #     auth_type=ADTEndpointAuthType.keybased,
-        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
-        # )
         endpoint_tuple_collection.append(
             EndpointTuple(
                 servicebus_endpoint,
@@ -472,22 +424,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 MOCK_DEAD_LETTER_ENDPOINT,
             )
         )
-
-        # self.cmd(
-        #     "dt endpoint wait --created -n {} -g {} --en {} --interval 1".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         servicebus_endpoint_msi,
-        #     )
-        # )
-
-        # assert_common_endpoint_attributes(
-        #     add_ep_sb_identity_output,
-        #     servicebus_endpoint_msi,
-        #     endpoint_type=ADTEndpointType.servicebus,
-        #     auth_type=ADTEndpointAuthType.identitybased,
-        #     dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
-        # )
         endpoint_tuple_collection.append(
             EndpointTuple(
                 servicebus_endpoint_msi,
@@ -514,21 +450,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             )
         )
 
-        # self.cmd(
-        #     "dt endpoint wait --created -n {} -g {} --en {} --interval 1".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         eventhub_endpoint,
-        #     )
-        # )
-
-        # assert_common_endpoint_attributes(
-        #     add_ep_output,
-        #     eventhub_endpoint,
-        #     ADTEndpointType.eventhub,
-        #     auth_type=ADTEndpointAuthType.keybased,
-        #     dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
-        # )
         endpoint_tuple_collection.append(
             EndpointTuple(
                 eventhub_endpoint,
@@ -559,22 +480,6 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 eventhub_endpoint_msi,
             )
         )
-
-        # show_ep_output = self.cmd(
-        #     "dt endpoint show -n {} -g {} --en {}".format(
-        #         endpoints_instance_name,
-        #         self.rg,
-        #         eventhub_endpoint_msi,
-        #     )
-        # ).get_output_in_json()
-
-        # assert_common_endpoint_attributes(
-        #     show_ep_output,
-        #     eventhub_endpoint_msi,
-        #     endpoint_type=ADTEndpointType.eventhub,
-        #     auth_type=ADTEndpointAuthType.identitybased,
-        #     dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
-        # )
         endpoint_tuple_collection.append(
             EndpointTuple(
                 eventhub_endpoint_msi,


### PR DESCRIPTION
Added no wait support to:
- az dt create
- az dt endpoint create
- az dt network private-endpoint set

Added needed tests and separated the dt endpoint route tests into one test that focuses on endpoint lifecycles and another one that focuses on route lifecycles.
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
