### PR TITLE
Add DPS Individual Enrollment Registration subgroup

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,13 @@ Release History
 
 * Updated creation for self-signed certificates to use the Cryptography library instead of the PyOpenSSL library.
 
+**IoT DPS updates**
+
+* Added registration commands for individual enrollment groups:
+    - az iot dps enrollment registration show
+    - az iot dps enrollment registration delete
+
+
 0.14.0
 +++++++++++++++
 

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -1233,6 +1233,30 @@ helps[
 """
 
 helps[
+    "iot dps enrollment registration"
+] = """
+    type: group
+    short-summary: Manage device registrations for an individual enrollment in an Azure IoT Hub Device
+        Provisioning Service.
+"""
+
+helps[
+    "iot dps enrollment registration show"
+] = """
+    type: command
+    short-summary: Get a device registration for an individual enrollment in an Azure IoT Hub Device
+        Provisioning Service.
+"""
+
+helps[
+    "iot dps enrollment registration delete"
+] = """
+    type: command
+    short-summary: Delete a device registration for an individual enrollment in an Azure IoT Hub Device
+        Provisioning Service.
+"""
+
+helps[
     "iot dps enrollment-group"
 ] = """
     type: group

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -1023,6 +1023,13 @@ def load_arguments(self, _):
             help="TPM endorsement key for a TPM device.",
         )
 
+    with self.argument_context("iot dps enrollment registration") as context:
+        context.argument(
+            "registration_id",
+            options_list=["--enrollment-id", "--eid"],
+            help="Individual device enrollment ID."
+        )
+
     with self.argument_context("iot dps enrollment-group") as context:
         context.argument(
             "enrollment_id",

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -181,6 +181,12 @@ def load_command_table(self, _):
         cmd_group.command("delete", "iot_dps_device_enrollment_delete")
 
     with self.command_group(
+        "iot dps enrollment registration", command_type=iotdps_ops
+    ) as cmd_group:
+        cmd_group.show_command("show", "iot_dps_registration_get")
+        cmd_group.command("delete", "iot_dps_registration_delete")
+
+    with self.command_group(
         "iot dps enrollment-group", command_type=iotdps_ops
     ) as cmd_group:
         cmd_group.command("create", "iot_dps_device_enrollment_group_create")


### PR DESCRIPTION
Paymaun discovered that registration show and delete work for individual enrollments too (but list only works for enrollment groups). Instead of un-grouping registration from enrollment-groups and confusing everyone, we agreed to add registration as a group under enrollments.

Added registration group:
![image](https://user-images.githubusercontent.com/73560279/166007970-bb4f36dd-b04c-43f3-8ab6-0eb085417d6a.png)


In the case of the registration commands for individual enrollments, registration_id is the same as enrollment_id:
![image](https://user-images.githubusercontent.com/73560279/166008127-e0b2e181-e4c8-40aa-96b4-caff63286c62.png)

Compared to the enrollment-group:
![image](https://user-images.githubusercontent.com/73560279/166008226-314cbb06-2b48-4eab-b636-0352e1ef0c61.png)

This is to avoid the mental hoops needed to jump through to figure out what registration id is.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
