### PR TITLE
Certops rewrite to use Cryptography

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -690,7 +690,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local,Setting
 # in the environment of the CLI
 ignored-modules=
       azure,azure.cli,azure.cli.core,azure.cli.core.extension,azure.cli.core.commands,
-      knack,six,msrest,msrestazure,OpenSSL,requests,uamqp,yaml,jmespath
+      knack,six,msrest,msrestazure,requests,uamqp,yaml,jmespath
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Release History
 ===============
 
 
+0.14.1
++++++++++++++++
+
+**IoT Hub updates**
+
+* Updated creation for self-signed certificates to use the Cryptography library instead of the PyOpenSSL library.
+
 0.14.0
 +++++++++++++++
 

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -60,7 +60,7 @@ def create_self_signed_certificate(subject, valid_days, cert_output_dir, cert_on
     ).decode('utf-8')
     key_dump = cert.public_bytes(serialization.Encoding.PEM).decode('utf-8')
     thumbprint_bytes = cert.fingerprint(hashes.SHA1())
-    thumbprint = ':'.join(f'{b:02X}' for b in thumbprint_bytes)
+    thumbprint = ''.join(f'{b:02X}' for b in thumbprint_bytes)
 
     if cert_output_dir and exists(cert_output_dir):
         cert_file = subject + '-cert.pem'

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -103,6 +103,7 @@ def open_certificate(certificate_path):
                 certificate = certificate.decode("utf-8")
             except UnicodeError:
                 certificate = base64.b64encode(certificate).decode("utf-8")
-    return (
-        certificate.rstrip()
-    )  # Remove trailing white space from the certificate content
+    else:
+        raise ValueError("Certificate file type must be either '.pem' or '.cer'.")
+    # Remove trailing white space from the certificate content
+    return certificate.rstrip()

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -13,8 +13,7 @@ from os.path import exists, join
 import base64
 from cryptography import x509
 from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -61,8 +61,7 @@ def create_self_signed_certificate(
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("utf-8")
     key_dump = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-    thumbprint_bytes = cert.fingerprint(hashes.SHA1())
-    thumbprint = "".join(f"{b:02X}" for b in thumbprint_bytes)
+    thumbprint = cert.fingerprint(hashes.SHA1()).hex().upper()
 
     if cert_output_dir and exists(cert_output_dir):
         cert_file = subject + "-cert.pem"

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -17,7 +17,9 @@ from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-def create_self_signed_certificate(subject, valid_days, cert_output_dir, cert_only=False):
+def create_self_signed_certificate(
+    subject, valid_days, cert_output_dir, cert_only=False
+):
     """
     Function used to create a self-signed certificate
 
@@ -35,35 +37,36 @@ def create_self_signed_certificate(subject, valid_days, cert_output_dir, cert_on
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     # create a self-signed cert
-    subject_name = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, subject),
-    ])
-    cert = x509.CertificateBuilder().subject_name(
-        subject_name
-    ).issuer_name(
-        subject_name
-    ).public_key(
-        key.public_key()
-    ).serial_number(
-        x509.random_serial_number()
-    ).not_valid_before(
-        datetime.datetime.utcnow()
-    ).not_valid_after(
-        datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
-    ).sign(key, hashes.SHA256())
+    subject_name = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, subject),
+        ]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(
+            datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
+        )
+        .sign(key, hashes.SHA256())
+    )
 
     cert_dump = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
-    ).decode('utf-8')
-    key_dump = cert.public_bytes(serialization.Encoding.PEM).decode('utf-8')
+    ).decode("utf-8")
+    key_dump = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
     thumbprint_bytes = cert.fingerprint(hashes.SHA1())
-    thumbprint = ''.join(f'{b:02X}' for b in thumbprint_bytes)
+    thumbprint = "".join(f"{b:02X}" for b in thumbprint_bytes)
 
     if cert_output_dir and exists(cert_output_dir):
-        cert_file = subject + '-cert.pem'
-        key_file = subject + '-key.pem'
+        cert_file = subject + "-cert.pem"
+        key_file = subject + "-key.pem"
 
         with open(join(cert_output_dir, cert_file), "wt", encoding="utf-8") as f:
             f.write(cert_dump)
@@ -73,9 +76,9 @@ def create_self_signed_certificate(subject, valid_days, cert_output_dir, cert_on
                 f.write(key_dump)
 
     result = {
-        'certificate': cert_dump,
-        'privateKey': key_dump,
-        'thumbprint': thumbprint
+        "certificate": cert_dump,
+        "privateKey": key_dump,
+        "thumbprint": thumbprint,
     }
 
     return result
@@ -93,11 +96,13 @@ def open_certificate(certificate_path):
         certificate (str): returns utf-8 encoded value from certificate file.
     """
     certificate = ""
-    if certificate_path.endswith('.pem') or certificate_path.endswith('.cer'):
+    if certificate_path.endswith(".pem") or certificate_path.endswith(".cer"):
         with open(certificate_path, "rb") as cert_file:
             certificate = cert_file.read()
             try:
                 certificate = certificate.decode("utf-8")
             except UnicodeError:
                 certificate = base64.b64encode(certificate).decode("utf-8")
-    return certificate.rstrip()  # Remove trailing white space from the certificate content
+    return (
+        certificate.rstrip()
+    )  # Remove trailing white space from the certificate content

--- a/azext_iot/tests/conftest.py
+++ b/azext_iot/tests/conftest.py
@@ -423,3 +423,12 @@ def fixture_dps_sas(mocker):
                                mock_dps_target['primarykey'])
     sas = mocker.patch(path_sas)
     sas.return_value = r
