### PR TITLE
Add experimental manifest init command.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,8 @@ unreleased
 * The command `az iot device-update device class list` adds support for `--filter` when no `--group-id` is provided.
 * The parameters `--account`, `--instance`, and `--resource-group` support setting default overridable values via config.
   Use `az config set` i.e. `az config set defaults.adu_account=<name>` or `az configure` i.e. `az configure --defaults adu_account=<name>`.
+* Introducing the experimental command `az iot device-update update init v5` for initializing (or generating) an import manifest
+  with the desired state.
 * Improved built-in documentation.
 
 

--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -832,7 +832,9 @@ def load_deviceupdate_help():
         type: command
         short-summary: Initialize a v5 import manifest with the desired state.
         long-summary: This command supports all attributes of the v5 import manifest. Review examples
-          and parameter descriptions for details on how to fully utilize the operation.
+          and parameter descriptions for details on how to fully utilize the operation. Note that
+          there is positional sensitivity between --step and --file, as well as --file and --related-file.
+          Review parameter help for more details.
 
         examples:
         - name: Initialize a minimum content import manifest.
@@ -857,7 +859,7 @@ def load_deviceupdate_help():
             --step handler=microsoft/script:1 properties='{"arguments": "--pre"}' description="Pre-install script"
             --file path=/my/update/scripts/preinstall.sh downloadHandler=microsoft/delta:1
             --related-file path=/my/update/scripts/related_preinstall.json properties='{"microsoft.sourceFileHashAlgorithm": "sha256"}'
-            --step provider=Microsoft name=SwUpdate version=1.1
+            --step updateId.provider=Microsoft updateId.name=SwUpdate updateId.version=1.1
             --step handler=microsoft/script:1 properties='{"arguments": "--post"}' description="Post-install script"
             --file path=/my/update/scripts/postinstall.sh
     """

--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -823,6 +823,11 @@ def load_deviceupdate_help():
             az iot device-update device show -n {account_name} -i {instance_name} -d {device_id}
     """
 
+    helps["iot device-update update init"] = """
+        type: group
+        short-summary: Utilities for initializing update import manifests.
+    """
+
     helps["iot device-update update init v5"] = """
         type: command
         short-summary: Initialize a v5 import manifest with the desired state.

--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -822,3 +822,37 @@ def load_deviceupdate_help():
           text: >
             az iot device-update device show -n {account_name} -i {instance_name} -d {device_id}
     """
+
+    helps["iot device-update update init v5"] = """
+        type: command
+        short-summary: Initialize a v5 import manifest with the desired state.
+        long-summary: This command supports all attributes of the v5 import manifest. Review examples
+          and parameter descriptions for details on how to fully utilize the operation.
+
+        examples:
+        - name: Initialize a minimum content import manifest.
+          text: >
+            az iot device-update update init v5 --update-provider Microsoft --update-name AptUpdate --update-version 1.0.0
+            --description "My minimum update"
+            --compat deviceManufacturer=Contoso deviceModel=Vacuum
+            --step handler=microsoft/apt:1 --file path=/my/apt/manifest/file
+
+        - name: Initialize a non-deployable leaf update to be referenced in a bundled update.
+          text: >
+            az iot device-update update init v5 --update-provider Microsoft --update-name SwUpdate --update-version 1.1
+            --compat deviceManufacturer=Contoso deviceModel=Microphone --step handler=microsoft/swupdate:1 description="Deploy Update"
+            --file path=/my/update/image/file1 --file path=/my/update/image/file2
+            --is-deployable false
+
+        - name: Initialize a bundled update referencing a leaf update as well as defining independent steps. Inline json examples
+            compatible with bash-like shells.
+          text: >
+            az iot device-update update init v5 --update-provider Microsoft --update-name Bundled --update-version 2.0
+            --compat deviceManufacturer=Contoso deviceModel=SpaceStation
+            --step handler=microsoft/script:1 properties='{"arguments": "--pre"}' description="Pre-install script"
+            --file path=/my/update/scripts/preinstall.sh downloadHandler=microsoft/delta:1
+            --related-file path=/my/update/scripts/related_preinstall.json properties='{"microsoft.sourceFileHashAlgorithm": "sha256"}'
+            --step provider=Microsoft name=SwUpdate version=1.1
+            --step handler=microsoft/script:1 properties='{"arguments": "--post"}' description="Post-install script"
+            --file path=/my/update/scripts/postinstall.sh
+    """

