### PR TITLE
Edge devices create - feature tweaks and tests

### DIFF
--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -233,7 +233,7 @@ class DeviceIdentityProvider(IoTHubProvider):
             if any(duplicates):
                 raise InvalidArgumentValueError(
                     f"The following devices already exist on hub '{self.hub_name}': {duplicates}. "
-                    "To clear all devices before creating the hierarchy, please utilize the `--clean` switch."
+                    "To delete all existing devices before creating new ones, please utilize the `--clean` switch."
                 )
 
         # Create all devices and configs

--- a/azext_iot/iothub/providers/helpers/edge_device_config.py
+++ b/azext_iot/iothub/providers/helpers/edge_device_config.py
@@ -103,6 +103,7 @@ DEVICE_CONFIG_SCHEMA_VALID_VERSIONS["1.0"] = {
 
 # Edge device TOML default values
 DEVICE_CONFIG_TOML = {
+    "auto_reprovisioning_mode": "Dynamic",
     "hostname": "",
     "provisioning": {
         "device_id": "",
@@ -258,8 +259,9 @@ def create_edge_device_config(
     device_toml[
         "trust_bundle_cert"
     ] = f"file:///etc/aziot/certificates/{EDGE_ROOT_CERTIFICATE_FILENAME}"
-    # Dynamic, AlwaysOnStartup, OnErrorOnly
-    device_toml["auto_reprovisioning_mode"] = "Dynamic"
+    # Dynamic is the default auto reprovisioning mode, but respect config settings
+    device_toml["auto_reprovisioning_mode"] = getattr(device_toml, "auto_reprovisioning_mode", "Dynamic")
+
     device_toml["hostname"] = (
         device_config.hostname if device_config.hostname else "{{HOSTNAME}}"
     )

--- a/azext_iot/tests/iothub/devices/device_configs/device_config.toml
+++ b/azext_iot/tests/iothub/devices/device_configs/device_config.toml
@@ -3,6 +3,7 @@
 
 hostname = ""
 parent_hostname = ""
+auto_reprovisioning_mode = "OnErrorOnly"
 
 [provisioning]
 device_id = ""

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -813,11 +813,15 @@ class TestEdgeHierarchyConfigFunctions:
             device_config.hostname if device_config.hostname else "{{HOSTNAME}}"
         )
 
-        # respect existing config reprovisioning mode
+        # respect existing config reprovisioning mode, or use "Dynamic" if not present
         if device_config_path:
             with open(device_config_path, "rb") as file:
                 expected_config = tomli.load(file)
-                assert device_toml["auto_reprovisioning_mode"] == getattr(expected_config, "auto_reprovisioning_mode", "Dynamic")
+                if not getattr(expected_config, "auto_reprovisioning_mode", None):
+                    assert device_toml["auto_reprovisioning_mode"] == "Dynamic"
+                else:
+                    assert device_toml["auto_reprovisioning_mode"] == expected_config["auto_provisioning_mode"]
+        # default should be dynamic
         else:
             assert device_toml["auto_reprovisioning_mode"] == "Dynamic"
 

--- a/azext_iot/tests/utility/test_iot_file_operations.py
+++ b/azext_iot/tests/utility/test_iot_file_operations.py
@@ -38,6 +38,7 @@ class TestFileOperations(object):
                     os.rmdir(destination)
         except Exception as ex:
             assert (error and isinstance(ex, error))
+        assert error is None
 
     @pytest.mark.parametrize(
         "target_directory, tarfile_path, tarfile_name, overwrite, error, delete_after_test",


### PR DESCRIPTION
Only set auto-reprovision mode to Dynamic if not set

Edit existing device-identity error message, add tests

Added test for file write error handling

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [x] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
