### PR TITLE
Add unit test to check for file header information

### DIFF
--- a/azext_iot/central/models/ga_2022_07_31/__init__.py
+++ b/azext_iot/central/models/ga_2022_07_31/__init__.py
@@ -1,3 +1,9 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 from azext_iot.central.models.ga_2022_07_31.api_token import ApiToken as ApiTokenGa
 from azext_iot.central.models.ga_2022_07_31.device_group import DeviceGroup as DeviceGroupGa
 from azext_iot.central.models.ga_2022_07_31.device import Device as DeviceGa

--- a/azext_iot/central/models/ga_2022_07_31/user.py
+++ b/azext_iot/central/models/ga_2022_07_31/user.py
@@ -1,3 +1,9 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 class User:
     def __init__(self, user: dict):
         self.id = user.get("id")

--- a/azext_iot/central/models/v2022_06_30_preview/__init__.py
+++ b/azext_iot/central/models/v2022_06_30_preview/__init__.py
@@ -1,3 +1,9 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 from azext_iot.central.models.v2022_06_30_preview.device import Device as DevicePreview
 from azext_iot.central.models.v2022_06_30_preview.query_response import (
     QueryResponse as QueryReponsePreview,

--- a/azext_iot/common/_homebrew_patch.py
+++ b/azext_iot/common/_homebrew_patch.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.

--- a/azext_iot/tests/utility/test_iot_utility_unit.py
+++ b/azext_iot/tests/utility/test_iot_utility_unit.py
@@ -477,3 +477,36 @@ class TestHandleServiceException(object):
 
         with pytest.raises(expected_error):
             handle_service_exception(error)
+
+
+class TestFileHeaders(object):
+    def test_file_headers(self):
+        from azext_iot.constants import EXTENSION_ROOT
+
+        header = """# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------"""
+
+        files_missing_header = []
+        sdk_root = "sdk"
+
+        def _validate_directory(path):
+            for entry in os.scandir(path):
+                if entry.is_dir(follow_symlinks=False) and sdk_root not in entry.path:
+                    _validate_directory(entry.path)
+                else:
+                    if entry.is_file() and entry.path.endswith(".py"):
+                        contents = None
+                        with open(entry.path, "rt", encoding="utf-8") as f:
+                            contents = f.read()
+                        if contents and not contents.startswith(header):
+                            files_missing_header.append(entry.path)
+
+        _validate_directory(EXTENSION_ROOT)
+        if files_missing_header:
+            pytest.fail(
+                "The following files are missing an encoding and license header, or it is improperly formatted:\n"
+                "{}".format("\n".join(files_missing_header))
+            )


### PR DESCRIPTION
This adds a unit test to check (similar to our `__init__.py` test) that each .py file (outside of `azext_iot/sdk`) has correct encoding and license header information.

Some of the generated SDKs have different header formatting depending on how/when they were generated, so this currently just skips the entire SDK folder for now.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
