### PR TITLE
Iot central dps enrollment cert fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,7 +19,10 @@ unreleased
   a default value will be automatically added with a warning.
 * If the inline step content handler starts with 'microsoft' (case-insensitive), valid first-party handler values
   will be enforced.
+  
+**IoT Central updates**
 
+* Fixed an issue with enrollement group certificate encoding 
 
 0.18.1
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,11 @@ unreleased
   To learn more about this transition, visit http://aka.ms/iot-ca-updates/.
 
 
+**IoT Central updates**
+
+* Fixed an issue with enrollement group certificate encoding 
+
+
 0.18.2
 +++++++++++++++
 
@@ -47,10 +52,6 @@ unreleased
   * The `eventgrid` endpoint does not support managed identities.
 * Resource group for endpoint resources are no longer required - if not present, the resource group of the
   digital twins instance is used.
-
-**IoT Central updates**
-
-* Fixed an issue with enrollement group certificate encoding 
 
 0.18.1
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,7 +52,7 @@ unreleased
   * The `eventgrid` endpoint does not support managed identities.
 * Resource group for endpoint resources are no longer required - if not present, the resource group of the
   digital twins instance is used.
-  
+
 
 0.18.1
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,7 @@ unreleased
   * The `eventgrid` endpoint does not support managed identities.
 * Resource group for endpoint resources are no longer required - if not present, the resource group of the
   digital twins instance is used.
+  
 
 0.18.1
 +++++++++++++++

--- a/azext_iot/central/commands_enrollment_group.py
+++ b/azext_iot/central/commands_enrollment_group.py
@@ -100,11 +100,13 @@ def create_enrollment_group(
     if attestation == 'x509':
         if primary_cert_path:
             primary_cert = open_certificate(primary_cert_path)
-            primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
+            if primary_cert_path.endswith(".pem"):
+                        primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
         if secondary_cert_path:
             secondary_cert = open_certificate(secondary_cert_path)
-            secondary_cert = base64.encodebytes((secondary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
+            if secondary_cert_path.endswith(".pem"):
+                secondary_cert = base64.encodebytes((secondary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
         if primary_cert_path or secondary_cert_path:
             response["x509"] = create_x509(
@@ -157,9 +159,13 @@ def update_enrollment_group(
 
     if primary_cert_path:
         primary_cert = open_certificate(primary_cert_path)
+        if primary_cert_path.endswith(".pem"):
+            primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
     if secondary_cert_path:
         secondary_cert = open_certificate(secondary_cert_path)
+        if secondary_cert_path.endswith(".pem"):
+            secondary_cert = base64.encodebytes((secondary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
     if primary_cert_path or secondary_cert_path:
         response["x509"] = create_x509(
@@ -251,11 +257,13 @@ def verify_x509(
 
     if primary_cert_path:
         primary_cert = open_certificate(primary_cert_path)
-        primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
+        if primary_cert_path.endswith(".pem"):
+            primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
     if secondary_cert_path:
         secondary_cert = open_certificate(secondary_cert_path)
-        secondary_cert = base64.encodebytes((secondary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
+        if secondary_cert_path.endswith(".pem"):
+            secondary_cert = base64.encodebytes((secondary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
     return provider.verify_x509(
         group_id=group_id,
@@ -317,7 +325,6 @@ def generate_verification_code(
     provider = CentralEnrollmentGroupProvider(
         cmd=cmd, app_id=app_id, token=token, api_version=api_version
     )
-
     return provider.generate_verification_code(
         group_id=group_id,
         certificate_entry=certificate_entry,

--- a/azext_iot/central/commands_enrollment_group.py
+++ b/azext_iot/central/commands_enrollment_group.py
@@ -101,7 +101,7 @@ def create_enrollment_group(
         if primary_cert_path:
             primary_cert = open_certificate(primary_cert_path)
             if primary_cert_path.endswith(".pem"):
-                        primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
+                primary_cert = base64.encodebytes((primary_cert.replace('\r', '') + '\n').encode()).decode().replace('\n', '')
 
         if secondary_cert_path:
             secondary_cert = open_certificate(secondary_cert_path)


### PR DESCRIPTION
Fixing encoding of certificates to skip cer file encoding while creating iot central enrollment group.
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
