### PR TITLE
Update Responses

### DIFF
--- a/dev_requirements
+++ b/dev_requirements
@@ -3,7 +3,7 @@ pytest-mock
 pytest-cov
 pytest-env
 uamqp~=1.2
-responses<=0.20.0
+responses==0.22.0
 black
 wheel==0.30.0
 pre-commit


### PR DESCRIPTION
Update and pin the responses to 0.22.0

The key change here is that now they support retry logic starting with 0.21.0 (https://github.com/getsentry/responses/commit/bdc5eff7169a6fba730f2f8427d5ec5a817b1ad5#diff-27a24757cfb28e26971f5b4f49ba6f533b5a51c770d57369cebbef09c7433d6c). But we do not want that retry logic in our tests so I forcefully turn it off!

Also from github issues, 0.21.0 returns the wrong type for retry errors so we will skip that version.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
