### PR TITLE
Update help text for adt invoke command example according to sample DTDL

### DIFF
--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -107,7 +107,7 @@ def load_iothub_help():
           text: >
             az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
 
-        - name: Invoke root level command "reboot" which takes a payload named "delay" conforming to DTDL model:
+        - name: Invoke root level command "reboot" which takes a payload named "delay" conforming to DTDL model -
           https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json.
           text: >
             az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload 5

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -107,8 +107,9 @@ def load_iothub_help():
           text: >
             az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
 
-        - name: Invoke root level command "reboot" which takes a payload named "delay" conforming to DTDL model -
-          https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json.
+        - name: |
+                Invoke root level command "reboot" which takes a payload named "delay" conforming to DTDL model
+                https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json.
           text: >
             az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload 5
 

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -105,7 +105,7 @@ def load_iothub_help():
         examples:
         - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property.
           text: >
-            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload '{"delay":5}'
+            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
 
         - name: Invoke command "getMaxMinReport" on component "thermostat1" that takes no input.
           text: >

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -109,9 +109,9 @@ def load_iothub_help():
           text: >
             az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
 
-        - name: Invoke root level command which takes a payload that includes certain property using inline JSON.
+        - name: In general, invoke command which takes a payload that includes certain property using inline JSON.
           text: >
-            az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{\\"property_name\\":property_value}'
+            az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
 
         - name: Invoke command "getMaxMinReport" on component "thermostat1" that takes no input.
           text: >

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -103,15 +103,15 @@ def load_iothub_help():
         short-summary: Invoke a root or component level command of a digital twin device.
 
         examples:
-        - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property with pre-configured DTDL model
-                such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
-                example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
-          text: >
-            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
-
         - name: In general, invoke command which takes a payload that includes certain property using inline JSON.
           text: >
             az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
+
+        - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property with pre-configured DTDL model
+        such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
+        example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
+          text: >
+            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
 
         - name: Invoke command "getMaxMinReport" on component "thermostat1" that takes no input.
           text: >

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -108,8 +108,8 @@ def load_iothub_help():
             az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
 
         - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property with pre-configured DTDL model
-        such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
-        example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
+          such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
+          example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
           text: >
             az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
 

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -103,9 +103,15 @@ def load_iothub_help():
         short-summary: Invoke a root or component level command of a digital twin device.
 
         examples:
-        - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property.
+        - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property with pre-configured DTDL model
+                such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
+                example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
           text: >
             az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
+
+        - name: Invoke root level command which takes a payload that includes certain property using inline JSON.
+          text: >
+            az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{\\"property_name\\":property_value}'
 
         - name: Invoke command "getMaxMinReport" on component "thermostat1" that takes no input.
           text: >

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -107,11 +107,10 @@ def load_iothub_help():
           text: >
             az iot hub digital-twin invoke-command --command-name {command_name} -n {iothub_name} -d {device_id} --payload '{"property_name": "property_value"}'
 
-        - name: Invoke root level command "reboot" which takes a payload that includes the "delay" property with pre-configured DTDL model
-          such as https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json. In the DTDL model
-          example, the "delay" property is defined as an integer, therefore integer in the payload will be mapped to set "delay".
+        - name: Invoke root level command "reboot" which takes a payload named "delay" conforming to DTDL model:
+          https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json.
           text: >
-            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload "5"
+            az iot hub digital-twin invoke-command --command-name reboot -n {iothub_name} -d {device_id} --payload 5
 
         - name: Invoke command "getMaxMinReport" on component "thermostat1" that takes no input.
           text: >


### PR DESCRIPTION
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
This pr address this issue[issue](https://github.com/Azure/azure-cli/issues/18461), according to the [DTDL sample](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json), the payload passed in successfully when it's only "5" instead of '{"delay":5}'