### PR TITLE
Support --model-id in device simulation. Prepare ADU CLI control plane with no flag.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,9 @@ unreleased
 * The **in preview** `az iot device-update` command group is now always available.
   No environment variable is needed for activation.
 
+  - The Device Update command group supports all `account` and `instance` related functionality against
+    control plane API version 2022-04-01-preview.
+
 **Digital Twin updates**
 
 * Updated `az dt model create` command to process input ontologies larger than 250 models in a single command run.
@@ -23,7 +26,9 @@ unreleased
 **IoT Central updates**
 
 * Add support for device groups CRUD.
+
   - az iot central device-group
+
     - az iot central device-group list
     - az iot central device-group show
     - az iot central device-group create
@@ -31,23 +36,30 @@ unreleased
     - az iot central device-group update
 
 * Add support for device attestation CRUD.
+
   - az iot central device attestation
+
     - az iot central device attestation show
     - az iot central device attestation create
     - az iot central device attestation delete
     - az iot central device attestation update
 
 * Add support for device/module properties/telemetry/command.
+
   - az iot central device list-components
   - az iot central device list-modules
   - az iot central device telemetry
+
     - az iot central device telemetry show
+
   - az iot central device twin
+
     - az iot central device twin show
     - az iot central device twin update
     - az iot central device twin replace
 
 * Add support for 2022-05-31 GA version.
+
   - az iot central api-token
   - az iot central device-template
   - az iot central device-group
@@ -78,7 +90,8 @@ unreleased
  
   - This command group is behind a feature flag environment variable. Set `IOT_CLI_ADU_ENABLED` to any value
     to activate the command group.
-  - The Device Update command group supports all `account` and `instance` related functionality.
+  - The Device Update command group supports all `account` and `instance` related functionality against
+    control plane API version 2022-04-01-preview.
 
 **IoT device updates**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,15 @@ Release History
 unreleased
 +++++++++++++++
 
+
+0.16.0
++++++++++++++++
+
+**Device Update**
+
+* The **in preview** `az iot device-update` command group is now always available.
+  No environment variable is needed for activation.
+
 **Digital Twin updates**
 
 * Updated `az dt model create` command to process input ontologies larger than 250 models in a single command run.
@@ -48,6 +57,11 @@ unreleased
   - az iot central role
   - az iot central user
 
+**IoT device updates**
+
+* `az iot device simulate` supports a `--model-id` argument. The model Id is used by a device to advertise the
+  digital twin interface it implements.
+
 
 0.15.0
 +++++++++++++++
@@ -59,14 +73,14 @@ unreleased
 
 **Device Update**
 
-* Introducing the Azure Device Update for IoT Hub root command group `az iot device-update`.
+* Introducing the **in preview** Azure Device Update for IoT Hub root command group `az iot device-update`.
   To learn more about the service visit https://docs.microsoft.com/en-us/azure/iot-hub-device-update/.
  
   - This command group is behind a feature flag environment variable. Set `IOT_CLI_ADU_ENABLED` to any value
     to activate the command group.
   - The Device Update command group supports all `account` and `instance` related functionality.
 
-**IoT Device updates**
+**IoT device updates**
 
 * Added device registration commands, `az iot device registration create` to register a device to an individual
   enrollment or an enrollment group. Currently, devices with symmetric key and x509 certificate authentication

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -71,8 +71,8 @@ unreleased
 
 **IoT device updates**
 
-* `az iot device simulate` supports a `--model-id` argument. The model Id is used by a device to advertise the
-  digital twin interface it implements.
+* `az iot device simulate` and `az iot device send-d2c-message` support a `--model-id` argument.
+  The model Id is used by a device to advertise the digital twin interface it implements.
 
 
 0.15.0

--- a/azext_iot/__init__.py
+++ b/azext_iot/__init__.py
@@ -9,7 +9,6 @@ from azure.cli.core.commands import CliCommandType
 from azext_iot.constants import VERSION
 import azext_iot._help  # noqa: F401
 from azext_iot.product.command_map import load_product_commands
-import os
 
 
 iothub_ops = CliCommandType(operations_tmpl="azext_iot.operations.hub#{}")

--- a/azext_iot/__init__.py
+++ b/azext_iot/__init__.py
@@ -26,12 +26,10 @@ class IoTExtCommandsLoader(AzCommandsLoader):
         from azext_iot.central.command_map import load_central_commands
         from azext_iot.digitaltwins.command_map import load_digitaltwins_commands
         from azext_iot.dps.command_map import load_dps_commands
-
-        if os.environ.get("IOT_CLI_ADU_ENABLED"):
-            from azext_iot.deviceupdate.command_map import load_deviceupdate_commands
-            load_deviceupdate_commands(self, args)
+        from azext_iot.deviceupdate.command_map import load_deviceupdate_commands
 
         load_command_table(self, args)
