### PR TITLE
IoT Hub IP Filter commands

### DIFF
--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -861,3 +861,38 @@ def load_iothub_help():
           text: >
             az iot hub certificate root-authority show --hub-name {iothub_name}
     """
+
+    helps["iot hub network-rule-set"] = """
+        type: group
+        short-summary: Manage the public network rule set for an IoT Hub instance.
+    """
+
+    helps["iot hub network-rule-set update"] = """
+        type: command
+        short-summary: Update the public network rule set for an IoT Hub instance.
+        examples:
+        - name: Update the public network rule set to deny all public access. This will not change the IP Rules.
+          text: >
+            az iot hub network-rule-set update --hub-name {iothub_name} --public-network-access Disabled
+        - name: Update the public network rule set to allow all public access. This will not change the IP Rules.
+          text: >
+            az iot hub network-rule-set update --hub-name {iothub_name} --public-network-access Enabled
+        - name: Update the public network rule set to allow two selected IP ranges.
+          text: >
+            az iot hub network-rule-set update --hub-name {iothub_name} --public-network-access IPRules --ip-rule name=myiprule address_range=192.0.0.0 --ip-rule name=myiprule2 address_range=0.0.0.0
+        - name: Remove all IP rules. This will not change the Public Network Access status.
+          text: >
+            az iot hub network-rule-set update --hub-name {iothub_name} --remove-all
+        - name: Overwrite the IP rules with the specified selected IP range. This will not change the Public Network Access status.
+          text: >
+            az iot hub network-rule-set update --hub-name {iothub_name} --remove-all --ip-rule name=myiprule address_range=192.0.0.0
+    """
+
+    helps["iot hub network-rule-set show"] = """
+        type: command
+        short-summary: Show the current public network rule set for an IoT Hub instance.
+        examples:
+        - name: Show the target IoT Hub public network rule set.
+          text: >
+            az iot hub network-rule-set show --hub-name {iothub_name}
+    """

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -26,6 +26,7 @@ device_identity_ops = CliCommandType(
 iothub_resource_ops = CliCommandType(
     operations_tmpl="azext_iot.iothub.commands_certificate#{}"
 )
+iothub_network_rule_set_ops = CliCommandType(operations_tmpl="azext_iot.iothub.commands_network_rule_sets#{}")
 
 
 class EndpointUpdateResultTransform(LongRunningOperation):  # pylint: disable=too-few-public-methods
@@ -123,6 +124,10 @@ def load_iothub_commands(self, _):
     with self.command_group("iot hub message-route fallback", command_type=iothub_message_route_ops) as cmd_group:
         cmd_group.show_command("show", "message_fallback_route_show")
         cmd_group.command("set", "message_fallback_route_set")
+
+    with self.command_group("iot hub network-rule-set", command_type=iothub_network_rule_set_ops) as cmd_group:
+        cmd_group.show_command("show", "network_rule_set_show")
+        cmd_group.command("update", "network_rule_set_update")
 
     with self.command_group("iot device", command_type=device_messaging_ops) as cmd_group:
         cmd_group.command("send-d2c-message", "iot_device_send_message")

--- a/azext_iot/iothub/commands_network_rule_sets.py
+++ b/azext_iot/iothub/commands_network_rule_sets.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+from azext_iot.iothub.providers.network_rule_sets import NetworkRuleSets
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def network_rule_set_update(
+    cmd,
+    hub_name: str,
+    public_network_access: Optional[bool] = None,
+    add_ip_rules: Optional[Dict[str, str]] = None,
+    apply_built_in: Optional[bool] = None,
+    remove_all: bool = False,
+    resource_group_name: Optional[str] = None,
+):
+    network_rule_set_provider = NetworkRuleSets(
+        cmd=cmd, hub_name=hub_name, rg=resource_group_name
+    )
+    return network_rule_set_provider.update(
+        public_network_access=public_network_access,
+        add_ip_rules=add_ip_rules,
+        apply_built_in=apply_built_in,
+        remove_all=remove_all
+    )
+
+
+def network_rule_set_show(
+    cmd,
+    hub_name: str,
+    resource_group_name: Optional[str] = None,
+):
+    network_rule_set_provider = NetworkRuleSets(
+        cmd=cmd, hub_name=hub_name, rg=resource_group_name
+    )
+    return network_rule_set_provider.show()

--- a/azext_iot/iothub/common.py
+++ b/azext_iot/iothub/common.py
@@ -188,3 +188,12 @@ class CertificateAuthorityVersions(Enum):
     """
     v2 = "v2"
     v1 = "v1"
+
+
+class PublicNetworkAccessType(Enum):
+    """
+    Public Network Access options
+    """
+    IPRules = "IPRules"
+    Enabled = "Enabled"
+    Disabled = "Disabled"

--- a/azext_iot/iothub/params.py
+++ b/azext_iot/iothub/params.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------------------
 
 from azext_iot.iothub.providers.state import HubAspects
-from azext_iot.iothub.common import CertificateAuthorityVersions
+from azext_iot.iothub.common import CertificateAuthorityVersions, PublicNetworkAccessType
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azext_iot.common.shared import DeviceAuthType, SettleType, ProtocolType, AckType
 from azext_iot.assets.user_messages import info_param_properties_device
@@ -640,6 +640,34 @@ def load_iothub_arguments(self, _):
             "system_properties",
             options_list=["--system-properties", "--sp"],
             help="System properties of the route message.",
