### PR TITLE
Remove client validation for loading certificate

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,9 @@ unreleased
 
 * Fixed an issue with enrollement group certificate encoding 
 
+**IoT DPS updates**
+
+* Removed file extension restriction when user attach certificate for enrollment groups creation/update commands.
 
 0.18.2
 +++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,7 +28,7 @@ unreleased
 
 **IoT DPS updates**
 
-* Removed file extension restriction when user attach certificate for enrollment groups creation/update commands,
+* Removed file extension restriction for attached certificates in individual enrollments and enrollment groups creation/update commands,
   and added suggested certificate format in `--help` docs.
 
 0.18.2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -28,7 +28,8 @@ unreleased
 
 **IoT DPS updates**
 
-* Removed file extension restriction when user attach certificate for enrollment groups creation/update commands.
+* Removed file extension restriction when user attach certificate for enrollment groups creation/update commands,
+  and added suggested certificate format in `--help` docs.
 
 0.18.2
 +++++++++++++++

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -1192,6 +1192,10 @@ helps[
 ] = """
     type: command
     short-summary: Create an individual device enrollment in an Azure IoT Hub Device Provisioning Service.
+    long-summary: |
+                  Please provide certificate format using Base64 ASCII encoding and the certificate
+                  should have matching BEGIN and END segments, for example:
+                  start with '-----BEGIN CERTIFICATE-----' and end with '-----END CERTIFICATE-----'.
     examples:
     - name: Create an enrollment '{enrollment_id}' with attestation type 'x509' in the Azure
             IoT Device Provisioning Service '{dps_name}' in the resource group
@@ -1246,6 +1250,10 @@ helps[
 ] = """
     type: command
     short-summary: Update an individual device enrollment in an Azure IoT Hub Device Provisioning Service.
+    long-summary: |
+                  Please provide certificate format using Base64 ASCII encoding and the certificate
+                  should have matching BEGIN and END segments, for example:
+                  start with '-----BEGIN CERTIFICATE-----' and end with '-----END CERTIFICATE-----'.
     examples:
     - name: Update enrollment '{enrollment_id}' with a new x509 certificate in the Azure IoT
             Device Provisioning Service '{dps_name}' in the resource group '{resource_group_name}'.
@@ -1352,6 +1360,10 @@ helps[
 ] = """
     type: command
     short-summary: Create an enrollment group in an Azure IoT Hub Device Provisioning Service.
+    long-summary: |
+                  Please provide certificate format using Base64 ASCII encoding and the certificate
+                  should have matching BEGIN and END segments, for example:
+                  start with '-----BEGIN CERTIFICATE-----' and end with '-----END CERTIFICATE-----'.
     examples:
     - name: Create an enrollment group '{enrollment_id}' in the Azure IoT provisioning service
             '{dps_name}' in the resource group '{resource_group_name} using an intermediate certificate as primary certificate'.
@@ -1368,7 +1380,7 @@ helps[
             'MyDps' in the resource group '{resource_group_name}' with provisioning status
             'enabled', initial twin properties
             '{"location":{"region":"US"}}' and initial twin tags '{"version_dps":"1"}'
-            using an intermediate certificate as primary certificate'.
+            using an intermediate certificate as primary certificate.
       text: >
         az iot dps enrollment-group create -g {resource_group_name} --dps-name {dps_name}
         --enrollment-id {enrollment_id} --certificate-path /certificates/Certificate.pem
@@ -1392,6 +1404,10 @@ helps[
 ] = """
     type: command
     short-summary: Update an enrollment group in an Azure IoT Hub Device Provisioning Service.
+    long-summary: |
+                  Please provide certificate format using Base64 ASCII encoding and the certificate
+                  should have matching BEGIN and END segments, for example:
+                  start with '-----BEGIN CERTIFICATE-----' and end with '-----END CERTIFICATE-----'.
     examples:
     - name: Update enrollment group '{enrollment_id}' in the Azure IoT provisioning service '{dps_name}'
             in the resource group '{resource_group_name}' with initial twin properties and initial twin tags.

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -114,14 +114,11 @@ def open_certificate(certificate_path: str) -> str:
         certificate (str): returns utf-8 encoded value from certificate file.
     """
     certificate = ""
-    if certificate_path.endswith(".pem") or certificate_path.endswith(".cer"):
-        with open(certificate_path, "rb") as cert_file:
-            certificate = cert_file.read()
-            try:
-                certificate = certificate.decode("utf-8")
-            except UnicodeError:
-                certificate = base64.b64encode(certificate).decode("utf-8")
-    else:
-        raise ValueError("Certificate file type must be either '.pem' or '.cer'.")
+    with open(certificate_path, "rb") as cert_file:
+        certificate = cert_file.read()
+        try:
+            certificate = certificate.decode("utf-8")
+        except UnicodeError:
+            certificate = base64.b64encode(certificate).decode("utf-8")
     # Remove trailing white space from the certificate content
     return certificate.rstrip()


### PR DESCRIPTION
This pr is the second part of addressing the enrollment group create/update with certificate issue. I removed the validation on the client side to make sure we are not over validating the certificate content, so that way the certificate validation now is fully handled by service call. The file extension check is removed and I kept the help text in place to give user more guidance on the certificate format

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
