### PR TITLE
Created test queries command for hub configuration

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,11 @@ unreleased
   
   To learn more about this transition, visit http://aka.ms/iot-ca-updates/.
 
+* Added test queries commands for configuration, it validates target condition and custom metric queries for a
+  configuration on the IoT Hub:
+
+    - az iot hub configuration test-queries
+
 
 **IoT Central updates**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ Release History
 
 unreleased
 +++++++++++++++
+**IoT Hub updates**
+
+* Added test queries commands for configuration, it validates target condition and custom metric queries for a
+  configuration on the IoT Hub:
+
+    - az iot hub configuration test-queries
 
 0.18.3
 +++++++++++++++
@@ -20,12 +26,6 @@ unreleased
   - az iot hub certificate root-authority set
   
   To learn more about this transition, visit http://aka.ms/iot-ca-updates/.
-
-* Added test queries commands for configuration, it validates target condition and custom metric queries for a
-  configuration on the IoT Hub:
-
-    - az iot hub configuration test-queries
-
 
 **IoT Central updates**
 

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -829,16 +829,15 @@ helps[
       This command supports both inline json and file input for custom metric queries `--custom-metric-queries`.
       Review examples and parameter description for details on how to fully utilize the operation.
 
-      - For bash inline json format use '{"key":"value"}' and \\ (backslash) for command continuation.
-      - For powershell inline json format use '{\\"key\\":\\"value\\"}' and ` (tilde) for command continuation.
-      - For cmd inline json format use \"{\\"key\\":\\"value\\"}\" and ^ (caret) for command continuation.
-      - For file based json input use "@/path/to/file". File based input avoids shell quotation issues.
+      Read more about using quotation marks and escapes characters in different shells here:
+      https://github.com/Azure/azure-iot-cli-extension/wiki/Tips#use-quotation-mark-properly-for-command-continuation
 
     examples:
     - name: Validate the target condition and custom metric queries with inline json.
       text: >
         az iot hub configuration test-queries -n {iothub_name} --target-condition "from devices.modules where tags.building=9"
-        --custom-metric-queries '{\\"mymetric\\":""select moduleId from devices.modules where tags.location=''US''""}'
+        --custom-metric-queries '{\\"mymetric\\":""select moduleId from devices.modules where tags.location=''US''"",
+        \\"mertic\\":\\"select *\\"}'
     - name: Validate the target condition and custom metric queries with json file.
       text: >
         az iot hub configuration test-queries -n {iothub_name} --target-condition "from devices.modules where tags.building=9"

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -821,6 +821,31 @@ helps[
 """
 
 helps[
+    "iot hub configuration test-queries"
+] = """
+    type: command
+    short-summary: Validates target condition and custom metric queries for a configuration on the IoT Hub
+    long-summary: |
+      This command supports both inline json and file input for custom metric queries `--custom-metric-queries`.
+      Review examples and parameter description for details on how to fully utilize the operation.
+
+      - For bash inline json format use '{"key":"value"}' and \\ (backslash) for command continuation.
+      - For powershell inline json format use '{\\"key\\":\\"value\\"}' and ` (tilde) for command continuation.
+      - For cmd inline json format use \"{\\"key\\":\\"value\\"}\" and ^ (caret) for command continuation.
+      - For file based json input use "@/path/to/file". File based input avoids shell quotation issues.
+
+    examples:
+    - name: Validate the target condition and custom metric queries with inline json.
+      text: >
+        az iot hub configuration test-queries -n {iothub_name} --target-condition "from devices.modules where tags.building=9"
+        --custom-metric-queries '{\\"mymetric\\":""select moduleId from devices.modules where tags.location=''US''""}'
+    - name: Validate the target condition and custom metric queries with json file.
+      text: >
+        az iot hub configuration test-queries -n {iothub_name} --target-condition "from devices.modules where tags.building=9"
+        --custom-metric-queries '/path/to/file'
+"""
+
+helps[
     "iot hub distributed-tracing"
 ] = """
     type: group

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -819,6 +819,13 @@ def load_arguments(self, _):
             type=int,
             help="Maximum number of configurations to return. By default all configurations are returned.",
         )