+        )
+
+    with self.argument_context("iot hub network-rule-set update") as context:
+        context.argument(
+            "public_network_access",
+            options_list=["--public-network-access", "--pna"],
+            arg_type=get_enum_type(PublicNetworkAccessType),
+            help="Option for public network access.",
+        )
+        context.argument(
+            "add_ip_rules",
+            options_list=["--ip-rule", "--ir"],
+            nargs="+",
+            action="append",
+            help="Space-separated key=value pairs corresponding to properties of the IP Rule to add. The following key values "
+            "are required: `name` and `address_range`. --ip-rule can be used 1 or more times.",
+        )
+        context.argument(
+            "remove_all",
+            options_list=["--remove-all", "-r"],
+            arg_type=get_three_state_flag(),
+            help="Force all IP Rules to be removed.",
+        )
+        context.argument(
+            "apply_built_in",
+            options_list=["--apply-to-built-in", "--atbi"],
+            arg_type=get_three_state_flag(),
+            help="Apply the IP Rules to the built-in Event Hub.",
         )
 
     with self.argument_context("iot hub certificate root-authority set") as context:

--- a/azext_iot/iothub/providers/network_rule_sets.py
+++ b/azext_iot/iothub/providers/network_rule_sets.py
@@ -1,0 +1,105 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import List, Optional
+from knack.log import get_logger
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.common.utility import assemble_nargs_to_dict, handle_service_exception
+from azext_iot.iothub.common import PublicNetworkAccessType
+from azext_iot.iothub.providers.base import IoTHubProvider
+from azure.core.exceptions import HttpResponseError
+
+
+logger = get_logger(__name__)
+
+
+class NetworkRuleSets(IoTHubProvider):
+    def __init__(
+        self,
+        cmd,
+        hub_name: str,
+        rg: Optional[str] = None,
+    ):
+        super(NetworkRuleSets, self).__init__(cmd, hub_name, rg, dataplane=False)
+        self.cli = EmbeddedCLI(cli_ctx=self.cmd.cli_ctx)
+
+    def update(
+        self,
+        public_network_access: Optional[str] = None,
+        add_ip_rules: Optional[List[List[str]]] = None,
+        # remove_ip_rules: Optional[List[str]] = None,
+        apply_built_in: Optional[bool] = None,
+        remove_all: bool = False,
+    ):
+        network_rule_sets = self.hub_resource.properties.public_network_access
+        if network_rule_sets is None and any([
+            add_ip_rules, apply_built_in, public_network_access == PublicNetworkAccessType.IPRules
+        ]):
+            network_rule_sets = {
+                "defaultAction": "Deny",
+                "applyToBuiltInEventHubEndpoint": False,
+                "ipRules": []
+            }
+        elif network_rule_sets:
+            network_rule_sets = network_rule_sets.serialize()
+
+        if apply_built_in:
+            network_rule_sets["applyToBuiltInEventHubEndpoint"] = apply_built_in
+
+        if remove_all:
+            network_rule_sets["ipRules"] = []
+
+        if add_ip_rules:
+            current_filters = network_rule_sets["ipRules"]
+            for rule in add_ip_rules:
+                rule = assemble_nargs_to_dict(rule)
+                if not all(["name" in rule, "address_range" in rule]):
+                    raise Exception("Must have name and address range for an ip rule.")
+                current_filters.append({
+                    "filterName": rule["name"],
+                    "action": "Allow",
+                    "ipMask": rule["address_range"]
+                })
+            network_rule_sets["ipRules"] = current_filters
+
+        if public_network_access == PublicNetworkAccessType.Enabled:
+            self.hub_resource.properties.public_network_access = PublicNetworkAccessType.Enabled
+            if network_rule_sets:
+                network_rule_sets["defaultAction"] = "Allow"
+        if public_network_access == PublicNetworkAccessType.Disabled:
+            self.hub_resource.properties.public_network_access = PublicNetworkAccessType.Disabled
+            if network_rule_sets:
+                network_rule_sets["defaultAction"] = "Allow"
+        if public_network_access == PublicNetworkAccessType.IPRules:
+            # Q - can this be null with network rule sets not null?
+            if self.hub_resource.properties.public_network_access:
+                self.hub_resource.properties.public_network_access = PublicNetworkAccessType.Enabled
+            network_rule_sets["defaultAction"] = "Deny"
+
+        self.hub_resource.properties.network_rule_sets = network_rule_sets
+
+        try:
+            self.discovery.client.begin_create_or_update(
+                self.hub_resource.additional_properties["resourcegroup"],
+                self.hub_resource.name,
+                self.hub_resource,
+                if_match=self.hub_resource.etag
+            )
+            return self.show()
+        except HttpResponseError as e:
+            handle_service_exception(e)
+
+    def show(self):
+        network_rule_sets = self.hub_resource.properties.network_rule_sets
+        if network_rule_sets is None:
+            pass
+        public_network_access = self.hub_resource.properties.public_network_access
+        if public_network_access is None:
+            public_network_access = PublicNetworkAccessType.Enabled
+        return {
+            "networkRuleSets" : network_rule_sets,
+            "publicNetworkAccess" : public_network_access
+        }


### PR DESCRIPTION
Adding IP filter with CLI is disgusting (https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-ip-filtering#retrieve-and-update-ip-filters-using-azure-cli). This is to make it better.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
