### PR TITLE
Added auto-responder tasks to Fabric Bot to help resolve common errors

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -102,8 +102,7 @@
             }
           }
         ]
-      },
-      "id": "4aC1bxl8vW6"
+      }
     },
     {
       "taskType": "trigger",
@@ -165,8 +164,7 @@
             }
           }
         ]
-      },
-      "id": "gkGX04TIbDC"
+      }
     },
     {
       "taskType": "scheduled",
@@ -269,7 +267,6 @@
           }
         ]
       },
-      "id": "Ems6CqozRvO",
       "disabled": true
     },
     {
@@ -322,7 +319,6 @@
           "project_card"
         ]
       },
-      "id": "ApEHPD2GIFx",
       "disabled": true
     },
     {
@@ -380,7 +376,6 @@
           "issue_comment"
         ]
       },
-      "id": "F5DPV6CTbbn",
       "disabled": true
     },
     {
@@ -426,7 +421,6 @@
           "project_card"
         ]
       },
-      "id": "70lcaRQxqte",
       "disabled": true
     },
     {
@@ -460,7 +454,6 @@
           "issue_comment"
         ]
       },
-      "id": "-HEhMrYOMRz",
       "disabled": true
     },
     {
@@ -563,7 +556,6 @@
           }
         ]
       },
-      "id": "iS-0P0cMYhr",
       "disabled": true
     },
     {
@@ -674,7 +666,6 @@
           }
         ]
       },
-      "id": "QWayG_kxFjE",
       "disabled": true
     },
     {
@@ -784,7 +775,6 @@
           }
         ]
       },
-      "id": "KYmqyfK21VT",
       "disabled": true
     },
     {
@@ -798,7 +788,6 @@
         "fixedLabelText": "Status: Fixed",
         "fixedLabelEnabled": true
       },
-      "id": "2RlCmYrW_qe",
       "disabled": true
     },
     {
@@ -806,7 +795,6 @@
       "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",
-      "id": "eWmCBKRBzcgieWQfmlV-f",
       "config": {
         "conditions": {
           "operator": "and",
@@ -847,7 +835,6 @@
       "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",
-      "id": "kMgy3MqHjZgYVBTS1Wp7G",
       "config": {
         "conditions": {
           "operator": "and",
@@ -882,6 +869,45 @@
         ]
       },
       "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "bodyContains",
+              "parameters": {
+                "bodyPattern": "gather() got an unexpected keyword argument 'loop'"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto-respond to `unexpected keyword argument 'loop'`",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thanks for submitting an issue, @${issueAuthor}. I noticed your issue contains the following error:\n\n`gather() got an unexpected keyword argument 'loop'`\nwhich can often be solved quickly by updating your installed version of the `azure-iot` extension.\n\nPlease try upgrading your CLI extension to a newer version and see if that resolves the issue:\n`az extension update --name azure-iot`"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -908,6 +908,45 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "bodyContains",
+              "parameters": {
+                "bodyPattern": "ImportError: cannot import name 'c_uamqp' from partially initialized module 'uamqp'"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto-respond to uamqp import error",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thanks for submitting an issue, @${issueAuthor}. I noticed your issue contains the following error:\n\n`ImportError: cannot import name 'c_uamqp' from partially initialized module 'uamqp'`\nwhich can often be solved quickly by either:\n- Updating your installed version of the `azure-iot` extension:\n  `az extension update --name azure-iot`\n- Performing a repair of the uamqp dependency:\n  `az iot hub monitor-events --hub-name {} --device-id {} --repair`\n\nPlease try these two resolution methods and see if that helps resolve your issue."
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
This will auto-respond to new issues containing the following error:
`gather() got an unexpected keyword argument 'loop'`

And will ask the user to attempt updating their extension version to fix the issue.

From the Fabric bot team - `id` field is not required (so can be removed in this PR), and if the `disabled` field is missing, it will default to `false`, so we're good to move forward with this.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
