### PR TITLE
doc improvements

### DIFF
--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -1066,41 +1066,44 @@ helps[
                   Deployment content is json and in the form of {"modulesContent":{...}} or {"content":{"modulesContent":{...}}}.
 
                   By default properties of system modules $edgeAgent and $edgeHub are validated against schemas installed with the IoT extension.
-                  This can be disabled by using the --no-validation switch.
+                  This validation is intended for base deployments. If the corresponding schema is not available or a base deployment is not detected,
+                  this step will be skipped. Schema validation can be disabled by using the --no-validation switch.
 
-                  Edge deployments can be created with user defined metrics for on demand evaluation.
-                  User metrics are json and in the form of {"queries":{...}} or {"metrics":{"queries":{...}}}.
+                  An edge deployment is classified as layered if a module has properties.desired.* defined.
+                  Any edge device targeted by a layered deployment, first needs a base deployment applied to it.
 
-                  Deployments are classified as layered only if the content has $edgeAgent and within the $edgeAgent object, properties.desired.x is defined,
-                  where x can be anything. If you just have properties.desired, the deployment will be treated as a full (non-layered) deployment.
-                  We recommend being consistent in formatting $edgeAgent and $edgeHub for layered and full deployments.
+                  Any layered deployments targeting a device must have a higher priority than the base deployment for that device.
+
+                  Note: If the properties.desired field of a module twin is set in a layered deployment,
+                  properties.desired will overwrite the desired properties for that module in any lower priority deployments.
     examples:
     - name: Create a deployment with labels (bash syntax example) that applies for devices in 'building 9' and
             the environment is 'test'.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
-        --content modules_content.json
+        --content ./modules_content.json
         --labels '{"key0":"value0", "key1":"value1"}'
         --target-condition "tags.building=9 and tags.environment='test'"
         --priority 3
     - name: Create a deployment with labels (powershell syntax example) that applies for devices tagged with environment 'dev'.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
-        --content modules_content.json
+        --content ./modules_content.json
         --labels "{'key':'value'}"
         --target-condition "tags.environment='dev'"
     - name: Create a layered deployment that applies for devices tagged with environment 'dev'.
             Both user metrics and modules content defined inline (powershell syntax example).
-            Note that this is a layered deployment because the $edgeAgent object has properties.desired.x defined.
+            Note that this is in layered deployment format as properties.desired.* has been defined.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
-        --content "{'modulesContent':{'`$edgeAgent':{'properties.desired.modules.mymodule0':{ }},'`$edgeHub':{'properties.desired.routes.myroute0':'FROM /messages/* INTO `$upstream'}}}"
+        --content "{'modulesContent':{'`$edgeAgent':{
+          'properties.desired.modules.mymodule0':{ }},'`$edgeHub':{'properties.desired.routes.myroute0':'FROM /messages/* INTO `$upstream'}}}"
         --target-condition "tags.environment='dev'"
         --priority 10
         --metrics "{'queries':{'mymetrik':'SELECT deviceId from devices where properties.reported.lastDesiredStatus.code = 200'}}"
     - name: Create a layered deployment that applies for devices in 'building 9' and environment 'test'.
             Both user metrics and modules content defined inline (bash syntax example).
-            Note that this is a layered deployment because the $edgeAgent object has properties.desired.x defined.
+            Note that this is in layered deployment format properties.desired.* has been defined.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
         --content '{"modulesContent":{"$edgeAgent":{"properties.desired.modules.mymodule0":{ }},"$edgeHub":{"properties.desired.routes.myroute0":"FROM /messages/* INTO $upstream"}}}'
