### PR TITLE
Address Ryan's comments for #634

### DIFF
--- a/azext_iot/tests/deviceupdate/conftest.py
+++ b/azext_iot/tests/deviceupdate/conftest.py
@@ -302,16 +302,16 @@ def _iothub_provisioner(request) -> Optional[dict]:
             hub_id_map = {}
             hub_names = []
 
-            # # Assign Data Contributor role to resource group if it does not exist
-            # account = cli.invoke("account show").as_json()
-            # scope_id = "/subscriptions/{}/resourceGroups/{}".format(
-            #     account["id"],
-            #     ACCOUNT_RG
-            # )
-            # assign_role_assignment(
-            #     role="IoT Hub Data Contributor",
-            #     scope=scope_id,
-            #     assignee=AUTH_RESOURCE_ID)
+            # Assign Data Contributor role to resource group if it does not exist
+            account = cli.invoke("account show").as_json()
+            scope_id = "/subscriptions/{}/resourceGroups/{}".format(
+                account["id"],
+                ACCOUNT_RG
+            )
+            assign_role_assignment(
+                role="IoT Hub Data Contributor",
+                scope=scope_id,
+                assignee=AUTH_RESOURCE_ID)
 
             for _ in range(desired_instance_count):
                 target_name = generate_linked_hub_id()

--- a/azext_iot/tests/deviceupdate/conftest.py
+++ b/azext_iot/tests/deviceupdate/conftest.py
@@ -302,16 +302,16 @@ def _iothub_provisioner(request) -> Optional[dict]:
             hub_id_map = {}
             hub_names = []
 
-            # Assign Data Contributor role to resource group if it does not exist
-            account = cli.invoke("account show").as_json()
-            scope_id = "/subscriptions/{}/resourceGroups/{}".format(
-                account["id"],
-                ACCOUNT_RG
-            )
-            assign_role_assignment(
-                role="IoT Hub Data Contributor",
-                scope=scope_id,
-                assignee=AUTH_RESOURCE_ID)
+            # # Assign Data Contributor role to resource group if it does not exist
+            # account = cli.invoke("account show").as_json()
+            # scope_id = "/subscriptions/{}/resourceGroups/{}".format(
+            #     account["id"],
+            #     ACCOUNT_RG
+            # )
+            # assign_role_assignment(
+            #     role="IoT Hub Data Contributor",
+            #     scope=scope_id,
+            #     assignee=AUTH_RESOURCE_ID)
 
             for _ in range(desired_instance_count):
                 target_name = generate_linked_hub_id()

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -262,7 +262,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             scope=rbac_instance["id"],
             assignee=rbac_assignee_owner)
 
-        assert assign_output
+        assert assign_output and assign_output.success()
 
         assert_common_rbac_attributes(
             assign_output.as_json(),
@@ -276,7 +276,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             scope=rbac_instance["id"],
             assignee=rbac_assignee_reader)
 
-        assert assign_output
+        assert assign_output and assign_output.success()
 
         assert_common_rbac_attributes(
             assign_output.as_json(),

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -260,10 +260,12 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         assign_output = assign_role_assignment(
             role=self.role_map["owner"],
             scope=rbac_instance["id"],
-            assignee=rbac_assignee_owner).as_json()
+            assignee=rbac_assignee_owner)
+
+        assert assign_output
 
         assert_common_rbac_attributes(
-            assign_output,
+            assign_output.as_json(),
             rbac_instance_name,
             "owner",
             rbac_assignee_owner,
@@ -272,10 +274,12 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         assign_output = assign_role_assignment(
             role=self.role_map["reader"],
             scope=rbac_instance["id"],
-            assignee=rbac_assignee_reader).as_json()
+            assignee=rbac_assignee_reader)
+
+        assert assign_output
 
         assert_common_rbac_attributes(
-            assign_output,
+            assign_output.as_json(),
             rbac_instance_name,
             "reader",
             rbac_assignee_reader,

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -18,7 +18,6 @@ from typing import TypeVar
 ensure_azure_namespace_path()
 
 from azure.iot.device import ProvisioningDeviceClient, IoTHubDeviceClient
-from azure.cli.core.azclierror import CLIInternalError
 from knack.log import get_logger
 
 


### PR DESCRIPTION
---
Pipleline run: https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=7922&view=results

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
