### PR TITLE
Incorrect alias definition for 'layered' parameter

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,9 @@ unreleased
 
 * Deprecation of `az iot product`. This command group will be removed in a future release.
 
+**IoT Edge Deployment**
+
+* Fixed the documentation issue where the `--layered` parameter's description incorrectly mentioned `This option is an alias for --no-validation.`.
 
 0.21.1
 +++++++++++++++

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -900,7 +900,7 @@ def load_arguments(self, _):
             help="Layered deployments allow you to define desired properties in $edgeAgent, $edgeHub and user "
             "modules that will layer on top of a base deployment. The properties specified in a layered "
             "deployment will merge with properties of the base deployment. Properties with the same path will be "
-            "overwritten based on deployment priority. This option is an alias for --no-validation.",
+            "overwritten based on deployment priority.",
         )
         context.argument(
             "no_validation",


### PR DESCRIPTION
The description for the `--layered` parameter, says "This option is an alias for --no-validation." I don't think it is an alias for --no-validation - it seems to have a different operation.

https://learn.microsoft.com/en-us/cli/azure/iot/edge/deployment?view=azure-cli-latest

Fixes Azure/azure-cli#26502


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
