### PR TITLE
Dt endpoint fixes

### DIFF
--- a/azext_iot/digitaltwins/providers/endpoint/builders.py
+++ b/azext_iot/digitaltwins/providers/endpoint/builders.py
@@ -94,7 +94,7 @@ class EventGridEndpointBuilder(BaseEndpointBuilder):
 
     def build_key_based(self):
         eg_topic_keys_op = self.cli.invoke(
-            "eventgrid topic key list -n {} -g {}".format(
+            "eventgrid topic key list --name {} -g {}".format(
                 self.endpoint_resource_name, self.endpoint_resource_group
             ),
             subscription=self.endpoint_subscription,
@@ -104,7 +104,7 @@ class EventGridEndpointBuilder(BaseEndpointBuilder):
         eg_topic_keys = eg_topic_keys_op.as_json()
 
         eg_topic_endpoint_op = self.cli.invoke(
-            "eventgrid topic show -n {} -g {}".format(
+            "eventgrid topic show --name {} -g {}".format(
                 self.endpoint_resource_name, self.endpoint_resource_group
             ),
             subscription=self.endpoint_subscription,
@@ -155,7 +155,7 @@ class ServiceBusEndpointBuilder(BaseEndpointBuilder):
 
     def build_key_based(self):
         sb_topic_keys_op = self.cli.invoke(
-            "servicebus topic authorization-rule keys list -n {} "
+            "servicebus topic authorization-rule keys list --name {} "
             "--namespace-name {} -g {} --topic-name {}".format(
                 self.endpoint_resource_policy,
                 self.endpoint_resource_namespace,
@@ -235,7 +235,7 @@ class EventHubEndpointBuilder(BaseEndpointBuilder):
 
     def build_key_based(self):
         eventhub_topic_keys_op = self.cli.invoke(
-            "eventhubs eventhub authorization-rule keys list -n {} "
+            "eventhubs eventhub authorization-rule keys list --name {} "
             "--namespace-name {} -g {} --eventhub-name {}".format(
                 self.endpoint_resource_policy,
                 self.endpoint_resource_namespace,


### PR DESCRIPTION
changing from -n to --name for servicebus/eventhub/eventgrid endpoint retrieval


dt for all python versions (failed test is dt_models)
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=7904&view=results

all services for one version
https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=7907&view=results

History
Fix to support authorization rule retrieval for digital twin endpoints with CLI core version 2.46.0. Affected commands are:
- az dt endpoint create


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