+        context.argument(
+            "custom_metric_queries",
+            options_list=["--custom-metric-queries"],
+            type=dict,
+            help="Map of custrom metric queries for configuration. "
+            'Format example: {"mertic1":"select *", "metric2":"select moduleId from devices.modules where tags.location=''US''"}',
+        )
 
     with self.argument_context("iot edge") as context:
         context.argument(

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -822,9 +822,7 @@ def load_arguments(self, _):
         context.argument(
             "custom_metric_queries",
             options_list=["--custom-metric-queries"],
-            type=dict,
-            help="Map of custrom metric queries for configuration. "
-            'Format example: {"mertic1":"select *", "metric2":"select moduleId from devices.modules where tags.location=''US''"}',
+            help="Inline custom metric queries JSON or file path to custom metric queries JSON. "
         )
 
     with self.argument_context("iot edge") as context:

--- a/azext_iot/commands.py
+++ b/azext_iot/commands.py
@@ -125,6 +125,7 @@ def load_command_table(self, _):
             getter_name="iot_hub_configuration_show",
             setter_name="iot_hub_configuration_update",
         )
+        cmd_group.command("test-queries", "iot_hub_configuration_test_queries")
 
     with self.command_group(
         "iot hub distributed-tracing", command_type=iothub_ops, is_preview=True

--- a/azext_iot/deviceupdate/_help.py
+++ b/azext_iot/deviceupdate/_help.py
@@ -842,13 +842,8 @@ def load_deviceupdate_help():
           `--related-file`. Review examples and parameter descriptions for details on how
           to fully utilize the operation.
 
-          - For bash inline json format use '{"key":"value"}' and \\ (backslash) for command continuation.
-          - For powershell inline json format use '{\\"key\\":\\"value\\"}' and ` (tilde) for command continuation.
-          - For cmd inline json format use \"{\\"key\\":\\"value\\"}\" and ^ (caret) for command continuation.
-          - For file based json input use "@/path/to/file". File based input avoids shell quotation issues.
-
-          For a detailed explanation of shell quoting rules please goto
-            https://learn.microsoft.com/en-us/cli/azure/use-cli-effectively
+          Read more about using quotation marks and escapes characters in different shells here
+            https://github.com/Azure/azure-iot-cli-extension/wiki/Tips#use-quotation-mark-properly-for-command-continuation
 
         examples:
         - name: Initialize a minimum content import manifest. Inline json optimized for `bash`.

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -49,6 +49,7 @@ from azext_iot._factory import SdkResolver, CloudError
 from azext_iot.operations.generic import _execute_query, _process_top
 from typing import Optional
 import pprint
+from azext_iot.common.utility import validate_key_value_pairs
 
 logger = get_logger(__name__)
 printer = pprint.PrettyPrinter(indent=2)
@@ -1641,8 +1642,13 @@ def iot_hub_configuration_test_queries(
     try:
         headers = {}
         headers["If-Match"] = '"{}"'.format(etag if etag else "*")
+        if custom_metric_queries:
+            custom_metric_queries = process_json_arg(custom_metric_queries, argument_name="content")
         result = service_sdk.configuration.test_queries(target_condition, custom_metric_queries)
-        print(result.target_condition_error)
+        if result.target_condition_error is not None:
+            logger.error('Target condition validation failed: "%s".', result.target_condition_error)
+        if result.custom_metric_query_errors is not None:
+            logger.error('Target condition validation failed: "%s".', result.custom_metric_query_errors)
     except CloudError as e:
         handle_service_exception(e)
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1625,7 +1625,7 @@ def iot_hub_configuration_test_queries(
     hub_name=None,
     resource_group_name=None,
     login=None,
-    auth_type_dataplane=None,
+    auth_type_dataplane=None
 ):
     discovery = IotHubDiscovery(cmd)
     target = discovery.get_target(
@@ -1641,14 +1641,17 @@ def iot_hub_configuration_test_queries(
         if custom_metric_queries:
             custom_metric_queries = process_json_arg(custom_metric_queries, argument_name="custom_metric_queries")
 
-        result = service_sdk.configuration.test_queries(target_condition, custom_metric_queries)
+        result = service_sdk.configuration.test_queries(target_condition, custom_metric_queries, raw=True).response.json()
+        validation_errors = []
 
-        if not result.target_condition_error and not result.custom_metric_query_errors:
+        if not result['targetConditionError'] and not result['customMetricQueryErrors']:
             return 'Validation passed!'
-        if result.target_condition_error:
-            return 'Target condition validation failed: {}.'.format(result.target_condition_error)
-        if result.custom_metric_query_errors:
-            return 'Custom metric query validation failed: {}.'.format(result.custom_metric_query_errors)
+        if result['targetConditionError']:
+            validation_errors.append('Target condition validation failed: {}.'.format(result['targetConditionError']))
+        if result['customMetricQueryErrors']:
+            validation_errors.append('Custom metric query validation failed: {}.'.format(result['customMetricQueryErrors']))
+
+        return validation_errors
     except CloudError as e:
         handle_service_exception(e)
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1639,17 +1639,16 @@ def iot_hub_configuration_test_queries(
 
     try:
         if custom_metric_queries:
-            custom_metric_queries = process_json_arg(custom_metric_queries, argument_name="content")
+            custom_metric_queries = process_json_arg(custom_metric_queries, argument_name="custom_metric_queries")
 
         result = service_sdk.configuration.test_queries(target_condition, custom_metric_queries)
 
         if not result.target_condition_error and not result.custom_metric_query_errors:
-            print("Validation passed!")
-            return
+            return 'Validation passed!'
         if result.target_condition_error:
-            logger.error('Target condition validation failed: "%s".', result.target_condition_error)
+            return 'Target condition validation failed: {}.'.format(result.target_condition_error)
         if result.custom_metric_query_errors:
-            logger.error('Target condition validation failed: "%s".', result.custom_metric_query_errors)
+            return 'Custom metric query validation failed: {}.'.format(result.custom_metric_query_errors)
     except CloudError as e:
         handle_service_exception(e)
 

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -1618,6 +1618,35 @@ def iot_hub_configuration_delete(
         handle_service_exception(e)
 
 
+def iot_hub_configuration_test_queries(
+    cmd,
+    target_condition=None,
+    custom_metric_queries=None,
+    hub_name=None,
+    resource_group_name=None,
+    login=None,
+    auth_type_dataplane=None,
+    etag=None,
+):
+    discovery = IotHubDiscovery(cmd)
+    target = discovery.get_target(
+        resource_name=hub_name,
+        resource_group_name=resource_group_name,
+        login=login,
+        auth_type=auth_type_dataplane,
+    )
+    resolver = SdkResolver(target=target)
+    service_sdk = resolver.get_sdk(SdkType.service_sdk)
+
+    try:
+        headers = {}
+        headers["If-Match"] = '"{}"'.format(etag if etag else "*")
+        result = service_sdk.configuration.test_queries(target_condition, custom_metric_queries)
+        print(result.target_condition_error)
+    except CloudError as e:
+        handle_service_exception(e)
+
+
 def iot_edge_deployment_metric_show(
     cmd,
     config_id,

--- a/azext_iot/tests/iothub/configurations/test_config_custom_queries.json
+++ b/azext_iot/tests/iothub/configurations/test_config_custom_queries.json
@@ -1,0 +1,1 @@
+{"mymetric": "SELECT deviceId from devices where properties.reported.lastDesiredStatus.code = 200"}

--- a/azext_iot/tests/iothub/configurations/test_config_custom_queries.json
+++ b/azext_iot/tests/iothub/configurations/test_config_custom_queries.json
@@ -1,1 +1,4 @@
-{"mymetric": "SELECT deviceId from devices where properties.reported.lastDesiredStatus.code = 200"}
+{
+    "metric1": "SELECT deviceId from devices where properties.reported.lastDesiredStatus.code = 200",
+    "mertic2": "SELECT moduleId from devices.modules where tags.location='US'"
+}

--- a/azext_iot/tests/iothub/configurations/test_iot_config_int.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_int.py
@@ -686,7 +686,6 @@ class TestIoTConfigurations(IoTLiveScenarioTest):
                     ),
                     auth_type=auth_phase,
                 ),
-                expect_failure=False,
             )
 
             # Validate custom metric queries for configuration
@@ -697,7 +696,6 @@ class TestIoTConfigurations(IoTLiveScenarioTest):
                     ),
                     auth_type=auth_phase,
                 ),
-                expect_failure=False,
             )
 
             # Create Edge deployment to ensure it doesn't show up on ADM list

--- a/azext_iot/tests/iothub/configurations/test_iot_config_int.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_int.py
@@ -24,6 +24,7 @@ edge_content_malformed_path = get_context_path(
 generic_metrics_path = get_context_path(__file__, "test_config_generic_metrics.json")
 adm_content_module_path = get_context_path(__file__, "test_adm_module_content.json")
 adm_content_device_path = get_context_path(__file__, "test_adm_device_content.json")
+custom_queries_path = get_context_path(__file__, "test_config_custom_queries.json")
 
 
 class TestIoTConfigurations(IoTLiveScenarioTest):
@@ -674,6 +675,29 @@ class TestIoTConfigurations(IoTLiveScenarioTest):
                     auth_type=auth_phase,
                 ),
                 expect_failure=True,
+            )
+
+            # Validate target condition for configuration
+            target_condition = "from devices.modules where tags.building=9"
+            self.cmd(
+                self.set_cmd_auth_type(
+                    "iot hub configuration test-queries -n {} --target-condition \"{}\"".format(
+                        self.entity_name, target_condition
+                    ),
+                    auth_type=auth_phase,
+                ),
+                expect_failure=False,
+            )
+
+            # Validate custom metric queries for configuration
+            self.cmd(
+                self.set_cmd_auth_type(
+                    "iot hub configuration test-queries -n {} --custom-metric-queries '{}'".format(
+                        self.entity_name, custom_queries_path
+                    ),
+                    auth_type=auth_phase,
+                ),
+                expect_failure=False,
             )
 
             # Create Edge deployment to ensure it doesn't show up on ADM list

--- a/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
@@ -908,23 +908,12 @@ class TestConfigTestQueries:
         service_client.return_value = build_mock_response(mocker, request.param, {})
         return service_client
 
-    @pytest.mark.parametrize(
-        "hub_name, target_condition, custom_metric_queries, etag",
-        [
-            (
-                mock_target["entity"],
-                "tags.building=43 and tags.environment='test'",
-                '{"hi": "sd"}',
-                [generate_generic_id(), None],
-            )
-        ],
-    )
-    def test_config_queries(self, fixture_cmd, serviceclient, hub_name, target_condition, custom_metric_queries):
+    def test_config_queries(self, fixture_cmd, serviceclient):
         subject.iot_hub_configuration_test_queries(
             cmd=fixture_cmd,
-            hub_name=hub_name,
-            target_condition=target_condition,
-            custom_metric_queries=custom_metric_queries,
+            hub_name=mock_target["entity"],
+            target_condition="tags.building=43 and tags.environment='test'",
+            custom_metric_queries='{"hi": "sd"}',
         )
         args = serviceclient.call_args
         url = args[0][0].url
@@ -937,24 +926,13 @@ class TestConfigTestQueries:
         assert body.get("targetCondition") == "tags.building=43 and tags.environment='test'"
         assert body.get("customMetricQueries") == {'hi': 'sd'}
 
-    @pytest.mark.parametrize(
-        "hub_name, target_condition, custom_metric_queries, etag",
-        [
-            (
-                mock_target["entity"],
-                "targetCondition",
-                "hello.txt",
-                [generate_generic_id(), None],
-            )
-        ],
-    )
     def test_config_queries_invalid_args(
-        self, fixture_cmd, serviceclient, hub_name, target_condition, custom_metric_queries
+        self, fixture_cmd, serviceclient
     ):
         with pytest.raises(CLIError):
             subject.iot_hub_configuration_test_queries(
                 cmd=fixture_cmd,
-                hub_name=hub_name,
-                target_condition=target_condition,
-                custom_metric_queries=custom_metric_queries,
+                hub_name=mock_target["entity"],
+                target_condition="targetCondition",
+                custom_metric_queries="hello.txt",
             )

--- a/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
@@ -914,18 +914,17 @@ class TestConfigTestQueries:
             (
                 mock_target["entity"],
                 "tags.building=43 and tags.environment='test'",
-                "{\"hi\": \"sd\"}",
+                '{"hi": "sd"}',
                 [generate_generic_id(), None],
             )
         ],
     )
-    def test_config_queries(self, fixture_cmd, serviceclient, hub_name, etag, target_condition, custom_metric_queries):
+    def test_config_queries(self, fixture_cmd, serviceclient, hub_name, target_condition, custom_metric_queries):
         subject.iot_hub_configuration_test_queries(
             cmd=fixture_cmd,
             hub_name=hub_name,
             target_condition=target_condition,
             custom_metric_queries=custom_metric_queries,
-            etag=etag,
         )
         args = serviceclient.call_args
         url = args[0][0].url
@@ -950,7 +949,7 @@ class TestConfigTestQueries:
         ],
     )
     def test_config_queries_invalid_args(
-        self, fixture_cmd, serviceclient, hub_name, etag, target_condition, custom_metric_queries
+        self, fixture_cmd, serviceclient, hub_name, target_condition, custom_metric_queries
     ):
         with pytest.raises(CLIError):
             subject.iot_hub_configuration_test_queries(
@@ -958,5 +957,4 @@ class TestConfigTestQueries:
                 hub_name=hub_name,
                 target_condition=target_condition,
                 custom_metric_queries=custom_metric_queries,
-                etag=etag,
             )


### PR DESCRIPTION
Created test queries command for hub configuration, it help to validate target condition and custom metric queries

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
