### PR TITLE
Name or hostname

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -94,7 +94,7 @@ def load_arguments(self, _):
         context.argument("resource_group_name", arg_type=resource_group_name_type)
         context.argument(
             "hub_name", options_list=["--hub-name", "-n"], arg_type=hub_name_type,
-            help="IoT Hub name. Required if --login is not provided.",
+            help="IoT Hub name or host name. Required if --login is not provided.",
             arg_group="IoT Hub Identifier"
         )
         context.argument(
@@ -928,7 +928,7 @@ def load_arguments(self, _):
         context.argument(
             "dps_name",
             options_list=["--dps-name", "-n"],
-            help="Name of the Azure IoT Hub Device Provisioning Service. Required if --login is not provided.",
+            help="Name or host name of the Azure IoT Hub Device Provisioning Service. Required if --login is not provided.",
             arg_group="Device Provisioning Service Identifier"
         )
         context.argument(

--- a/azext_iot/common/base_discovery.py
+++ b/azext_iot/common/base_discovery.py
@@ -134,7 +134,7 @@ class BaseDiscovery(ABC):
 
         Raises ResourceNotFoundError if no resource is found.
 
-        :param resource_name: Resource Name
+        :param resource_name: Resource Name or Resource Host Name
         :type resource_name: str
         :param rg: Resource Group
         :type rg: str
@@ -144,6 +144,7 @@ class BaseDiscovery(ABC):
         """
         self._initialize_client()
 
+        resource_name = resource_name.split(".")[0]
         if rg:
             try:
                 return self.client.get(

--- a/azext_iot/tests/dps/core/test_dps_discovery_int.py
+++ b/azext_iot/tests/dps/core/test_dps_discovery_int.py
@@ -12,12 +12,16 @@ from azext_iot.tests.settings import Setting
 def test_dps_discovery(provisioned_iot_dps_no_hub_module):
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+    dps_hostname = provisioned_iot_dps_no_hub_module["dps"]["properties"]["serviceOperationsHostName"]
     cmd_shell = Setting()
     setattr(cmd_shell, "cli_ctx", get_dummy_cli())
     desired_policy_name = "provisioningserviceowner"
     discovery = DPSDiscovery(cmd_shell)
 
     resource = discovery.find_resource(resource_name=dps_name)
+    assert resource.name == dps_name
+
+    resource = discovery.find_resource(resource_name=dps_hostname)
     assert resource.name == dps_name
 
     auto_policy = discovery.find_policy(resource_name=dps_name, rg=dps_rg).as_dict()

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_int.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_int.py
@@ -25,6 +25,10 @@ class TestIoTHubDiscovery(IoTLiveScenarioTest):
         iothub = discovery.find_resource(resource_name=self.entity_name)
         assert iothub.name == self.entity_name
 
+        iothub_hostname = iothub.properties.host_name
+        iothub = discovery.find_resource(resource_name=iothub_hostname)
+        assert iothub.name == self.entity_name
+
         auto_policy = discovery.find_policy(resource_name=self.entity_name, rg=self.entity_rg).as_dict()
         rights_set = set(auto_policy["rights"].split(", "))
         assert rights_set == PRIVILEDGED_ACCESS_RIGHTS_SET


### PR DESCRIPTION
Not really sure what else was desired from this task

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
