### PR TITLE
Refreshed device identity import/export - improve service error handling

### DIFF
--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -382,13 +382,13 @@ def load_deviceupdate_help():
             az iot du update import -n {account_name} -i {instance_name} --hashes sha256={hash_value} --size {size_in_bytes}
             --url {manifest_location} --file filename={file1_name} url={file1_url} --file filename={file2_name} url={file2_url}
 
-        - name: Import an update with two related files and no reference steps, letting the CLI calculate the update manifest
+        - name: Import an update with two related files and no reference steps, letting the CLI calculate the import manifest
             hash value and size in bytes.
           text: >
             az iot du update import -n {account_name} -i {instance_name} --url {manifest_location}
             --file filename={file1_name} url={file1_url} --file filename={file2_name} url={file2_url}
 
-        - name: Import a parent update with two child update reference steps, where all three update manifests have one related file.
+        - name: Import a parent update with two child update reference steps, where all three import manifests have one related file.
             Let the CLI calculate hash value and size in bytes for all. This operation will rely on the `--defer` capability.
           text: >
             az iot du update import -n {account_name} -i {instance_name} --url {parent_manifest_location}
@@ -830,7 +830,7 @@ def load_deviceupdate_help():
 
     helps["iot du update init"] = """
         type: group
-        short-summary: Utility for update manifest initialization.
+        short-summary: Utility for import manifest initialization.
     """
 
     helps["iot du update init v5"] = """
@@ -903,12 +903,12 @@ def load_deviceupdate_help():
         short-summary: Stage an update for import to a target instance.
         long-summary: |
           Staging an update refers to accelerating the pre-requisite steps
-          of importing an update to a target instance. For a given update manifest, the process
+          of importing an update to a target instance. For a given import manifest, the process
           will determine relevant files, push them to a desired storage container,
           generate SAS URIs and cover other preparation steps for a succesful import.
 
           This command depends on a convention based organization of update files. All update files
-          for a target manifest are expected to be in the same directory the update manifest resides in.
+          for a target manifest are expected to be in the same directory the import manifest resides in.
 
           Key based access is used to upload blob artifacts and to generate 3 hour duration SAS URIs with read access.
 

--- a/azext_iot/deviceupdate/params.py
+++ b/azext_iot/deviceupdate/params.py
@@ -474,7 +474,7 @@ def load_deviceupdate_arguments(self, _):
         context.argument(
             "description",
             options_list=["--description"],
-            help="Description for the import update manifest.",
+            help="Description for the import manifest.",
         )
         context.argument(
             "deployable",
@@ -543,19 +543,19 @@ def load_deviceupdate_arguments(self, _):
         context.argument(
             "storage_account_name",
             options_list=["--storage-account"],
-            help="Desired storage account name to stage update manifest artifacts.",
+            help="Desired storage account name to stage import manifest artifacts.",
             arg_group="Storage"
         )
         context.argument(
             "storage_container_name",
             options_list=["--storage-container"],
-            help="Desired storage container name to stage update manifest artifacts.",
+            help="Desired storage container name to stage import manifest artifacts.",
             arg_group="Storage"
         )
         context.argument(
             "storage_account_subscription",
             options_list=["--storage-subscription"],
-            help="Desired storage account subscription to stage update manifest artifacts. "
+            help="Desired storage account subscription to stage import manifest artifacts. "
             "Applicable when the storage and device update accounts are in different subscriptions.",
             arg_group="Storage"
         )
@@ -564,7 +564,7 @@ def load_deviceupdate_arguments(self, _):
             nargs="?",
             action="append",
             options_list=["--manifest-path"],
-            help="Local file path to the update manifest that should be staged. Can be used 1 or more times.",
+            help="Local file path to the import manifest that should be staged. Can be used 1 or more times.",
         )
         context.argument(
             "then_import",

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -2330,12 +2330,10 @@ def iot_device_export(
         )
     if storage_authentication_type is not None:
         logger.warning(
-            "The parameter --sat/--storage-authentication-type has been deprecated and should not be provided"
+            "The parameter --sat/--storage-authentication-type has been deprecated and should not be provided. "
         )
-    if auth_type_dataplane is not None:
         logger.warning(
-            "The parameter --auth-type is now used to specify dataplane auth-type instead of storage auth-type. "
-            + "The storage auth-type is automatically derived and should no longer be provided as input."
+            "The parameter --auth-type is now used to specify IoT Hub data access auth type instead of storage access auth type. "
         )
 
     service_sdk = _get_service_sdk(
@@ -2379,12 +2377,10 @@ def iot_device_import(
         )
     if storage_authentication_type is not None:
         logger.warning(
-            "The parameter --sat/--storage-authentication-type has been deprecated and should not be provided"
+            "The parameter --sat/--storage-authentication-type has been deprecated and should not be provided. "
         )
-    if auth_type_dataplane is not None:
         logger.warning(
-            "The parameter --auth-type is now used to specify dataplane auth-type instead of storage auth-type. "
-            + "The storage auth-type is automatically derived and should no longer be provided as input."
+            "The parameter --auth-type is now used to specify IoT Hub data access auth type instead of storage access auth type. "
         )
 
     service_sdk = _get_service_sdk(

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -2347,7 +2347,11 @@ def iot_device_export(
         include_keys=include_keys,
         identity=identity
     )
-    return service_sdk.jobs.create_import_export_job(export_job_properties)
+
+    try:
+        return service_sdk.jobs.create_import_export_job(export_job_properties)
+    except CloudError as e:
+        handle_service_exception(e)
 
 
 def iot_device_import(
@@ -2392,7 +2396,11 @@ def iot_device_import(
         output_blob_container_uri=output_blob_container_uri,
         identity=identity
     )
-    return service_sdk.jobs.create_import_export_job(import_job_properties)
+
+    try:
+        return service_sdk.jobs.create_import_export_job(import_job_properties)
+    except CloudError as e:
+        handle_service_exception(e)
 
 
 def iot_hub_monitor_events(

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -8,10 +8,13 @@ import json
 import os
 
 from inspect import getsourcefile
-from azure.iot.device import ProvisioningDeviceClient, IoTHubDeviceClient
-
+from azext_iot.common.utility import ensure_azure_namespace_path
 from azext_iot.common.utility import read_file_content
 from azext_iot.tests.settings import DynamoSettings
+
+ensure_azure_namespace_path()
+
+from azure.iot.device import ProvisioningDeviceClient, IoTHubDeviceClient
 
 GLOBAL_PROVISIONING_HOST = "global.azure-devices-provisioning.net"
 TAG_ENV_VAR = [

--- a/azext_iot/tests/iothub/core/test_iot_hub_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_unit.py
@@ -14,6 +14,7 @@ from azext_iot.common.shared import (
     JobType,
     AuthenticationType,
 )
+from azure.cli.core.azclierror import BadRequestError
 
 hub_name = "hubname"
 shared_access_key_name = "TEST_SAS_KEY_NAME"
@@ -82,6 +83,24 @@ class TestIoTHubDeviceIdentityExport(object):
 
         yield mocked_response
 
+    @pytest.fixture(params=[(400, BadRequestError)])
+    def service_client_error(self, mocked_response, get_mgmt_client, request):
+        mocked_response.assert_all_requests_are_fired = True
+
+        mocked_response.add(
+            method=responses.POST,
+            url="https://{}/jobs/create?api-version=2021-04-12".format(hub_name),
+            body=json.dumps(
+                {"Message": "ErrorCode:BlobContainerValidationError;Failed to read devices blob from the input container."}
+            ),
+            status=request.param[0],
+            content_type="application/json",
+            match_querystring=False,
+        )
+        setattr(mocked_response, "expected_exception", request.param[1])
+
+        yield mocked_response
+
     @pytest.mark.parametrize(
         "req",
         [
@@ -134,6 +153,16 @@ class TestIoTHubDeviceIdentityExport(object):
                 resource_group_name=req["resource_group_name"],
             )
 
+    def test_device_identity_export_error(self, fixture_cmd, service_client_error):
+        with pytest.raises(CLIError) as e:
+            subject.iot_device_export(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                blob_container_uri=blob_container_uri,
+                resource_group_name="myresourcegroup",
+            )
+        assert isinstance(e.value, service_client_error.expected_exception)
+
 
 class TestIoTHubDeviceIdentityImport(object):
     @pytest.fixture
@@ -148,6 +177,24 @@ class TestIoTHubDeviceIdentityImport(object):
             content_type="application/json",
             match_querystring=False,
         )
+
+        yield mocked_response
+
+    @pytest.fixture(params=[(400, BadRequestError)])
+    def service_client_error(self, mocked_response, get_mgmt_client, request):
+        mocked_response.assert_all_requests_are_fired = True
+
+        mocked_response.add(
+            method=responses.POST,
+            url="https://{}/jobs/create?api-version=2021-04-12".format(hub_name),
+            body=json.dumps(
+                {"Message": "ErrorCode:BlobContainerValidationError;Failed to read devices blob from the input container."}
+            ),
+            status=request.param[0],
+            content_type="application/json",
+            match_querystring=False,
+        )
+        setattr(mocked_response, "expected_exception", request.param[1])
 
         yield mocked_response
 
@@ -201,3 +248,14 @@ class TestIoTHubDeviceIdentityImport(object):
                 identity=req["identity"],
                 resource_group_name=req["resource_group_name"],
             )
+
+    def test_device_identity_import_error(self, fixture_cmd, service_client_error):
+        with pytest.raises(CLIError) as e:
+            subject.iot_device_import(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                input_blob_container_uri=blob_container_uri,
+                output_blob_container_uri=blob_container_uri + "2",
+                resource_group_name="myresourcegroup",
+            )
+        assert isinstance(e.value, service_client_error.expected_exception)


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