+        load_deviceupdate_commands(self, args)
         load_iothub_commands(self, args)
         load_central_commands(self, args)
         load_digitaltwins_commands(self, args)

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -153,12 +153,6 @@ def load_arguments(self, _):
             help="Json payload to be passed to method. Must be file path or raw json.",
         )
         context.argument(
-            "timeout",
-            options_list=["--timeout", "--to"],
-            type=int,
-            help="Maximum number of seconds to wait for device method result.",
-        )
-        context.argument(
             "method_connect_timeout",
             options_list=["--method-connect-timeout", "--mct"],
             type=int,
@@ -300,6 +294,22 @@ def load_arguments(self, _):
             "auth_type_dataplane",
             options_list=["--auth-type"],
             arg_type=hub_auth_type_dataplane_param_type,
+        )
+
+    with self.argument_context("iot hub invoke-device-method") as context:
+        context.argument(
+            "timeout",
+            options_list=["--timeout", "--to"],
+            type=int,
+            help="Maximum number of seconds to wait for the device method result.",
+        )
+
+    with self.argument_context("iot hub invoke-module-method") as context:
+        context.argument(
+            "timeout",
+            options_list=["--timeout", "--to"],
+            type=int,
+            help="Maximum number of seconds to wait for the module method result.",
         )
 
     with self.argument_context("iot hub connection-string") as context:

--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -597,3 +597,17 @@ def ensure_azure_namespace_path():
         sys.path.insert(0, ext_path)
 
     return
+
+
+def is_valid_dtmi(dtmi):
+    """Checks validity of a DTMI
+    :param str dtmi: DTMI
+    :returns: Boolean indicating if DTMI is valid
+    :rtype: bool
+    """
+    pattern = re.compile(
+        "^dtmi:[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?(?::[A-Za-z](?:[A-Za-z0-9_]*[A-Za-z0-9])?)*;[1-9][0-9]{0,8}$"
+    )
+    if not pattern.match(dtmi):
+        return False
+    return True

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.15.0"
+VERSION = "0.16.0"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -211,6 +211,11 @@ def load_deviceupdate_help():
         - name: Set a specific instance tag attribute.
           text: >
             az iot device-update instance update -n {account_name} -i {instance_name} --set tags.env='test'
+
+        - name: Enable diagnostics and configure a storage account for log collection.
+          text: >
+            az iot device-update instance update -n {account_name} -i {instance_name} --set enableDiagnostics=true
+            diagnosticStorageProperties.resourceId={storage_account_resource_id}
     """
 
     helps["iot device-update instance show"] = """

--- a/azext_iot/deviceupdate/commands_instance.py
+++ b/azext_iot/deviceupdate/commands_instance.py
@@ -56,17 +56,20 @@ def update_instance(cmd, parameters: DeviceUpdateMgmtModels.Instance):
     instance_manager = DeviceUpdateInstanceManager(cmd=cmd)
     storage_properties = parameters.diagnostic_storage_properties
     if storage_properties:
-        is_dict = isinstance(storage_properties, dict)
-        authentication_type = (
-            storage_properties.get("authenticationType") if is_dict else storage_properties.authentication_type
-        )
+        # Storage properties can be a dict or DeviceUpdateMgmtModels.DiagnosticStorageProperties
+        # depending on how the CLI core generic update helpers are used i.e. --set with an existing object vs new.
+        if isinstance(storage_properties, dict):
+            authentication_type = storage_properties.get("authenticationType")
+            resource_id = storage_properties.get("resourceId")
+            connection_string = storage_properties.get("connectionString")
+        else:
+            authentication_type = storage_properties.authentication_type
+            resource_id = storage_properties.resource_id
+            connection_string = storage_properties.connection_string
+
         if not authentication_type:
             authentication_type = ADUInstanceDiagnosticStorageAuthType.KEYBASED.value
 
