### PR TITLE
Embedded CLI Subscription fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,16 @@
 Release History
 ===============
 
-unreleased
+0.17.2
 +++++++++++++++
+
+**General Updates**
+
+* Hotfix for ensuring the global subscription parameter (`--subscription`) passes through sub-commands. Affected commands include:
+
+  - az dt create
+  - az dt job import
+  - az iot device-update account create
 
 
 0.17.1
@@ -125,7 +133,7 @@ unreleased
 
 * Introducing the **in preview** Azure Device Update for IoT Hub root command group `az iot device-update`.
   To learn more about the service visit https://docs.microsoft.com/en-us/azure/iot-hub-device-update/.
- 
+
   - This command group is behind a feature flag environment variable. Set `IOT_CLI_ADU_ENABLED` to any value
     to activate the command group.
   - The Device Update command group supports all `account` and `instance` related functionality against

--- a/azext_iot/common/embedded_cli.py
+++ b/azext_iot/common/embedded_cli.py
@@ -15,19 +15,25 @@ logger = get_logger(__name__)
 
 
 class EmbeddedCLI(object):
-    def __init__(self):
+    def __init__(self, user_subscription: str = None):
         super(EmbeddedCLI, self).__init__()
         self.output = ""
         self.error_code = 0
         self.az_cli = get_default_cli()
+        self.user_subscription = user_subscription
 
     def invoke(self, command: str, subscription: str = None):
         output_file = StringIO()
 
         command = self._ensure_json_output(command=command)
+        # prioritize subscription passed into invoke
         if subscription:
             command = self._ensure_subscription(
                 command=command, subscription=subscription
+            )
+        elif self.user_subscription:
+            command = self._ensure_subscription(
+                command=command, subscription=self.user_subscription
             )
 
         # TODO: Capture stderr?

--- a/azext_iot/common/embedded_cli.py
+++ b/azext_iot/common/embedded_cli.py
@@ -15,12 +15,12 @@ logger = get_logger(__name__)
 
 
 class EmbeddedCLI(object):
-    def __init__(self, user_subscription: str = None):
+    def __init__(self, cli_ctx=None):
         super(EmbeddedCLI, self).__init__()
         self.output = ""
         self.error_code = 0
         self.az_cli = get_default_cli()
-        self.user_subscription = user_subscription
+        self.user_subscription = cli_ctx.data.get('subscription_id') if cli_ctx else None
 
     def invoke(self, command: str, subscription: str = None):
         output_file = StringIO()

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.17.1"
+VERSION = "0.17.2"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/deviceupdate/providers/base.py
+++ b/azext_iot/deviceupdate/providers/base.py
@@ -101,7 +101,7 @@ class DeviceUpdateAccountManager(DeviceUpdateClientHandler):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.mgmt_client = self.get_mgmt_client()
-        self.cli = EmbeddedCLI()
+        self.cli = EmbeddedCLI(user_subscription=cmd.cli_ctx.data["subscription_id"])
 
     def find_account(self, target_name: str, target_rg: Optional[str] = None) -> AccountContainer:
         def find_account_rg(id: str):

--- a/azext_iot/deviceupdate/providers/base.py
+++ b/azext_iot/deviceupdate/providers/base.py
@@ -109,7 +109,7 @@ class DeviceUpdateAccountManager(DeviceUpdateClientHandler):
     def __init__(self, cmd):
         super().__init__(cmd=cmd)
         self.mgmt_client = self.get_mgmt_client()
-        self.cli = EmbeddedCLI(user_subscription=cmd.cli_ctx.data["subscription_id"])
+        self.cli = EmbeddedCLI(cli_ctx=cmd.cli_ctx)
 
     def find_account(self, target_name: str, target_rg: Optional[str] = None) -> AccountContainer:
         def find_account_rg(id: str):

--- a/azext_iot/digitaltwins/providers/import_job.py
+++ b/azext_iot/digitaltwins/providers/import_job.py
@@ -20,7 +20,7 @@ class ImportJobProvider(DigitalTwinsProvider):
     def __init__(self, cmd, name: str, rg: str = None):
         super(ImportJobProvider, self).__init__(cmd=cmd, name=name, rg=rg)
         self.sdk = self.get_sdk().import_jobs
