### PR TITLE
fix state

### DIFF
--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -497,7 +497,7 @@ class StateProvider(IoTHubProvider):
         # if incorrect permissions, will fail to retrieve any devices
         devices = {}
         try:
-            twins = _iot_device_twin_list(target=target, top=-1)
+            twins = _iot_device_twin_list(target=target, top=None)
         except AzCLIError:
             logger.warning(usr_msgs.SAVE_DEVICES_RETRIEVE_FAIL_MSG)
             return
@@ -1017,7 +1017,7 @@ class StateProvider(IoTHubProvider):
 
     def delete_all_devices(self):
         """Delete all devices if possible."""
-        identities = _iot_device_twin_list(target=self.target, top=-1)
+        identities = _iot_device_twin_list(target=self.target, top=None)
         for d in tqdm(identities, desc=usr_msgs.DELETE_DEVICES_DESC, ascii=" #"):
             try:
                 _iot_device_delete(target=self.target, device_id=d["deviceId"])


### PR DESCRIPTION
process top to validator broke a state dataplane thing. Here is the fix

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