-        resource_id = storage_properties.get("resourceId") if is_dict else storage_properties.resource_id
-        connection_string = (
-            storage_properties.get("connectionString") if is_dict else storage_properties.connection_string
-        )
         if (
             authentication_type == ADUInstanceDiagnosticStorageAuthType.KEYBASED.value
             and resource_id

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -272,6 +272,8 @@ def load_iothub_help():
         examples:
         - name: Basic usage (mqtt)
           text: az iot device simulate -n {iothub_name} -d {device_id}
+        - name: Basic usage for device registering the model Id of 'dtmi:com:example:Thermostat;1' upon connection (mqtt)
+          text: az iot device simulate -n {iothub_name} -d {device_id} --model-id 'dtmi:com:example:Thermostat;1'
         - name: Basic usage for device with x509 authentication (mqtt)
           text: az iot device simulate -n {iothub_name} -d {device_id} --cp {certificate_file_path} --kp {key_file_path}
         - name: Basic usage for device with x509 authentication (mqtt) in which the key file has a passphrase

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -243,6 +243,8 @@ def load_iothub_help():
         examples:
         - name: Basic usage
           text: az iot device send-d2c-message -n {iothub_name} -d {device_id}
+        - name: Basic usage for device registering the model Id of 'dtmi:com:example:Thermostat;1' upon connection
+          text: az iot device send-d2c-message -n {iothub_name} -d {device_id} --model-id 'dtmi:com:example:Thermostat;1'
         - name: Basic usage for device with x509 authentication
           text: az iot device send-d2c-message -n {iothub_name} -d {device_id} --cp {certificate_file_path} --kp {key_file_path}
         - name: Basic usage for device with x509 authentication in which the key file has a passphrase

--- a/azext_iot/iothub/_validators.py
+++ b/azext_iot/iothub/_validators.py
@@ -12,8 +12,8 @@ def validate_device_model_id(namespace: Namespace):
     if hasattr(namespace, 'model_id'):
         from azext_iot.common.utility import is_valid_dtmi
         model_id = namespace.model_id
-        if not(is_valid_dtmi(model_id)):
+        if model_id and not(is_valid_dtmi(model_id)):
             raise InvalidArgumentValueError(
-                "Invalid dtmi value provided. A valid dtmi will look like "
+                f"Invalid dtmi value '{model_id}' provided. A valid dtmi will look like "
                 "'dtmi:com:example:TemperatureController;1'. "
                 "See https://github.com/Azure/digital-twin-model-identifier for more details.")

--- a/azext_iot/iothub/_validators.py
+++ b/azext_iot/iothub/_validators.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from argparse import Namespace
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+
+def validate_device_model_id(namespace: Namespace):
+    if hasattr(namespace, 'model_id'):
+        from azext_iot.common.utility import is_valid_dtmi
+        model_id = namespace.model_id
+        if not(is_valid_dtmi(model_id)):
+            raise InvalidArgumentValueError(
+                "Invalid dtmi value provided. A valid dtmi will look like "
+                "'dtmi:com:example:TemperatureController;1'. "
+                "See https://github.com/Azure/digital-twin-model-identifier for more details.")

--- a/azext_iot/iothub/commands_device_messaging.py
+++ b/azext_iot/iothub/commands_device_messaging.py
@@ -183,6 +183,7 @@ def iot_simulate_device(
     hub_name: Optional[str] = None,
     resource_group_name: Optional[str] = None,
     login: Optional[str] = None,
+    model_id: Optional[str] = None,
 ):
     messaging_provider = DeviceMessagingProvider(
         cmd=cmd, device_id=device_id, hub_name=hub_name, rg=resource_group_name, login=login
@@ -200,7 +201,8 @@ def iot_simulate_device(
         passphrase=passphrase,
         method_response_code=method_response_code,
         method_response_payload=method_response_payload,
-        init_reported_properties=init_reported_properties
+        init_reported_properties=init_reported_properties,
+        model_id=model_id
     )
 
 

--- a/azext_iot/iothub/commands_device_messaging.py
+++ b/azext_iot/iothub/commands_device_messaging.py
@@ -24,6 +24,7 @@ def iot_device_send_message(
     hub_name: Optional[str] = None,
     resource_group_name: Optional[str] = None,
     login: Optional[str] = None,
+    model_id: Optional[str] = None,
 ):
     messaging_provider = DeviceMessagingProvider(
         cmd=cmd, device_id=device_id, hub_name=hub_name, rg=resource_group_name, login=login
@@ -35,7 +36,8 @@ def iot_device_send_message(
         device_symmetric_key=device_symmetric_key,
         certificate_file=certificate_file,
         key_file=key_file,
-        passphrase=passphrase
+        passphrase=passphrase,
+        model_id=model_id,
     )
 
 

--- a/azext_iot/iothub/params.py
+++ b/azext_iot/iothub/params.py
@@ -114,6 +114,14 @@ def load_iothub_arguments(self, _):
             arg_group="Device Authentication",
             help="Passphrase for key file.",
         )
+        context.argument(
+            "model_id",
+            options_list=["--model-id", "--dtmi"],
+            help="The Digital Twin Model Id the device will report when connecting to the hub. See "
+            "https://docs.microsoft.com/en-us/azure/iot-develop/overview-iot-plug-and-play for more details.",
+            arg_group="Digital Twin",
+            validator=validate_device_model_id,
+        )
 
     with self.argument_context("iot device simulate") as context:
         context.argument(
@@ -138,14 +146,6 @@ def load_iothub_arguments(self, _):
             options_list=["--init-reported-properties", "--irp"],
             help="Initial state of twin reported properties for the target device when the simulator is run. "
             "Optional param, only supported for mqtt.",
-        )
-        context.argument(
-            "model_id",
-            options_list=["--model-id", "--dtmi"],
-            help="The Digital Twin Model Id the device will report when connecting to the hub. See "
-            "https://docs.microsoft.com/en-us/azure/iot-develop/overview-iot-plug-and-play for more details.",
-            arg_group="Digital Twin",
-            validator=validate_device_model_id,
         )
 
     with self.argument_context("iot device c2d-message") as context:

--- a/azext_iot/iothub/params.py
+++ b/azext_iot/iothub/params.py
@@ -8,6 +8,7 @@ from azure.cli.core.commands.parameters import get_enum_type, get_three_state_fl
 from azext_iot.common.shared import SettleType, ProtocolType, AckType
 from azext_iot.assets.user_messages import info_param_properties_device
 from azext_iot._params import hub_auth_type_dataplane_param_type
+from azext_iot.iothub._validators import validate_device_model_id
 
 
 def load_iothub_arguments(self, _):
@@ -141,8 +142,10 @@ def load_iothub_arguments(self, _):
         context.argument(
             "model_id",
             options_list=["--model-id", "--dtmi"],
-            help="The Digital Twin Model Id the device will report when connecting to the hub.",
-            arg_group="Digital Twin"
+            help="The Digital Twin Model Id the device will report when connecting to the hub. See "
+            "https://docs.microsoft.com/en-us/azure/iot-develop/overview-iot-plug-and-play for more details.",
+            arg_group="Digital Twin",
+            validator=validate_device_model_id,
         )
 
     with self.argument_context("iot device c2d-message") as context:

--- a/azext_iot/iothub/params.py
+++ b/azext_iot/iothub/params.py
@@ -138,6 +138,12 @@ def load_iothub_arguments(self, _):
             help="Initial state of twin reported properties for the target device when the simulator is run. "
             "Optional param, only supported for mqtt.",
         )
+        context.argument(
+            "model_id",
+            options_list=["--model-id", "--dtmi"],
+            help="The Digital Twin Model Id the device will report when connecting to the hub.",
+            arg_group="Digital Twin"
+        )
 
     with self.argument_context("iot device c2d-message") as context:
         context.argument(

--- a/azext_iot/iothub/providers/device_messaging.py
+++ b/azext_iot/iothub/providers/device_messaging.py
@@ -290,7 +290,8 @@ class DeviceMessagingProvider(IoTHubProvider):
         passphrase: Optional[str] = None,
         method_response_code: Optional[str] = None,
         method_response_payload: Optional[str] = None,
-        init_reported_properties: Optional[str] = None
+        init_reported_properties: Optional[str] = None,
+        model_id: Optional[str] = None,
     ):
         import sys
         import uuid
@@ -333,6 +334,10 @@ class DeviceMessagingProvider(IoTHubProvider):
                 raise ArgumentUsageError(
                     "'certificate-file', 'key-file', and 'passphrase' not supported, {} doesn't allow x509 "
                     "certificate authentication".format(protocol_type)
+                )
+            if model_id:
+                raise ArgumentUsageError(
+                    f"`model-id` is not supported with {protocol_type} protocol."
                 )
 
         properties_to_send = _simulate_get_default_properties(protocol_type)
@@ -388,7 +393,8 @@ class DeviceMessagingProvider(IoTHubProvider):
                     device_id=self.device_id,
                     method_response_code=method_response_code,
                     method_response_payload=method_response_payload,
-                    init_reported_properties=init_reported_properties
+                    init_reported_properties=init_reported_properties,
+                    model_id=model_id
                 )
                 client_mqtt.execute(
                     data=generator(),

--- a/azext_iot/iothub/providers/device_messaging.py
+++ b/azext_iot/iothub/providers/device_messaging.py
@@ -61,6 +61,7 @@ class DeviceMessagingProvider(IoTHubProvider):
         certificate_file: Optional[str] = None,
         key_file: Optional[str] = None,
         passphrase: Optional[str] = None,
+        model_id: Optional[str] = None,
     ):
         from azext_iot.iothub.providers.mqtt import MQTTProvider
 