-        self.cli = EmbeddedCLI()
+        self.cli = EmbeddedCLI(user_subscription=cmd.cli_ctx.data["subscription_id"])
 
     def _get_blob_url(self, blob_name: str, blob_container: str, storage_account: str):
         storage_account_cstring_op = self.cli.invoke(

--- a/azext_iot/digitaltwins/providers/import_job.py
+++ b/azext_iot/digitaltwins/providers/import_job.py
@@ -20,7 +20,7 @@ class ImportJobProvider(DigitalTwinsProvider):
     def __init__(self, cmd, name: str, rg: str = None):
         super(ImportJobProvider, self).__init__(cmd=cmd, name=name, rg=rg)
         self.sdk = self.get_sdk().import_jobs
-        self.cli = EmbeddedCLI(user_subscription=cmd.cli_ctx.data["subscription_id"])
+        self.cli = EmbeddedCLI(cli_ctx=cmd.cli_ctx)
 
     def _get_blob_url(self, blob_name: str, blob_container: str, storage_account: str):
         storage_account_cstring_op = self.cli.invoke(

--- a/azext_iot/digitaltwins/providers/rbac.py
+++ b/azext_iot/digitaltwins/providers/rbac.py
@@ -9,8 +9,8 @@ from azext_iot.common.embedded_cli import EmbeddedCLI
 
 
 class RbacProvider(object):
-    def __init__(self):
-        self.cli = EmbeddedCLI()
+    def __init__(self, user_subscription: str = None):
+        self.cli = EmbeddedCLI(user_subscription=user_subscription)
 
     def list_assignments(self, dt_scope, include_inherited=False, role_type=None):
         include_inherited_flag = ""

--- a/azext_iot/digitaltwins/providers/rbac.py
+++ b/azext_iot/digitaltwins/providers/rbac.py
@@ -9,8 +9,8 @@ from azext_iot.common.embedded_cli import EmbeddedCLI
 
 
 class RbacProvider(object):
-    def __init__(self, user_subscription: str = None):
-        self.cli = EmbeddedCLI(user_subscription=user_subscription)
+    def __init__(self, cli_ctx=None):
+        self.cli = EmbeddedCLI(cli_ctx=cli_ctx)
 
     def list_assignments(self, dt_scope, include_inherited=False, role_type=None):
         include_inherited_flag = ""

--- a/azext_iot/digitaltwins/providers/resource.py
+++ b/azext_iot/digitaltwins/providers/resource.py
@@ -38,7 +38,8 @@ class ResourceProvider(DigitalTwinsResourceManager):
     def __init__(self, cmd):
         super(ResourceProvider, self).__init__(cmd=cmd)
         self.mgmt_sdk = self.get_mgmt_sdk()
-        self.rbac = RbacProvider()
+        self.rbac = RbacProvider(user_subscription=cmd.cli_ctx.data["subscription_id"])
+
 
     def create(
         self,
@@ -54,9 +55,11 @@ class ResourceProvider(DigitalTwinsResourceManager):
     ):
         if not location:
             from azext_iot.common.embedded_cli import EmbeddedCLI
+            # check correct subscription if provided
+            subscription = self.cmd.cli_ctx.data["subscription_id"]
 
             resource_group_meta = (
-                EmbeddedCLI()
+                EmbeddedCLI(user_subscription=subscription)
                 .invoke("group show --name {}".format(resource_group_name))
                 .as_json()
             )

--- a/azext_iot/digitaltwins/providers/resource.py
+++ b/azext_iot/digitaltwins/providers/resource.py
@@ -38,7 +38,7 @@ class ResourceProvider(DigitalTwinsResourceManager):
     def __init__(self, cmd):
         super(ResourceProvider, self).__init__(cmd=cmd)
         self.mgmt_sdk = self.get_mgmt_sdk()
-        self.rbac = RbacProvider(user_subscription=cmd.cli_ctx.data["subscription_id"])
+        self.rbac = RbacProvider(cmd.cli_ctx)
 
 
     def create(
@@ -55,11 +55,8 @@ class ResourceProvider(DigitalTwinsResourceManager):
     ):
         if not location:
             from azext_iot.common.embedded_cli import EmbeddedCLI
-            # check correct subscription if provided
-            subscription = self.cmd.cli_ctx.data["subscription_id"]
-
             resource_group_meta = (
-                EmbeddedCLI(user_subscription=subscription)
+                EmbeddedCLI(cli_ctx=self.cmd.cli_ctx)
                 .invoke("group show --name {}".format(resource_group_name))
                 .as_json()
             )

--- a/azext_iot/digitaltwins/providers/resource.py
+++ b/azext_iot/digitaltwins/providers/resource.py
@@ -40,7 +40,6 @@ class ResourceProvider(DigitalTwinsResourceManager):
         self.mgmt_sdk = self.get_mgmt_sdk()
         self.rbac = RbacProvider(cmd.cli_ctx)
 
-
     def create(
         self,
         name,

--- a/azext_iot/tests/utility/test_iot_utility_unit.py
+++ b/azext_iot/tests/utility/test_iot_utility_unit.py
@@ -352,10 +352,14 @@ class TestEmbeddedCli(object):
             ),
         ],
     )
-    def test_embedded_cli(self, mocked_azclient, command, user_subscription, subscription):
+    def test_embedded_cli(self, mocker, mocked_azclient, command, user_subscription, subscription):
         import shlex
 
-        cli = EmbeddedCLI(user_subscription)
+        cli_ctx = mocker.MagicMock()
+        cli_ctx.data = {}
+        if user_subscription:
+            cli_ctx.data["subscription_id"] = user_subscription
+        cli = EmbeddedCLI(cli_ctx)
         cli.invoke(command=command, subscription=subscription)
 
         # Due to forced json output

--- a/azext_iot/tests/utility/test_iot_utility_unit.py
+++ b/azext_iot/tests/utility/test_iot_utility_unit.py
@@ -331,7 +331,6 @@ class TestEmbeddedCli(object):
         azclient.test_meta.error_code = request.param
         return azclient
 
-
     @pytest.mark.parametrize(
         "command, user_subscription, subscription",
         [
@@ -341,7 +340,8 @@ class TestEmbeddedCli(object):
                 "20a300e5-a444-4130-bb5a-1abd08ad930a",
                 None
             ),
-            ("iot hub device-identity create -n abcd -d dcba",
+            (
+                "iot hub device-identity create -n abcd -d dcba",
                 None,
                 "20a300e5-a444-4130-bb5a-1abd08ad930a"
             ),


### PR DESCRIPTION
Customer has pointed out that `dt create` with `--subscription` does not work. Upon inspection, it was determined that the `group show` command used to get location of the resource group was not passing in the user defined subscription.

This adds an optional user_subscription to the EmbeddedCLI class. If it is defined, then it will be used during invoke commands. However, a subscription passed into the invoke takes priority over the user_subscription (specifically for the endpoint commands).

This pr ensures all EmbeddedCLI's in non-test code use the user_subscription if defined.

Added a unit test to ensure embeddedcli functions as expected.

pipeline run for dt + adu:
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=6566&view=results

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