@@ -1110,15 +1113,15 @@ helps[
             Both user metrics and modules content defined from file.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
-        --content layered_modules_content.json
+        --content ./modules_content.json
         --target-condition "tags.building=9 and tags.environment='test'"
-        --metrics metrics_content.json
-    - name: Create a deployment with an alternative input style of labels and metrics (shell agnostic)
+        --metrics ./metrics_content.json
+    - name: Create a deployment whose definition is from file with shell-agnostic input of labels and metrics.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
-        --content layered_modules_content.json
+        --content ./modules_content.json
         --target-condition "tags.building=9 and tags.environment='test'"
-        --custom-labels key0="value0" key1="value1"
+        --custom-labels key0=value0 key1=value1
         --custom-metric-queries mymetric1="select deviceId from devices where tags.location='US'" mymetric2="select *"
 """
 

--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -1066,7 +1066,7 @@ helps[
                   Deployment content is json and in the form of {"modulesContent":{...}} or {"content":{"modulesContent":{...}}}.
 
                   By default properties of system modules $edgeAgent and $edgeHub are validated against schemas installed with the IoT extension.
-                  This validation is intended for base deployments. If the corresponding schema is not available or a base deployment is not detected,
+                  This validation is intended for base deployments. If the corresponding schema is not available or base deployment format is not detected,
                   this step will be skipped. Schema validation can be disabled by using the --no-validation switch.
 
                   An edge deployment is classified as layered if a module has properties.desired.* defined.
@@ -1103,7 +1103,7 @@ helps[
         --metrics "{'queries':{'mymetrik':'SELECT deviceId from devices where properties.reported.lastDesiredStatus.code = 200'}}"
     - name: Create a layered deployment that applies for devices in 'building 9' and environment 'test'.
             Both user metrics and modules content defined inline (bash syntax example).
-            Note that this is in layered deployment format properties.desired.* has been defined.
+            Note that this is in layered deployment format as properties.desired.* has been defined.
       text: >
         az iot edge deployment create -d {deployment_name} -n {iothub_name}
         --content '{"modulesContent":{"$edgeAgent":{"properties.desired.modules.mymodule0":{ }},"$edgeHub":{"properties.desired.routes.myroute0":"FROM /messages/* INTO $upstream"}}}'

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -236,16 +236,16 @@ def load_arguments(self, _):
             nargs="+",
             options_list=["--custom-metric-queries", "--cmq"],
             help="An alternative input style (space separated key=value pairs) for --metrics and intended to replace "
-            "it in the future."
-            'For example: metric1="select deviceId from devices where tags.location=''US''" metric2="select *"',
+            "it in the future. "
+            'Format example: metric1="select deviceId from devices where tags.location=\'US\'" metric2="select *"',
         )
         context.argument(
             "custom_labels",
             nargs="+",
             options_list=["--custom-labels", "--cl"],
             help="An alternative input style (space separated key=value pairs) for --labels and intended to replace "
-            "it in the future."
-            'For example: key1=value1 key2="this is my value"',
+            "it in the future. "
+            'Format example: key1=value1 key2="this is my value"',
         )
 
     with self.argument_context("iot hub") as context:
@@ -865,15 +865,16 @@ def load_arguments(self, _):
         context.argument(
             "metrics",
             options_list=["--metrics", "-m"],
-            help="IoT Edge deployment metric definitions. Provide file path or raw json."
+            help="IoT Edge deployment user metric definitions. Provide file path or raw json. "
+            'User metrics are in the form of {"queries":{...}} or {"metrics":{"queries":{...}}}. '
             "Using --custom-metric-queries instead of --metrics is recommended.",
         )
         context.argument(
             "labels",
             options_list=["--labels", "--lab"],
             help="Map of labels to be applied to target deployment. "
-            "Using --custom-labels instead of --labels is recommended."
-            'Use the following format: \'{"key0":"value0", "key1":"value1"}\'',
+            'Use the following format: \'{"key0":"value0", "key1":"value1"}\'. '
+            "Using --custom-labels instead of --labels is recommended.",
         )
         context.argument(
             "top",
@@ -886,9 +887,9 @@ def load_arguments(self, _):
             options_list=["--layered"],
             arg_type=get_three_state_flag(),
             help="Layered deployments allow you to define desired properties in $edgeAgent, $edgeHub and user "
-            "modules that will layer on top of a base deployment. For example the routes specified in a layered "
-            "deployment will merge with routes of the base deployment. Routes with the same name will be "
-            "overwritten based on deployment priority.",
+            "modules that will layer on top of a base deployment. The properties specified in a layered "
+            "deployment will merge with properties of the base deployment. Properties with the same path will be "
+            "overwritten based on deployment priority. This option is an alias for --no-validation.",
         )
         context.argument(
             "no_validation",

--- a/azext_iot/tests/deviceupdate/test_adu_update_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_update_int.py
@@ -284,7 +284,12 @@ def test_instance_update_lifecycle(provisioned_instances_module: Dict[str, dict]
     assert len(show_device_group_best_updates) == 1
     assert show_device_group_best_updates[0]["deviceClassId"] == device_class_id
     assert show_device_group_best_updates[0]["groupId"] == device_group_id
-    assert show_device_group_best_updates[0]["update"]["updateId"] == show_simple_update["updateId"]
+
+    for update_kpi in ["name", "provider", "version"]:
+        assert (
+            update_kpi in show_device_group_best_updates[0]["update"]["updateId"]
+            and show_device_group_best_updates[0]["update"]["updateId"][update_kpi] == simple_manifest_id[update_kpi]
+        )
 
     show_device_group_update_compliance = cli.invoke(
         show_device_group_template_cmd.replace("#", device_group_show_flags[2])).as_json()


### PR DESCRIPTION
For ADU test change.

https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=8108&view=results

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
