### PR TITLE
Hub device identity list to twin list

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,8 @@ unreleased
 
 **IoT Hub**
 
-* Deprecate `az iot hub device-identity list` in favor of `az iot hub device-twin list`. Functionality remains the same.
+* Add `az iot hub device-twin list` as a highly recommended alternative to `az iot hub device-identity list`. Functionality remains the same as both return a list of device twins and `az iot hub device-identity list` may be altered or deprecated in the future.
+
 
 0.17.3
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Release History
 unreleased
 +++++++++++++++
 
+**IoT Hub**
+
+* Deprecate `az iot hub device-identity list` in favor of `az iot hub device-twin list`. Functionality remains the same.
 
 0.17.3
 +++++++++++++++
@@ -23,7 +26,7 @@ unreleased
 * Add support for enrollment groups CRUD.
 
   - az iot central enrollment-group
- 
+
     - az iot central enrollment-group list
     - az iot central enrollment-group show
     - az iot central enrollment-group create
@@ -35,7 +38,7 @@ unreleased
 * Add support for scheduled jobs CRUD.
 
   - az iot central scheduled-job
- 
+
     - az iot central scheduled-job list
     - az iot central scheduled-job show
     - az iot central scheduled-job create

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -189,7 +189,9 @@ helps[
     type: command
     short-summary: List devices in an IoT Hub.
     long-summary: |
-                   This command is an alias for `az iot hub device-twin list`, which is recommended over this command. In the future, this `az iot hub device-identity list` command may be deprecated.
+                   This command is an alias for `az iot hub device-twin list`, which is recommended over
+                   this command. In the future, this `az iot hub device-identity list` command may be
+                   deprecated.
 
 """
 

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -188,7 +188,9 @@ helps[
 ] = """
     type: command
     short-summary: List devices in an IoT Hub.
-    long-summary: This command is an alias for `az iot hub device-twin list`.
+    long-summary: |
+                   This command is an alias for `az iot hub device-twin list`, which is recommended over this command. In the future, this `az iot hub device-identity list` command may be deprecated.
+
 """
 
 helps[

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -188,6 +188,7 @@ helps[
 ] = """
     type: command
     short-summary: List devices in an IoT Hub.
+    long-summary: This command is an alias for `az iot hub device-twin list`.
 """
 
 helps[

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -404,6 +404,16 @@ helps[
 """
 
 helps[
+    "iot hub device-twin list"
+] = """
+    type: command
+    short-summary: List device twins in an IoT Hub.
+    long-summary: |
+                   This command is the same as iot hub query with the query "select * from devices" for
+                   all devices and "select * from devices where capabilities.iotEdge = true" for edge devices.
+"""
+
+helps[
     "iot hub device-twin update"
 ] = """
     type: command

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -189,9 +189,9 @@ helps[
     type: command
     short-summary: List devices in an IoT Hub.
     long-summary: |
-                   This command is an alias for `az iot hub device-twin list`, which is recommended over
+                   This command is an alias for `az iot hub device-twin list`, which is highly recommended over
                    this command. In the future, this `az iot hub device-identity list` command may be
-                   deprecated.
+                   altered or deprecated.
 
 """
 

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -31,7 +31,11 @@ def load_command_table(self, _):
     ) as cmd_group:
         cmd_group.command("create", "iot_device_create")
         cmd_group.show_command("show", "iot_device_show")
-        cmd_group.command("list", "iot_device_list")
+        cmd_group.command(
+            "list",
+            "iot_device_twin_list",
+            deprecate_info=self.deprecate(redirect='new-test', hide=True)
+        )
         cmd_group.command("delete", "iot_device_delete")
         cmd_group.generic_update_command(
             "update",
@@ -98,6 +102,7 @@ def load_command_table(self, _):
         "iot hub device-twin", command_type=iothub_ops
     ) as cmd_group:
         cmd_group.show_command("show", "iot_device_twin_show")