+
+
+@pytest.fixture
+def patch_certificate_open(mocker):
+    patch = mocker.patch(
+        "azext_iot.operations.dps.open_certificate"
+    )
+    patch.return_value = ""
+    return patch

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -49,7 +49,7 @@ def generate_enrollment_create_req(attestation_type=None, endorsement_key=None,
 
 class TestEnrollmentCreate():
     @pytest.fixture()
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open):
         mocked_response.add(
             method=responses.PUT,
             url="https://{}/enrollments/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -61,7 +61,7 @@ class TestEnrollmentCreate():
         yield mocked_response
 
     @pytest.fixture(params=[400, 401, 500])
-    def serviceclient_generic_error(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient_generic_error(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.PUT,
             url="https://{}/enrollments/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -340,7 +340,7 @@ def generate_enrollment_update_req(certificate_path=None, iot_hub_host_name=None
 
 class TestEnrollmentUpdate():
     @pytest.fixture()
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         # Initial GET
         mocked_response.add(
             method=responses.GET,
@@ -464,7 +464,7 @@ class TestEnrollmentUpdate():
 
 class TestEnrollmentShow():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.GET,
             url="https://{}/enrollments/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -477,7 +477,7 @@ class TestEnrollmentShow():
         yield mocked_response
 
     @pytest.fixture()
-    def serviceclient_attestation(self, mocked_response, fixture_gdcs, fixture_dps_sas):
+    def serviceclient_attestation(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open):
         mocked_response.add(
             method=responses.GET,
             url="https://{}/enrollments/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -552,7 +552,7 @@ class TestEnrollmentShow():
 
 class TestEnrollmentList():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.POST,
             url="https://{}/enrollments/query?".format(mock_dps_target['entity']),
@@ -592,7 +592,7 @@ class TestEnrollmentList():
 
 class TestEnrollmentDelete():
     @pytest.fixture(params=[204])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.DELETE,
             url="https://{}/enrollments/{}".format(mock_dps_target['entity'], enrollment_id),

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
@@ -59,7 +59,7 @@ def generate_enrollment_group_create_req(iot_hub_host_name=None,
 
 class TestEnrollmentGroupCreate():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.PUT,
             url="https://{}/enrollmentGroups/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -322,7 +322,7 @@ def generate_enrollment_group_update_req(iot_hub_host_name=None,
 
 class TestEnrollmentGroupUpdate():
     @pytest.fixture(params=[(200, generate_enrollment_group_show(), 200)])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         # Initial GET
         mocked_response.add(
             method=responses.GET,
@@ -498,7 +498,7 @@ class TestEnrollmentGroupUpdate():
 
 class TestEnrollmentGroupShow():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.GET,
             url="https://{}/enrollmentGroups/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -510,7 +510,7 @@ class TestEnrollmentGroupShow():
         yield mocked_response
 
     @pytest.fixture()
-    def serviceclient_attestation(self, mocked_response, fixture_gdcs, fixture_dps_sas):
+    def serviceclient_attestation(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open):
         mocked_response.add(
             method=responses.GET,
             url="https://{}/enrollmentGroups/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -583,7 +583,7 @@ class TestEnrollmentGroupShow():
 
 class TestEnrollmentGroupList():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.POST,
             url="https://{}/enrollmentGroups/query?".format(mock_dps_target['entity']),
@@ -622,7 +622,7 @@ class TestEnrollmentGroupList():
 
 class TestEnrollmentGroupDelete():
     @pytest.fixture(params=[204])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.DELETE,
             url="https://{}/enrollmentGroups/{}".format(mock_dps_target['entity'], enrollment_id),
@@ -670,7 +670,7 @@ def generate_registration_state_show():
 
 class TestRegistrationShow():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.GET,
             url="https://{}/registrations/{}?".format(mock_dps_target['entity'], registration_id),
@@ -707,7 +707,7 @@ class TestRegistrationShow():
 
 class TestRegistrationList():
     @pytest.fixture(params=[200])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.POST,
             url="https://{}/registrations/{}/query?".format(mock_dps_target['entity'], enrollment_id),
@@ -743,7 +743,7 @@ class TestRegistrationList():
 
 class TestRegistrationDelete():
     @pytest.fixture(params=[204])
-    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, request):
+    def serviceclient(self, mocked_response, fixture_gdcs, fixture_dps_sas, patch_certificate_open, request):
         mocked_response.add(
             method=responses.DELETE,
             url="https://{}/registrations/{}".format(mock_dps_target['entity'], registration_id),


### PR DESCRIPTION
Rewrite certops.py to use the cryptography library rather than the pyopenssl library. This solves the issue of having to uninstall and reinstall both libraries because they cannot be installed correctly the first time.

Before:
![image](https://user-images.githubusercontent.com/73560279/163645448-69ab2947-15e0-4211-80d9-677af9eea1de.png)

After:
![image](https://user-images.githubusercontent.com/73560279/163646156-e01bc60c-96b9-46a2-a9c0-bfa789afed0c.png)


Pipeline run
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=5449&view=results

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
