### PR TITLE
Update Responses to use 0.22.0

### DIFF
--- a/azext_iot/tests/digitaltwins/test_dt_model_unit.py
+++ b/azext_iot/tests/digitaltwins/test_dt_model_unit.py
@@ -13,7 +13,7 @@ from knack.cli import CLIError
 from azext_iot.digitaltwins import commands_models as subject
 from msrest.paging import Paged
 from urllib.parse import unquote
-from urllib3.exceptions import MaxRetryError
+from msrest.exceptions import ClientRequestError
 from azext_iot.tests.digitaltwins.dt_helpers import (
     generate_model_id,
     generate_model_result,
@@ -321,7 +321,7 @@ class TestShowModel(object):
         yield mocked_response
 
     def test_show_model_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.show_model(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -330,7 +330,7 @@ class TestShowModel(object):
                 resource_group_name=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -518,7 +518,7 @@ class TestUpdateModel(object):
         yield mocked_response
 
     def test_update_model_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.update_model(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -529,7 +529,7 @@ class TestUpdateModel(object):
         status_codes = [call.response.status_code for call in service_client_error.calls]
         # Retries 5 times
         if status_codes == [204] + [500] * 5:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -581,7 +581,7 @@ class TestDeleteModel(object):
         yield mocked_response
 
     def test_delete_model_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.delete_model(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -589,7 +589,7 @@ class TestDeleteModel(object):
                 resource_group_name=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -694,13 +694,13 @@ class TestDeleteAllModels(object):
         yield mocked_response
 
     def test_delete_all_models_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.delete_all_models(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
                 resource_group_name=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)

--- a/azext_iot/tests/digitaltwins/test_dt_twin_unit.py
+++ b/azext_iot/tests/digitaltwins/test_dt_twin_unit.py
@@ -11,7 +11,7 @@ import json
 from knack.cli import CLIError
 from azext_iot.digitaltwins import commands_twins as subject
 from msrest.paging import Paged
-from urllib3.exceptions import MaxRetryError
+from msrest.exceptions import ClientRequestError
 from azext_iot.tests.digitaltwins.dt_helpers import (
     etag,
     generate_generic_id,
@@ -245,7 +245,7 @@ class TestTwinCreateTwin(object):
         yield mocked_response
 
     def test_create_twin_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.create_twin(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -254,7 +254,7 @@ class TestTwinCreateTwin(object):
                 properties=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -309,7 +309,7 @@ class TestTwinShowTwin(object):
         [None, resource_group]
     )
     def test_show_twin_error(self, fixture_cmd, service_client_error, resource_group_name):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.show_twin(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -317,7 +317,7 @@ class TestTwinShowTwin(object):
                 resource_group_name=resource_group_name
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -424,7 +424,7 @@ class TestTwinUpdateTwin(object):
         yield mocked_response
 
     def test_update_twin_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.update_twin(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -436,7 +436,7 @@ class TestTwinUpdateTwin(object):
         status_codes = [call.response.status_code for call in service_client_error.calls]
         # Retries 5 times
         if status_codes == [202] + [500] * 5:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -496,7 +496,7 @@ class TestTwinDeleteTwin(object):
         [(None, None), (resource_group, None), (None, etag)]
     )
     def test_delete_twin_error(self, fixture_cmd, service_client_error, resource_group_name, etag):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.delete_twin(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -505,7 +505,7 @@ class TestTwinDeleteTwin(object):
                 etag=etag
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -681,7 +681,7 @@ class TestTwinCreateRelationship(object):
         yield mocked_response
 
     def test_create_relationship_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.create_relationship(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -691,7 +691,7 @@ class TestTwinCreateRelationship(object):
                 relationship=""
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -740,7 +740,7 @@ class TestTwinShowRelationship(object):
         yield mocked_response
 
     def test_show_relationship_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.show_relationship(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -749,7 +749,7 @@ class TestTwinShowRelationship(object):
                 resource_group_name=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -857,7 +857,7 @@ class TestTwinUpdateRelationship(object):
         yield mocked_response
 
     def test_update_relationship_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.update_relationship(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -870,7 +870,7 @@ class TestTwinUpdateRelationship(object):
         status_codes = [call.response.status_code for call in service_client_error.calls]
         # Retries 5 times
         if status_codes == [204] + [500] * 5:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -1005,7 +1005,7 @@ class TestTwinListRelationship(object):
         yield mocked_response
 
     def test_list_relationship_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)):
+        with pytest.raises((CLIError, ClientRequestError)):
             subject.list_relationships(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -1072,7 +1072,7 @@ class TestTwinDeleteRelationship(object):
         yield mocked_response
 
     def test_delete_relationship_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.delete_relationship(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -1082,7 +1082,7 @@ class TestTwinDeleteRelationship(object):
                 etag=None
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 
@@ -1438,7 +1438,7 @@ class TestTwinShowComponent(object):
         yield mocked_response
 
     def test_show_component_error(self, fixture_cmd, service_client_error):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.show_component(
                 cmd=fixture_cmd,
                 name_or_hostname=hostname,
@@ -1447,7 +1447,7 @@ class TestTwinShowComponent(object):
                 resource_group_name=None,
             )
         if service_client_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -9,7 +9,7 @@ import json
 import responses
 from azext_iot.operations import dps as subject
 from knack.util import CLIError
-from urllib3.exceptions import MaxRetryError
+from msrest.exceptions import ClientRequestError
 from azext_iot.tests.conftest import mock_dps_target, mock_symmetric_key_attestation
 
 
@@ -270,7 +270,7 @@ class TestEnrollmentCreate():
         (generate_enrollment_create_req(attestation_type='tpm', endorsement_key='mykey'))
     ])
     def test_enrollment_show_error(self, serviceclient_generic_error, fixture_cmd, req):
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.iot_dps_device_enrollment_create(
                 cmd=fixture_cmd,
                 enrollment_id=req['enrollment_id'],
@@ -285,7 +285,7 @@ class TestEnrollmentCreate():
                 provisioning_status=req['provisioning_status'],
             )
         if serviceclient_generic_error.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -9,6 +9,7 @@ import json
 import responses
 from azext_iot.operations import dps as subject
 from knack.util import CLIError
+from urllib3.exceptions import MaxRetryError
 from azext_iot.tests.conftest import mock_dps_target, mock_symmetric_key_attestation
 
 
@@ -269,7 +270,7 @@ class TestEnrollmentCreate():
         (generate_enrollment_create_req(attestation_type='tpm', endorsement_key='mykey'))
     ])
     def test_enrollment_show_error(self, serviceclient_generic_error, fixture_cmd, req):
-        with pytest.raises(CLIError):
+        with pytest.raises((CLIError, MaxRetryError)) as e:
             subject.iot_dps_device_enrollment_create(
                 cmd=fixture_cmd,
                 enrollment_id=req['enrollment_id'],
@@ -283,6 +284,10 @@ class TestEnrollmentCreate():
                 initial_twin_properties=req['initial_twin_properties'],
                 provisioning_status=req['provisioning_status'],
             )
+        if serviceclient_generic_error.calls[0].response.status_code == 500:
+            assert isinstance(e.value, MaxRetryError)
+        else:
+            assert isinstance(e.value, CLIError)
 
 
 def generate_enrollment_show(**kvp):

--- a/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
@@ -12,7 +12,7 @@ import json
 from uuid import uuid4
 from random import randint
 from knack.cli import CLIError
-from urllib3.exceptions import MaxRetryError
+from msrest.exceptions import ClientRequestError
 from azext_iot.operations import hub as subject
 from azext_iot.common.utility import read_file_content, evaluate_literal, validate_key_value_pairs
 from azext_iot.tests.conftest import (
@@ -903,12 +903,12 @@ class TestConfigList:
 
     def test_config_list_error(self, fixture_cmd, service_client_generic_errors):
         service_client_generic_errors.assert_all_requests_are_fired = False
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.iot_hub_configuration_list(
                 cmd=fixture_cmd, hub_name=mock_target["entity"]
             )
         if service_client_generic_errors.calls[0].response.status_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 

--- a/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
+++ b/azext_iot/tests/iothub/configurations/test_iot_config_unit.py
@@ -12,6 +12,7 @@ import json
 from uuid import uuid4
 from random import randint
 from knack.cli import CLIError
+from urllib3.exceptions import MaxRetryError
 from azext_iot.operations import hub as subject
 from azext_iot.common.utility import read_file_content, evaluate_literal, validate_key_value_pairs
 from azext_iot.tests.conftest import (
@@ -902,10 +903,14 @@ class TestConfigList:
 
     def test_config_list_error(self, fixture_cmd, service_client_generic_errors):
         service_client_generic_errors.assert_all_requests_are_fired = False
-        with pytest.raises(CLIError):
+        with pytest.raises((CLIError, MaxRetryError)) as e:
             subject.iot_hub_configuration_list(
                 cmd=fixture_cmd, hub_name=mock_target["entity"]
             )
+        if service_client_generic_errors.calls[0].response.status_code == 500:
+            assert isinstance(e.value, MaxRetryError)
+        else:
+            assert isinstance(e.value, CLIError)
 
 
 class TestConfigApply:

--- a/azext_iot/tests/iothub/core/test_iot_ext_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_ext_unit.py
@@ -31,7 +31,7 @@ from azext_iot.tests.conftest import (
 )
 from azext_iot.common.shared import DeviceAuthApiType
 from pathlib import Path
-from urllib3.exceptions import MaxRetryError
+from msrest.exceptions import ClientRequestError
 
 CWD = os.path.dirname(os.path.abspath(__file__))
 device_id = "mydevice"
@@ -673,13 +673,13 @@ class TestDeviceShow:
             match_querystring=False,
         )
 
-        with pytest.raises((CLIError, MaxRetryError)) as e:
+        with pytest.raises((CLIError, ClientRequestError)) as e:
             subject.iot_device_show(
                 cmd=fixture_cmd, device_id=device_id, hub_name=mock_target["entity"]
             )
 
         if error_code == 500:
-            assert isinstance(e.value, MaxRetryError)
+            assert isinstance(e.value, ClientRequestError)
         else:
             assert isinstance(e.value, CLIError)
 

--- a/dev_requirements
+++ b/dev_requirements
@@ -3,7 +3,7 @@ pytest-mock
 pytest-cov
 pytest-env
 uamqp~=1.2
-responses==0.21.0
+responses==0.22.0
 black
 wheel==0.30.0
 pre-commit

--- a/dev_requirements
+++ b/dev_requirements
@@ -3,7 +3,7 @@ pytest-mock
 pytest-cov
 pytest-env
 uamqp~=1.2
-responses<=0.20.0
+responses==0.21.0
 black
 wheel==0.30.0
 pre-commit


### PR DESCRIPTION
Update to pin responses to the newest 0.22.0. Only tests were updated.

The biggest change is that now 500 return a different error - msrest.exceptions.ClientRequestError. This is similar to what the service returns for a hub with a non working dataplane.

Query has also been changed: if you have a 500 response with a next link, the responses package will go to the next page rather than failing right away. Tests have been updated to reflect this.

Note that 0.21.0 is skipped because the 500's return urllib3.exceptions.MaxRetryError

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
