### PR TITLE
Fix the flaky ADT unit test

### DIFF
--- a/azext_iot/tests/digitaltwins/test_dt_resource_unit.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_unit.py
@@ -149,11 +149,12 @@ class TestTwinCreateInstance(object):
             location=location
         )
         while len(service_client_with_failed_retry.calls) == 1:
-            sleep(10)
+            sleep(15)
         check_request = service_client_with_failed_retry.calls[1].request
         assert "operationkey" in check_request.url
 
         # The LRO poller calls once more for some reason
+        print(len(service_client_with_failed_retry.calls))
         assert len(service_client_with_failed_retry.calls) >= 2
         assert service_client_with_failed_retry.calls[1].response.content.decode("utf-8") == failed
 

--- a/azext_iot/tests/digitaltwins/test_dt_resource_unit.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_unit.py
@@ -149,14 +149,15 @@ class TestTwinCreateInstance(object):
             location=location
         )
         while len(service_client_with_failed_retry.calls) == 1:
-            sleep(15)
+            sleep(10)
         check_request = service_client_with_failed_retry.calls[1].request
         assert "operationkey" in check_request.url
 
         # The LRO poller calls once more for some reason
-        print(len(service_client_with_failed_retry.calls))
         assert len(service_client_with_failed_retry.calls) >= 2
         assert service_client_with_failed_retry.calls[1].response.content.decode("utf-8") == failed
+        # Sleep to give time for the poller
+        sleep(1)
 
         # The poller.result will have the error
         assert result.status() == "Failed"


### PR DESCRIPTION
Just a change from location headers to async operation headers and some body adjustments. 

Issue 
![image](https://user-images.githubusercontent.com/73560279/195904737-50f53ed9-0645-47b6-8a16-d1ec39ada8a1.png)

![image](https://user-images.githubusercontent.com/73560279/195904902-f8221958-47ae-4c5b-810e-2a8590ae8390.png)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