--- a/azext_iot/deviceupdate/command_map.py
+++ b/azext_iot/deviceupdate/command_map.py
@@ -106,6 +106,12 @@ def load_deviceupdate_commands(self, _):
         cmd_group.show_command("show", "show_update_file")
 
     with self.command_group(
+        "iot device-update update init",
+        command_type=deviceupdate_update_ops,
+    ) as cmd_group:
+        cmd_group.command("v5", "manifest_init_v5", is_experimental=True)
+
+    with self.command_group(
         "iot device-update device",
         command_type=deviceupdate_device_ops,
     ) as cmd_group:

--- a/azext_iot/deviceupdate/commands_update.py
+++ b/azext_iot/deviceupdate/commands_update.py
@@ -294,6 +294,7 @@ def manifest_init_v5(
         related_step_file_map = _associate_related(step_file_params, "--step")
 
         assembled_step = DeviceUpdateDataManager.assemble_nargs_to_dict(steps[s])
+        step = {}
         if all(k in assembled_step for k in ("updateId.provider", "updateId.name", "updateId.version")):
             # reference step
             step = {
@@ -324,6 +325,11 @@ def manifest_init_v5(
 
             if "properties" in assembled_step:
                 step["handlerProperties"] = json.loads(assembled_step["properties"])
+
+        if not step:
+            raise ArgumentUsageError(
+                "Usage of --step requires at least an entry of handler=<value> for an inline step or "
+                "all of updateId.provider=<value>, updateId.name=<value>, updateId.version=<value> for a reference step.")
 
         step_desc = assembled_step.get("description") or assembled_step.get("desc")
         if step_desc:

--- a/azext_iot/deviceupdate/params.py
+++ b/azext_iot/deviceupdate/params.py
@@ -440,3 +440,81 @@ def load_deviceupdate_arguments(self, _):
             options_list=["--description"],
             help="Description for the log collection operation.",
         )
+
+    with self.argument_context("iot device-update update init") as context:
+        context.argument(
+            "update_provider",
+            options_list=["--update-provider"],
+            help="The update provider as a component of updateId.",
+        )
+        context.argument(
+            "update_name",
+            options_list=["--update-name"],
+            help="The update name as a component of updateId.",
+        )
+        context.argument(
+            "update_version",
+            options_list=["--update-version"],
+            help="The update version as a component of updateId.",
+        )
+        context.argument(
+            "description",
+            options_list=["--description"],
+            help="Description for the import update manifest.",
+        )
+        context.argument(
+            "deployable",
+            options_list=["--is-deployable"],
+            arg_type=get_three_state_flag(),
+            help="Indicates whether the update is independently deployable.",
+        )
+        context.argument(
+            "compatibility",
+            options_list=["--compat"],
+            nargs="+",
+            action="append",
+            help="Space-separated key=value pairs corresponding to properties of a device this update is compatible with. "
+            "Typically used for defining properties such as deviceManufacturer and deviceModel. "
+            "--compat can be used 1 or more times. ",
+        )
+        context.argument(
+            "steps",
+            options_list=["--step"],
+            nargs="+",
+            action="append",
+            help="Space-separated key=value pairs corresponding to 'instructions.steps' element properties. "
+            "The client will determine if a step is an inline or reference step based on the provided "
+            "key value pairs. If either inline or reference step can be satisfied, the reference step will be prioritized. "
+            "Usage of --file will be associated with the nearest inline --step entry, deriving the value for 'files'. "
+            "The following reference step keys are supported: "
+            "`updateId.provider`, `updateId.name` `updateId.version` and `description`."
+            "The following inline step keys are supported: "
+            "`handler` (ex: 'microsoft/script:1' or 'microsoft/swupdate:1' or 'microsoft/apt:1'), "
+            "`properties` (in-line json object the agent will pass to the handler) and `description`. "
+            "--step can be used 1 or more times.",
+        )
+        context.argument(
+            "files",
+            options_list=["--file"],
+            nargs="+",
+            action="append",
+            help="Space-separated key=value pairs corresponding to 'files' element properties. "
+            "A --file entry can include the closest --related-file entries if provided. "
+            "The following keys are supported: "
+            "`path` [required] local file path to update file, "
+            "`downloadHandler` (ex: 'microsoft/delta:1') download handler for utilizing related files "
+            "to download payload file. "
+            "--file can be used 1 or more times."
+        )
+        context.argument(
+            "related_files",
+            options_list=["--related-file"],
+            nargs="+",
+            action="append",
+            help="Space-separated key=value pairs corresponding to 'files[*].relatedFiles' element properties. "
+            "A --related-file entry will be associated to the closest --file entry if it exists. "
+            "The following keys are supported: "
+            "`path` [required] local file path to related update file, "
+            "`properties` in-line json object passed to the download handler. "
+            "--related-file can be used 1 or more times."
+        )

--- a/azext_iot/tests/deviceupdate/test_adu_manifest_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_manifest_int.py
@@ -164,12 +164,21 @@ def test_adu_manifest_init_v5(options, expected):
             "--step handler=microsoft/apt:1 "
             "--file downhandler=abcd/123",
         ),
-        (  # path key is required for --related-file
+        (
+            # path key is required for --related-file
             "--update-provider digimaun --update-name invalid --update-version 1.0.0 "
             "--compat deviceManufacturer=Contoso deviceModel=Vacuum "
             "--step handler=microsoft/apt:1 "
             f"--file path=\"{get_context_path(__file__, 'manifests', 'libcurl4-doc-apt-manifest.json')}\" "
             "--related-file properties='{\"a\": 1}'"
+        ),
+        (
+            # Usage of --step requires at least an entry of handler=<value> for an inline step or
+            # all of updateId.provider=<value>, updateId.name=<value>, updateId.version=<value> for a reference step.
+            "--update-provider digimaun --update-name invalid --update-version 1.0.0 "
+            "--compat deviceManufacturer=Contoso deviceModel=Vacuum "
+            "--step stuff=things "
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'libcurl4-doc-apt-manifest.json')}\" "
         ),
     ],
 )