+        cmd_group.command("list", "iot_device_twin_list")
         cmd_group.command("replace", "iot_device_twin_replace")
         cmd_group.generic_update_command(
             "update",

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -34,7 +34,7 @@ def load_command_table(self, _):
         cmd_group.command(
             "list",
             "iot_device_twin_list",
-            deprecate_info=self.deprecate(redirect='new-test', hide=True)
+            deprecate_info=self.deprecate(redirect='iot device-twin list')
         )
         cmd_group.command("delete", "iot_device_delete")
         cmd_group.generic_update_command(

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -34,7 +34,7 @@ def load_command_table(self, _):
         cmd_group.command(
             "list",
             "iot_device_twin_list",
-            deprecate_info=self.deprecate(redirect='iot device-twin list')
+            # deprecate_info=self.deprecate(redirect='iot device-twin list')
         )
         cmd_group.command("delete", "iot_device_delete")
         cmd_group.generic_update_command(

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -120,35 +120,6 @@ def _iot_device_show(target, device_id):
         handle_service_exception(e)
 
 
-def iot_device_list(
-    cmd,
-    hub_name=None,
-    top=1000,
-    edge_enabled=False,
-    resource_group_name=None,
-    login=None,
-    auth_type_dataplane=None,
-):
-    query = (
-        "select * from devices where capabilities.iotEdge = true"
-        if edge_enabled
-        else "select * from devices"
-    )
-    result = iot_query(
-        cmd=cmd,
-        query_command=query,
-        hub_name=hub_name,
-        top=top,
-        resource_group_name=resource_group_name,
-        login=login,
-        auth_type_dataplane=auth_type_dataplane,
-    )
-
-    if not result:
-        logger.info('No registered devices found on hub "%s".', hub_name)
-    return result
-
-
 def iot_device_create(
     cmd,
     device_id,
@@ -1751,6 +1722,35 @@ def _iot_device_twin_show(target, device_id):
         return service_sdk.devices.get_twin(id=device_id, raw=True).response.json()
     except CloudError as e:
         handle_service_exception(e)
+
+
+def iot_device_twin_list(
+    cmd,
+    hub_name=None,
+    top=1000,
+    edge_enabled=False,
+    resource_group_name=None,
+    login=None,
+    auth_type_dataplane=None,
+):
+    query = (
+        "select * from devices where capabilities.iotEdge = true"
+        if edge_enabled
+        else "select * from devices"
+    )
+    result = iot_query(
+        cmd=cmd,
+        query_command=query,
+        hub_name=hub_name,
+        top=top,
+        resource_group_name=resource_group_name,
+        login=login,
+        auth_type_dataplane=auth_type_dataplane,
+    )
+
+    if not result:
+        logger.info('No registered devices found on hub "%s".', hub_name)
+    return result
 
 
 def iot_twin_update_custom(instance, desired=None, tags=None):

--- a/azext_iot/tests/iothub/__init__.py
+++ b/azext_iot/tests/iothub/__init__.py
@@ -231,7 +231,7 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
     def tearDown(self):
         device_list = []
         device_list.extend(d["deviceId"] for d in self.cmd(
-            f"iot hub device-identity list -n {self.entity_name} -g {self.entity_rg}"
+            f"iot hub device-twin list -n {self.entity_name} -g {self.entity_rg}"
         ).get_output_in_json())
 
         config_list = []

--- a/azext_iot/tests/iothub/core/test_iot_ext_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_ext_unit.py
@@ -665,7 +665,7 @@ class TestDeviceShow:
             )
 
 
-class TestDeviceList:
+class TestDeviceTwinList:
     @pytest.fixture(params=[10, 0])
     def service_client(self, mocked_response, fixture_ghcs, request):
         result = []
@@ -688,7 +688,7 @@ class TestDeviceList:
 
     @pytest.mark.parametrize("top, edge", [(10, True), (1000, False)])
     def test_device_list(self, fixture_cmd, service_client, top, edge):
-        result = subject.iot_device_list(
+        result = subject.iot_device_twin_list(
             cmd=fixture_cmd, hub_name=mock_target["entity"], top=top, edge_enabled=edge
         )
         list_request = service_client.calls[0].request
@@ -711,14 +711,14 @@ class TestDeviceList:
     @pytest.mark.parametrize("top", [-2, 0])
     def test_device_list_invalid_args(self, fixture_cmd, top):
         with pytest.raises(CLIError):
-            subject.iot_device_list(
+            subject.iot_device_twin_list(
                 cmd=fixture_cmd, hub_name=mock_target["entity"], top=top
             )
 
     def test_device_list_error(self, fixture_cmd, service_client_generic_errors):
         service_client_generic_errors.assert_all_requests_are_fired = False
         with pytest.raises(CLIError):
-            subject.iot_device_list(
+            subject.iot_device_twin_list(
                 cmd=fixture_cmd, hub_name=mock_target["entity"],
             )
 

--- a/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
+++ b/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
@@ -270,7 +270,7 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 # List devices
                 self.cmd(
                     self.set_cmd_auth_type(
-                        f"iot hub device-identity twin -n {self.entity_name} -g {self.entity_rg}",
+                        f"iot hub device-twin list -n {self.entity_name} -g {self.entity_rg}",
                         auth_type=auth_phase,
                     ),
                     checks=query_checks,
@@ -279,7 +279,7 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 # List devices filtering for edge devices
                 edge_filtered_list = self.cmd(
                     self.set_cmd_auth_type(
-                        f"iot hub device-identity twin -n {self.entity_name} -g {self.entity_rg} --ee",
+                        f"iot hub device-twin list -n {self.entity_name} -g {self.entity_rg} --ee",
                         auth_type=auth_phase,
                     )
                 ).get_output_in_json()

--- a/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
+++ b/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
@@ -270,7 +270,7 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 # List devices
                 self.cmd(
                     self.set_cmd_auth_type(
-                        f"iot hub device-identity list -n {self.entity_name} -g {self.entity_rg}",
+                        f"iot hub device-identity twin -n {self.entity_name} -g {self.entity_rg}",
                         auth_type=auth_phase,
                     ),
                     checks=query_checks,
@@ -279,7 +279,7 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 # List devices filtering for edge devices
                 edge_filtered_list = self.cmd(
                     self.set_cmd_auth_type(
-                        f"iot hub device-identity list -n {self.entity_name} -g {self.entity_rg} --ee",
+                        f"iot hub device-identity twin -n {self.entity_name} -g {self.entity_rg} --ee",
                         auth_type=auth_phase,
                     )
                 ).get_output_in_json()


### PR DESCRIPTION
Move `az iot hub device-identity list` to `az iot hub device-twin list` as a start for a deprecation. 

The current list command already returns a list of twins rather than devices. This will resolve some confusion when using the command.

Future plans for `az iot hub device-identity list` is to either fully deprecate it or use the device-identity API (which will require service investment in fixing).

Pipeline run: https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=6734&view=results

New help (`az iot hub device-twin list`):
![image](https://user-images.githubusercontent.com/73560279/195474126-ec475678-f49e-431b-9855-4b49d61689c4.png)

Old help (`az iot hub device-identity list`):
![image](https://user-images.githubusercontent.com/73560279/195648857-6db07969-d533-4f71-8d2b-990154d945ef.png)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