@@ -78,7 +79,8 @@ class DeviceMessagingProvider(IoTHubProvider):
             hub_hostname=self.target["entity"],
             device_conn_string=device_connection_string,
             x509_files=device["authentication"].get("x509_files"),
-            device_id=self.device_id
+            device_id=self.device_id,
+            model_id=model_id
         )
         for _ in range(msg_count):
             client_mqtt.send_d2c_message(message_text=data, properties=properties)

--- a/azext_iot/iothub/providers/mqtt.py
+++ b/azext_iot/iothub/providers/mqtt.py
@@ -23,7 +23,8 @@ class MQTTProvider(object):
         x509_files: Optional[Dict[str, str]] = None,
         method_response_code: Optional[str] = None,
         method_response_payload: Optional[str] = None,
-        init_reported_properties: Optional[str] = None
+        init_reported_properties: Optional[str] = None,
+        **kwargs: Any,
     ):
         ensure_azure_namespace_path()
         from azure.iot.device import IoTHubDeviceClient as mqtt_device_client
@@ -40,14 +41,16 @@ class MQTTProvider(object):
                 ),
                 hostname=hub_hostname,
                 device_id=self.device_id,
-                websockets=True
+                websockets=True,
+                product_info=kwargs.get("model_id", None),
             )
         elif "x509=true" in device_conn_string:
             raise RequiredArgumentMissingError("Please provide the certificate and key files for the device.")
         else:
             self.device_client = mqtt_device_client.create_from_connection_string(
                 device_conn_string,
-                websockets=True
+                websockets=True,
+                product_info=kwargs.get("model_id", None),
             )
         self.device_client.on_message_received = self.message_handler
         self.device_client.on_method_request_received = self.method_request_handler