--- a/azext_iot/tests/deviceupdate/test_adu_manifest_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_manifest_int.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+from knack.log import get_logger
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.tests.conftest import get_context_path
+
+cli = EmbeddedCLI()
+
+logger = get_logger(__name__)
+
+
+@pytest.mark.parametrize(
+    "options, expected",
+    [
+        (
+            "--update-provider digimaun0 --update-name simpleaptupdate --update-version 1.0.0 "
+            "--compat deviceManufacturer=Contoso deviceModel=Vacuum "
+            "--compat deviceManufacturer=Contoso deviceModel=Radio "
+            "--step handler=microsoft/apt:1 "
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'libcurl4-doc-apt-manifest.json')}\"",
+            {
+                "updateId": {"provider": "digimaun0", "name": "simpleaptupdate", "version": "1.0.0"},
+                "compatibility": [
+                    {"deviceManufacturer": "Contoso", "deviceModel": "Vacuum"},
+                    {"deviceManufacturer": "Contoso", "deviceModel": "Radio"},
+                ],
+                "instructions": {
+                    "steps": [{"handler": "microsoft/apt:1", "files": ["libcurl4-doc-apt-manifest.json"], "type": "inline"}]
+                },
+                "files": [
+                    {
+                        "filename": "libcurl4-doc-apt-manifest.json",
+                        "sizeInBytes": 163,
+                        "hashes": {"sha256": "iFWTIaxp33tf5BR1w0fMmnnHpjsUjLRQ9eZFjw74LbU="},
+                    }
+                ],
+                "manifestVersion": "5.0",
+            },
+        ),
+        (
+            "--update-provider digimaun1 --update-name Microphone --update-version 2.0.0 "
+            "--compat deviceManufacturer=Contoso deviceModel=Microphone "
+            "--step handler=microsoft/swupdate:1 "
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'surface15', 'action.sh')}\" "
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'surface15', 'install.sh')}\" "
+            "--is-deployable false",
+            {
+                "updateId": {"provider": "digimaun1", "name": "Microphone", "version": "2.0.0"},
+                "compatibility": [
+                    {"deviceManufacturer": "Contoso", "deviceModel": "Microphone"},
+                ],
+                "instructions": {
+                    "steps": [{"handler": "microsoft/swupdate:1", "files": ["action.sh", "install.sh"], "type": "inline"}]
+                },
+                "files": [
+                    {
+                        "filename": "action.sh",
+                        "sizeInBytes": 33,
+                        "hashes": {"sha256": "n+KGjLjSGr7LVKsgWiExUDeU6Z2ZTJu0tpAWxkmYKxA="},
+                    },
+                    {
+                        "filename": "install.sh",
+                        "sizeInBytes": 23,
+                        "hashes": {"sha256": "u6QdeTFImuTiReJ4WP9RlnYABdpd0cs8kuCz2zrHW28="},
+                    },
+                ],
+                "manifestVersion": "5.0",
+                "isDeployable": False,
+            },
+        ),
+        (
+            "--update-provider digimaun2 --update-name Toaster --update-version 1.0.1 "
+            "--compat deviceManufacturer=Contoso deviceModel=Toaster "
+            '--step handler=microsoft/script:1 properties=\'{"args": "--pre"}\' description="Pre-install script" files=image '
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'surface15', 'install.sh')}\" "
+            "downloadHandler=microsoft/delta:1 "
+            f"--related-file path=\"{get_context_path(__file__, 'manifests', 'simple_apt_manifest_v5.json')}\" "
+            'properties=\'{"microsoft.sourceFileHashAlgorithm":"sha256", '
+            '"microsoft.sourceFileHash":"YmFYwnEUddq2nZsBAn5v7gCRKdHx+TUntMz5tLwU+24="}\' '
+            '--step updateId.provider=digimaun updateId.name=Microphone updateId.version=1.3 description="Microphone Firmware" '
+            '--step updateId.provider=digimaun updateId.name=Speaker updateId.version=0.9 description="Speaker Firmware" '
+            '--step handler=microsoft/script:1 properties=\'{"args":"--post"}\' description="Post-install script" '
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'surface15', 'action.sh')}\" ",
+            {
+                "updateId": {"provider": "digimaun2", "name": "Toaster", "version": "1.0.1"},
+                "compatibility": [
+                    {"deviceManufacturer": "Contoso", "deviceModel": "Toaster"},
+                ],
+                "instructions": {
+                    "steps": [
+                        {
+                            "type": "inline",
+                            "handler": "microsoft/script:1",
+                            "handlerProperties": {"args": "--pre"},
+                            "files": ["image"],
+                            "description": "Pre-install script",
+                        },
+                        {
+                            "type": "reference",
+                            "updateId": {"provider": "digimaun", "name": "Microphone", "version": "1.3"},
+                            "description": "Microphone Firmware",
+                        },
+                        {
+                            "type": "reference",
+                            "updateId": {"provider": "digimaun", "name": "Speaker", "version": "0.9"},
+                            "description": "Speaker Firmware",
+                        },
+                        {
+                            "type": "inline",
+                            "handler": "microsoft/script:1",
+                            "handlerProperties": {"args": "--post"},
+                            "files": ["action.sh"],
+                            "description": "Post-install script",
+                        },
+                    ]
+                },
+                "files": [
+                    {
+                        "filename": "install.sh",
+                        "sizeInBytes": 23,
+                        "hashes": {"sha256": "u6QdeTFImuTiReJ4WP9RlnYABdpd0cs8kuCz2zrHW28="},
+                        "downloadHandler": {"id": "microsoft/delta:1"},
+                        "relatedFiles": [
+                            {
+                                "filename": "simple_apt_manifest_v5.json",
+                                "sizeInBytes": 1031,
+                                "hashes": {"sha256": "L+ZKmOOT3xRfHsFK7pcTXBLjeI2OFCW0855qIcV5sts="},
+                                "properties": {
+                                    "microsoft.sourceFileHash": "YmFYwnEUddq2nZsBAn5v7gCRKdHx+TUntMz5tLwU+24=",
+                                    "microsoft.sourceFileHashAlgorithm": "sha256",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "filename": "action.sh",
+                        "sizeInBytes": 33,
+                        "hashes": {"sha256": "n+KGjLjSGr7LVKsgWiExUDeU6Z2ZTJu0tpAWxkmYKxA="},
+                    },
+                ],
+                "manifestVersion": "5.0",
+            },
+        ),
+    ],
+)
+def test_adu_manifest_init_v5(options, expected):
+    result = cli.invoke(f"iot device-update update init v5 {options}").as_json()
+    del result["createdDateTime"]
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        (
+            # path key is required for --file
+            "--update-provider digimaun --update-name invalid --update-version 1.0.0 "
+            "--compat deviceManufacturer=Contoso deviceModel=Vacuum "
+            "--step handler=microsoft/apt:1 "
+            "--file downhandler=abcd/123",
+        ),
+        (  # path key is required for --related-file
+            "--update-provider digimaun --update-name invalid --update-version 1.0.0 "
+            "--compat deviceManufacturer=Contoso deviceModel=Vacuum "
+            "--step handler=microsoft/apt:1 "
+            f"--file path=\"{get_context_path(__file__, 'manifests', 'libcurl4-doc-apt-manifest.json')}\" "
+            "--related-file properties='{\"a\": 1}'"
+        ),
+    ],
+)
+def test_adu_manifest_init_v5_invalid_path_required(options):
+    assert not cli.invoke(f"iot device-update update init v5 {options}").success()


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).


https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=6514&view=results