### PR TITLE
Fixes for device registration error handling

### DIFF
--- a/azext_iot/dps/common.py
+++ b/azext_iot/dps/common.py
@@ -25,5 +25,5 @@ COMPUTE_KEY_ERROR = "Enrollment group id via --group-id is required if --compute
 CERTIFICATE_FILE_ERROR = "Both certificate and key files are required for registration with x509."
 CERTIFICATE_RETRIEVAL_ERROR = "Please provide the certificate and key files via --certificate-file-path and --key-file-path."
 MISSING_DPS_CREDENTIALS_ERROR = "Cannot retrieve device information with only the DPS Id Scope. Please provide the device "\
-    "credentials, an DPS entity name (via the '['--dps-name']' or '-n' parameter), or DPS connection string via --login."
+    "credentials, a DPS entity name (via the '--dps-name' or '-n' parameters), or DPS connection string via --login."
 TPM_SUPPORT_ERROR = "Device registration with TPM attestation is not supported yet."

--- a/azext_iot/dps/common.py
+++ b/azext_iot/dps/common.py
@@ -17,11 +17,13 @@ CERT_AUTH = "x509 Authentication"
 # Error messages from Device SDK
 DISABLED_REGISTRATION_ERROR = "Query Status Operation encountered an invalid registration status 'disabled' with a "\
     "status code of 200"
-FAILED_REGISTRATION_ERROR = "Query Status operation returned a failed registration status with a status code of '200'"
+FAILED_REGISTRATION_ERROR = "Query Status operation returned a failed registration status with a status code of 200"
 UNAUTHORIZED_ERROR = "register request returned a service error status code 401"
 
 # Error messages for Client
 COMPUTE_KEY_ERROR = "Enrollment group id via --group-id is required if --compute-key is used."
 CERTIFICATE_FILE_ERROR = "Both certificate and key files are required for registration with x509."
-CERTIFICATE_RETRIEVAL_ERROR = "Please provide the certificate and key files via --certificate-path and --key-path."
+CERTIFICATE_RETRIEVAL_ERROR = "Please provide the certificate and key files via --certificate-file-path and --key-file-path."
+MISSING_DPS_CREDENTIALS_ERROR = "Cannot retrieve device information with only the DPS Id Scope. Please provide the device "\
+    "credentials, an DPS entity name (via the '['--dps-name']' or '-n' parameter), or DPS connection string via --login."
 TPM_SUPPORT_ERROR = "Device registration with TPM attestation is not supported yet."

--- a/azext_iot/dps/providers/device_registration.py
+++ b/azext_iot/dps/providers/device_registration.py
@@ -16,6 +16,7 @@ from azext_iot.dps.common import (
     CERTIFICATE_FILE_ERROR,
     CERTIFICATE_RETRIEVAL_ERROR,
     TPM_SUPPORT_ERROR,
+    MISSING_DPS_CREDENTIALS_ERROR
 )
 from azext_iot.dps.providers.discovery import DPSDiscovery
 from azext_iot.operations.dps import (
@@ -153,6 +154,8 @@ class DeviceRegistrationProvider():
             )
         elif certificate_file or key_file:
             raise RequiredArgumentMissingError(CERTIFICATE_FILE_ERROR)
+        elif not (self.dps_name or self.login):
+            raise RequiredArgumentMissingError(MISSING_DPS_CREDENTIALS_ERROR)
         # Retrieve the attestation if nothing is provided.
         else:
             self._get_attestation_params(enrollment_group_id=enrollment_group_id)

--- a/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
+++ b/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
@@ -36,6 +36,17 @@ class TestDPSDeviceRegistrationsGroup(IoTDPSLiveScenarioTest):
                 expect_failure=True
             )
 
+            # Cannot retrieve device credentials
+            self.cmd(
+                self.set_cmd_auth_type(
+                    "iot device registration create --id-scope {} --group-id {} --registration-id {}".format(
+                        self.id_scope, group_id, device_id1
+                    ),
+                    auth_type=auth_phase
+                ),
+                expect_failure=True
+            )
+
             # Regular enrollment group
             keys = self.cmd(
                 self.set_cmd_auth_type(

--- a/azext_iot/tests/dps/device_registration/test_iot_device_registration_individual_int.py
+++ b/azext_iot/tests/dps/device_registration/test_iot_device_registration_individual_int.py
@@ -37,6 +37,17 @@ class TestDPSDeviceRegistrationsIndividual(IoTDPSLiveScenarioTest):
                 expect_failure=True
             )
 
+            # Cannot retrieve device credentials
+            self.cmd(
+                self.set_cmd_auth_type(
+                    "iot device registration create --id-scope {} --registration-id {}".format(
+                        self.id_scope, enrollment_id
+                    ),
+                    auth_type=auth_phase
+                ),
+                expect_failure=True
+            )
+
             # Enrollment with no device id; deviceId becomes enrollmentId
             keys = self.cmd(
                 self.set_cmd_auth_type(


### PR DESCRIPTION
Errors for the following were fixed:
1. the error for when a cert file or key file 
2. id scope when device credentials are still needed

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