--- a/azext_iot/tests/conftest.py
+++ b/azext_iot/tests/conftest.py
@@ -254,31 +254,6 @@ def fixture_device_messaging_iot_device_show_sas(mocker):
     return device
 
 
-@pytest.fixture()
-def fixture_self_signed_device_show_self_signed(mocker):
-    device = mocker.patch(path_iot_device_show)
-    device.return_value = {
-        "authentication": {
-            "symmetricKey": {"primaryKey": "test_pk", "secondaryKey": "test_sk"},
-            "type": DeviceAuthApiType.selfSigned.value,
-            "x509Thumbprint": {"primaryThumbprint": None, "secondaryThumbprint": None},
-        },
-        "capabilities": {"iotEdge": False},
-        "cloudToDeviceMessageCount": 0,
-        "connectionState": "Disconnected",
-        "connectionStateUpdatedTime": "2021-05-27T00:36:11.2861732Z",
-        "deviceId": "Test_Device_1",
-        "etag": "ODgxNTgwOA==",
-        "generationId": "637534345627501371",
-        "hub": "test-iot-hub.azure-devices.net",
-        "lastActivityTime": "2021-05-27T00:18:16.3154299Z",
-        "status": "enabled",
-        "statusReason": None,
-        "statusUpdatedTime": "0001-01-01T00:00:00Z",
-    }
-    return device
-
-
 # TODO: To be deprecated asap. Leverage mocked_response fixture for this functionality.
 def build_mock_response(
     mocker=None, status_code=200, payload=None, headers=None, **kwargs

--- a/azext_iot/tests/deviceupdate/test_adu_account_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_account_int.py
@@ -12,12 +12,9 @@ from azext_iot.tests.deviceupdate.conftest import (
     generate_account_id
 )
 from typing import Dict
-import os
+
 
 cli = EmbeddedCLI()
-
-if not os.environ.get("IOT_CLI_ADU_ENABLED"):
-    pytest.skip("ADU behind feature flag.", allow_module_level=True)
 
 
 @pytest.mark.adu_infrastructure(location="eastus2euap", count=2, delete=False)
@@ -71,11 +68,14 @@ def test_account_create_identity_system_assign_scope(provisioned_accounts: Dict[
 def test_account_create_custom():
     # Test create --no-wait/wait combo.
     target_account_name = generate_account_id()
+    # @digimaun - We can uncomment once we have more capacity in none eastus2euap location.
+    # group = cli.invoke(f"group show -n {ACCOUNT_RG}").as_json()
     cli.invoke(f"iot device-update account create -n {target_account_name} -g {ACCOUNT_RG} -l eastus2euap --no-wait")
     cli.invoke(f"iot device-update account wait -n {target_account_name} --created")
     account = cli.invoke(f"iot device-update account show -n {target_account_name}").as_json()
     assert account["provisioningState"] == "Succeeded"
     assert account["name"] == target_account_name
+    # assert account["location"] == group["location"]
     cli.invoke(f"iot device-update account delete -n {target_account_name} -y --no-wait")
 
 
@@ -107,15 +107,14 @@ def test_account_private_links_endpoint_connections(provisioned_accounts: Dict[s
     target_account_name = list(provisioned_accounts["accounts"].keys())[0]
     # There is a single command for private link resources
     expected_links = ["DeviceUpdate"]
-    # @digimaun - private-link-resource operations currently error in the API.
-    # link_resources: list = cli.invoke(
-    #     f"iot device-update account private-link-resource list -n {target_account_name}").as_json()
-    # assert len(link_resources) > 0
-    # link_map = {}
-    # for link in link_resources:
-    #     link_map[link["groupId"]] = 1
-    # for expected_link in expected_links:
-    #     assert expected_link in link_map
+    link_resources: list = cli.invoke(
+        f"iot device-update account private-link-resource list -n {target_account_name}").as_json()
+    assert len(link_resources) > 0
+    link_map = {}
+    for link in link_resources:
+        link_map[link["groupId"]] = 1
+    for expected_link in expected_links:
+        assert expected_link in link_map
 
     nsg_name = generate_generic_id()
     vnet_name = generate_generic_id()
@@ -126,7 +125,6 @@ def test_account_private_links_endpoint_connections(provisioned_accounts: Dict[s
     try:
         cli.invoke(f"network nsg create -n {nsg_name} -g {ACCOUNT_RG}").as_json()  # Will fail if not succesful
         cli.invoke(f"network vnet create -n {vnet_name} -g {ACCOUNT_RG} --subnet-name {subnet_name} --nsg {nsg_name}").as_json()
-
         cli.invoke(
             f"network private-endpoint create --connection-name {conn_name} -n {endpoint_name} "
             f"--private-connection-resource-id {provisioned_accounts['accounts'][target_account_name]['id']} "

--- a/azext_iot/tests/deviceupdate/test_adu_account_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_account_int.py
@@ -68,7 +68,7 @@ def test_account_create_identity_system_assign_scope(provisioned_accounts: Dict[
 def test_account_create_custom():
     # Test create --no-wait/wait combo.
     target_account_name = generate_account_id()
-    # @digimaun - We can uncomment once we have more capacity in none eastus2euap location.
+    # @digimaun - We can uncomment once we have more capacity in non-eastus2euap locations.
     # group = cli.invoke(f"group show -n {ACCOUNT_RG}").as_json()
     cli.invoke(f"iot device-update account create -n {target_account_name} -g {ACCOUNT_RG} -l eastus2euap --no-wait")
     cli.invoke(f"iot device-update account wait -n {target_account_name} --created")

--- a/azext_iot/tests/deviceupdate/test_adu_instance_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_instance_int.py
@@ -9,27 +9,25 @@ from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.tests.deviceupdate.conftest import ACCOUNT_RG
 from azext_iot.tests.generators import generate_generic_id
 from typing import Dict
-import os
+
 
 cli = EmbeddedCLI()
-
-if not os.environ.get("IOT_CLI_ADU_ENABLED"):
-    pytest.skip("ADU behind feature flag.", allow_module_level=True)
-
 
 #  Instance creation and manipulation takes an extra long time overhead.
 #  Therefore we are aiming to provision instance resources conservatively.
 
 
 #  Currently only 1 iothub can be created per instance, even though the API definition shows a collection.
+
 @pytest.mark.adu_infrastructure(location="eastus2euap", instance_count=2)
-def test_instance_show_list_update_delete(provisioned_instances: Dict[str, dict]):
+def test_instance_list_show_delete(provisioned_instances: Dict[str, dict]):
     for account_record in provisioned_instances.keys():
         instance_names = list(provisioned_instances[account_record].keys())
         instance_list_result: list = cli.invoke(f"iot device-update instance list -n {account_record}").as_json()
         assert len(instance_names) == len(instance_list_result)
         for instance in instance_list_result:
             assert instance["name"] in instance_names
+            assert cli.invoke(f"iot device-update instance show -n {account_record} -i {instance['name']}").success()
         instance_list_by_group_result: list = cli.invoke(
             f"iot device-update instance list -n {account_record} -g {ACCOUNT_RG}"
         ).as_json()
@@ -52,30 +50,41 @@ def test_instance_show_list_update_delete(provisioned_instances: Dict[str, dict]
 @pytest.mark.adu_infrastructure(
     location="eastus2euap", instance_count=1, instance_diagnostics=True, instance_diagnostics_user_storage=True
 )
-def test_instance_create_custom_storage_update_show_delete(provisioned_instances: Dict[str, dict]):
-    for account_record in provisioned_instances.keys():
-        instance_names = list(provisioned_instances[account_record].keys())
-        random_tag1 = generate_generic_id()
-        random_tag2 = generate_generic_id()
-        updated_instance: dict = cli.invoke(
-            f"iot device-update instance update -n {account_record} -i {instance_names[0]} --set tags.env1={random_tag1}"
-        ).as_json()
-        assert updated_instance["provisioningState"] == "Succeeded"
-        assert updated_instance["tags"]["env1"] == random_tag1
-        cli.invoke(
-            f"iot device-update instance update -n {account_record} -i {instance_names[0]} "
-            f"-g {ACCOUNT_RG} --set tags.env2={random_tag2} enableDiagnostics=false --no-wait"
-        )
-        cli.invoke(f"iot device-update instance wait -n {account_record} -i {instance_names[0]} --updated")
-        shown_instance: dict = cli.invoke(f"iot device-update instance show -n {account_record} -i {instance_names[0]}").as_json()
-        assert shown_instance["provisioningState"] == "Succeeded"
-        assert shown_instance["tags"]["env1"] == random_tag1
-        assert shown_instance["tags"]["env2"] == random_tag2
-        assert shown_instance["enableDiagnostics"] is False
-        assert shown_instance["id"] == provisioned_instances[account_record][instance_names[0]]["id"]
-        assert shown_instance["accountName"] == account_record
-        # delete synchronously
-        assert cli.invoke(f"iot device-update instance delete -n {account_record} -i {instance_names[0]} -y").success()
-        assert not cli.invoke(
-            f"iot device-update instance show -n {account_record} -i {instance_names[0]} -g {ACCOUNT_RG}"
-        ).success()
+def test_instance_custom_storage_update_show_delete(provisioned_instances: Dict[str, dict]):
+    account_name = list(provisioned_instances.keys())[0]
+    instance_name = list(provisioned_instances[account_name].keys())[0]
+    random_tag1 = generate_generic_id()
+    random_tag2 = generate_generic_id()
+    # Fetch backing storage account
+    storage_resource_id = cli.invoke(f"iot device-update instance show -n {account_name} -i {instance_name}").as_json()[
+        "diagnosticStorageProperties"
+    ]["resourceId"]
+    # Set tag, disable diagnostics and remove existing diagnostic storage account.
+    updated_instance: dict = cli.invoke(
+        f"iot device-update instance update -n {account_name} -i {instance_name} --set tags.env1={random_tag1} "
+        "diagnosticStorageProperties=null enableDiagnostics=false"
+    ).as_json()
+    assert updated_instance["provisioningState"] == "Succeeded"
+    assert updated_instance["tags"]["env1"] == random_tag1
+    assert updated_instance["enableDiagnostics"] is False
+    assert updated_instance["diagnosticStorageProperties"] is None
+    # Set another tag, enable diagnostics and re-add existing storage account.
+    cli.invoke(
+        f"iot device-update instance update -n {account_name} -i {instance_name} "
+        f"-g {ACCOUNT_RG} --set tags.env2={random_tag2} enableDiagnostics=true "
+        f"diagnosticStorageProperties.resourceId={storage_resource_id} --no-wait"
+    )
+    cli.invoke(f"iot device-update instance wait -n {account_name} -i {instance_name} --updated")
+    shown_instance: dict = cli.invoke(f"iot device-update instance show -n {account_name} -i {instance_name}").as_json()
+    assert shown_instance["provisioningState"] == "Succeeded"
+    assert shown_instance["tags"]["env1"] == random_tag1
+    assert shown_instance["tags"]["env2"] == random_tag2
+    assert shown_instance["enableDiagnostics"] is True
+    assert shown_instance["diagnosticStorageProperties"]["resourceId"] == storage_resource_id
+    assert shown_instance["id"] == provisioned_instances[account_name][instance_name]["id"]
+    assert shown_instance["accountName"] == account_name
+    # Delete synchronously
+    assert cli.invoke(f"iot device-update instance delete -n {account_name} -i {instance_name} -y").success()
+    assert not cli.invoke(
+        f"iot device-update instance show -n {account_name} -i {instance_name} -g {ACCOUNT_RG}"
+    ).success()

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -357,14 +357,15 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         self.cmd(
             "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {} --model-id {}".format(
                 device_id, self.entity_name, self.entity_rg, send_d2c_msg,
-                keys["secondaryKey"], "abcd:com:example"
+                keys["secondaryKey"], "abcd:com:"
             ),
             expect_failure=True
         )
 
+        # Error - model Id requires valid dtmi.
         self.cmd(
             "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {} --model-id {} ".format(
-                device_id, self.entity_name, self.entity_rg, send_d2c_msg, keys["primaryKey"], "dtmi:com:example"
+                device_id, self.entity_name, self.entity_rg, send_d2c_msg, keys["primaryKey"], "dtmi:com:example;"
             ),
             expect_failure=True
         )

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -10,7 +10,6 @@ import json
 
 from time import time
 from uuid import uuid4
-from azext_iot.tests.generators import generate_generic_id
 from azext_iot.tests.helpers import CERT_ENDING, KEY_ENDING
 from azext_iot.tests.iothub import IoTLiveScenarioTest, PREFIX_DEVICE
 from azext_iot.common.utility import (

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -460,6 +460,15 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             f"iot hub device-twin show -d {device_ids[1]} -n {self.entity_name} -g {self.entity_rg}").get_output_in_json()
         assert twin_result["modelId"] == model_id
 
+        # Error - a valid dtmi is expected.
+        self.cmd(
+            "iot device simulate -d {} -n {} -g {} --da '{}' --mc 1 --mi 1 --cp {} --kp {} --pass {} --model-id {}".format(
+                device_ids[1], self.entity_name, self.entity_rg, simulate_msg,
+                f"{device_ids[1]}-cert.pem", f"{device_ids[1]}-key.pem", fake_pass, "not:good:dtmi"
+            ),
+            expect_failure=True
+        )
+
         device_events.append((device_ids[1], f"{simulate_msg} #1"))
 
         self.cmd(

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -304,7 +304,6 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         enqueued_time = calculate_millisec_since_unix_epoch_utc()
         simulate_msg = "Key Connection Simulate"
         send_d2c_msg = "Key Connection Send-D2C-Message"
-        model_id = f"dtmi:com:example:{generate_generic_id()};1"
 
         keys = self.cmd(
             "iot hub device-identity create -d {} -n {} -g {}".format(
@@ -331,25 +330,45 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         device_events.append((device_id, send_d2c_msg))
 
         # Simulate with secondary key and include model Id upon connection
+        model_id_simulate_key = "dtmi:com:example:simulatekey;1"
         self.cmd(
             "iot device simulate -d {} -n {} -g {} --da '{}' --mc 1 --mi 1 --key {} --model-id {}".format(
-                device_id, self.entity_name, self.entity_rg, simulate_msg,
-                keys["secondaryKey"], model_id
+                device_id, self.entity_name, self.entity_rg, simulate_msg, keys["secondaryKey"], model_id_simulate_key
             )
         )
+        device_events.append((device_id, f"{simulate_msg} #1"))
         twin_result = self.cmd(
             f"iot hub device-twin show -d {device_id} -n {self.entity_name} -g {self.entity_rg}").get_output_in_json()
-        assert twin_result["modelId"] == model_id
+        assert twin_result["modelId"] == model_id_simulate_key
 
-        device_events.append((device_id, f"{simulate_msg} #1"))
-
+        # Include model Id for send-d2c-message with secondary key
+        model_id_d2c_key = "dtmi:com:example:d2ckey;1"
         self.cmd(
-            "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {}".format(
+            "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {} --model-id {}".format(
                 device_id, self.entity_name, self.entity_rg, send_d2c_msg,
-                keys["secondaryKey"]
+                keys["secondaryKey"], model_id_d2c_key
             )
         )
         device_events.append((device_id, send_d2c_msg))
+        twin_result = self.cmd(
+            f"iot hub device-twin show -d {device_id} -n {self.entity_name} -g {self.entity_rg}").get_output_in_json()
+        assert twin_result["modelId"] == model_id_d2c_key
+
+        # Error - model Id requires valid dtmi.
+        self.cmd(
+            "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {} --model-id {}".format(
+                device_id, self.entity_name, self.entity_rg, send_d2c_msg,
+                keys["secondaryKey"], "abcd:com:example"
+            ),
+            expect_failure=True
+        )
+
+        self.cmd(
+            "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --key {} --model-id {} ".format(
+                device_id, self.entity_name, self.entity_rg, send_d2c_msg, keys["primaryKey"], "dtmi:com:example"
+            ),
+            expect_failure=True
+        )
 
         self._monitor_checker(enqueued_time=enqueued_time, device_events=device_events)
 
@@ -360,7 +379,6 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         enqueued_time = calculate_millisec_since_unix_epoch_utc()
         simulate_msg = "Cert Connection Simulate"
         send_d2c_msg = "Cert Connection Send-D2C-Message"
-        model_id = f"dtmi:com:example:{generate_generic_id()};1"
 
         self.cmd(
             "iot hub device-identity create -d {} -n {} -g {} --am x509_thumbprint --valid-days 10 --od '{}'".format(
@@ -450,26 +468,17 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         )
 
         # x509 CA device simulation and include model Id upon connection
+        model_id_simulate_x509ca = "dtmi:com:example:simulatex509ca;1"
         self.cmd(
             "iot device simulate -d {} -n {} -g {} --da '{}' --mc 1 --mi 1 --cp {} --kp {} --pass {} --model-id {}".format(
                 device_ids[1], self.entity_name, self.entity_rg, simulate_msg,
-                f"{device_ids[1]}-cert.pem", f"{device_ids[1]}-key.pem", fake_pass, model_id
+                f"{device_ids[1]}-cert.pem", f"{device_ids[1]}-key.pem", fake_pass, model_id_simulate_x509ca
             )
         )
+        device_events.append((device_ids[1], f"{simulate_msg} #1"))
         twin_result = self.cmd(
             f"iot hub device-twin show -d {device_ids[1]} -n {self.entity_name} -g {self.entity_rg}").get_output_in_json()
-        assert twin_result["modelId"] == model_id
-
-        # Error - a valid dtmi is expected.
-        self.cmd(
-            "iot device simulate -d {} -n {} -g {} --da '{}' --mc 1 --mi 1 --cp {} --kp {} --pass {} --model-id {}".format(
-                device_ids[1], self.entity_name, self.entity_rg, simulate_msg,
-                f"{device_ids[1]}-cert.pem", f"{device_ids[1]}-key.pem", fake_pass, "not:good:dtmi"
-            ),
-            expect_failure=True
-        )
-
-        device_events.append((device_ids[1], f"{simulate_msg} #1"))
+        assert twin_result["modelId"] == model_id_simulate_x509ca
 
         self.cmd(
             "iot device send-d2c-message -d {} -n {} -g {} --da '{}' --cp {} --kp {} --pass {}".format(

--- a/azext_iot/tests/iothub/devices/test_iot_device_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_device_unit.py
@@ -553,12 +553,6 @@ class TestDeviceSimulate:
                 cmd=fixture_cmd, device_id=device_id, hub_name=mock_target["entity"]
             )
 
-    def test_device_simulate_mqtt_non_sas_device_error(self, fixture_ghcs, fixture_self_signed_device_show_self_signed):
-        with pytest.raises(CLIError):
-            subject.iot_simulate_device(
-                cmd=fixture_cmd, device_id=device_id, hub_name=mock_target["entity"]
-            )
-
 
 class TestMQTTClientSetup:
     def test_mqtt_provider_creation_sas_device(self, mqttclient_cs):


### PR DESCRIPTION
* Prepare ADU CLI control plane with no activation flag required.
* Support --model-id in device simulation.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).


Test run:
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=6143&view=results