### PR TITLE
Remove python 3.7

### DIFF
--- a/.azure-devops/create-release.yml
+++ b/.azure-devops/create-release.yml
@@ -32,10 +32,6 @@ parameters:
   type: object
   default: >
     {
-      Python37:
-      {
-        python: '3.7'
-      },
       Python38:
       {
         python: '3.8'

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -63,8 +63,6 @@ jobs:
     vmImage: ${{ parameters.linuxImage }}
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -35,6 +35,10 @@ parameters:
   type: object
   default: >
     {
+      Python38:
+      {
+        python: '3.8'
+      },
       Python310:
       {
         python: '3.10'

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -35,10 +35,6 @@ parameters:
   type: object
   default: >
     {
-      Python37:
-      {
-        python: '3.7'
-      },
       Python310:
       {
         python: '3.10'

--- a/.azure-devops/tox.yml
+++ b/.azure-devops/tox.yml
@@ -2,10 +2,6 @@ trigger: none
 pr: none
 
 parameters:
-- name: python37
-  displayName: 'Test Python 3.7'
-  type: boolean
-  default: true
 - name: python38
   displayName: 'Test Python 3.8'
   type: boolean
@@ -42,25 +38,9 @@ jobs:
   strategy:
     matrix:
       'linters':
-        python: '3.7'
+        python: '3.8'
         toxEnvStr: 'lint'
         desc: 'Flake8, Pylint'
-      ${{ if parameters.python37 }}:
-        ${{ if parameters.azmin }}:
-          'python 3.7 tests, min CLI':
-            python: '3.7'
-            toxEnvStr: 'py3.7-azmin-unit'
-            desc: 'python 3.7 tests, min CLI'
-        ${{ if parameters.azcur }}:
-          'python 3.7 tests, current CLI':
-            python: '3.7'
-            toxEnvStr: 'py3.7-azcur-unit'
-            desc: 'Python 3.7 tests, current CLI'
-        ${{ if parameters.azdev }}:
-          'python 3.7 tests, dev CLI':
-            python: '3.7'
-            toxEnvStr: 'py3.7-azdev-unit'
-            desc: 'Python 3.7 tests, dev CLI'
       ${{ if parameters.python38 }}:
         ${{ if parameters.azmin }}:
           'python 3.8 tests, min CLI':

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,15 @@ Release History
 ===============
 
 
+0.22.0
++++++++++++++++
+
+**General updates**
+
+* Dropped support for Python 3.7. The IoT extension is constrained to Python 3.8 or greater.
+  If for whatever reason you cannot upgrade from 3.7 you are able to use older extension versions.
+
+
 0.21.5
 +++++++++++++++
 

--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -365,11 +365,7 @@ def test_import_and_version(package, expected_version):
     is at least the expected version. This utility will not work for packages
     that are installed without metadata.
     """
-
-    try:
-        from importlib import metadata
-    except ImportError:
-        import importlib_metadata as metadata
+    from importlib import metadata
 
     try:
         return metadata.version(package) >= expected_version

--- a/azext_iot/monitor/telemetry.py
+++ b/azext_iot/monitor/telemetry.py
@@ -76,11 +76,7 @@ def start_multiple_monitors(
         try:
             # TODO: remove when deprecating
             # pylint: disable=no-member
-            tasks = (
-                asyncio.Task.all_tasks(loop)
-                if sys.version_info < (3, 7)
-                else asyncio.all_tasks(loop)
-            )
+            tasks = asyncio.all_tasks(loop)
             for t in tasks:  # pylint: disable=no-member
                 t.cancel()
             loop.run_forever()

--- a/docs/tox-testing.md
+++ b/docs/tox-testing.md
@@ -5,7 +5,6 @@
 Currently, our testing matrix is broken up into the following groups:
 
 - Python versions to run tests:
-    - 3.7 (support ends 2023-06-27)
     - 3.8
     - 3.9
     - 3.10
@@ -13,7 +12,7 @@ Currently, our testing matrix is broken up into the following groups:
 - Azure CLI Core versions to test extension against:
     - `azmin` installs the minimum supported CLI version (currently `2.32.0`)
     - `azcur` installs the latest released CLI version from PyPi
-    - `azdev` installs the CLI from your local CLI instance (located at `../azure-cli`) 
+    - `azdev` installs the CLI from your local CLI instance (located at `../azure-cli`)
 - Types of tests to run:
     - Linting / style only
     - Unit tests
@@ -22,19 +21,19 @@ Currently, our testing matrix is broken up into the following groups:
 
 ## Running Tox Locally
 In order to run tox testing environments as currently configured, you must install tox (currently in `dev_requirements`, so already part of dev setup) and have the azure-cli repo cloned alongside your extension repo:
-    
+
     ./azure-cli
     ./azure-iot-cli-extension
 
 Environment strings can be passed to tox with `-e "env"` for a single environment, or `-e "env1, env2"` for multiple environments.
 
 If you need to add additional inputs to `pytest` - you can do so by using `--` as a separator, like below (only test last failed, very verbose):
- 
+
         `tox -e "python-azdev-unit" -- --lf --vv`
 
-The first time you run a new environment in tox, it will perform some setup tasks and dependency installation which will incur some overhead, but ensuing test runs will be able to skip this step. 
+The first time you run a new environment in tox, it will perform some setup tasks and dependency installation which will incur some overhead, but ensuing test runs will be able to skip this step.
 
-- Tox can detect dependency / command changes in tox.ini and other related settings, but does not check files external to tox (code, dev_requirements, etc). 
+- Tox can detect dependency / command changes in tox.ini and other related settings, but does not check files external to tox (code, dev_requirements, etc).
 
 - In order to rebuild a tox environment, you need to run tox with the `-r` switch.
 
@@ -42,19 +41,18 @@ The [current tox config](../tox.ini) supports local test configurations for the 
 
 - Linting
   - To run flake8 and pylint locally on your code, simply run:
-    
+
         tox -e lint
 
 - Various Python and AZ CLI Versions
   - The tox environment string (passed to `-e`) will be parsed as such:
-    
-        py{thon,3.7...3.11}-az{min,cur,dev}-{int,unit}
+
+        py{thon,3.8...3.11}-az{min,cur,dev}-{int,unit}
 
     |Python version | CLI version   | Test type     |
     |---------------|---------------|---------------|
     |"python"|"azmin"|"int"|
-    |"py3.7"|"azcur"|"unit"|
-    |"py3.8"|"azdev"||
+    |"py3.8"|"azdev"|"unit"|
     |"py3.9"|||
     |"py3.10"|||
     |"py3.11"|||
@@ -66,20 +64,20 @@ The [current tox config](../tox.ini) supports local test configurations for the 
 ### Tox Environment Selection Examples:
 
     tox -e "lint, python-azdev-unit"
-        - Default if you run `tox` with no arguments 
+        - Default if you run `tox` with no arguments
         - Run linters, current python/dev CLI unit tests
     tox -e "python-azdev-int"
         - Current python interpreter, local azure CLI install, integration tests
-    tox -e "py3.7-azmin-unit"
-        - Python 3.7, min supported CLI, unit tests
-    tox -e "py{3.7,3.11}-az{min,cur}-unit"
-        - Python 3.7, min supported CLI core, unit tests
-        - Python 3.7, currently released CLI core, unit tests
-        - Python 3.11, min supported CLI core, unit tests
+    tox -e "py3.8-azmin-unit"
+        - Python 3.8, min supported CLI, unit tests
+    tox -e "py{3.8,3.11}-az{min,cur}-unit"
+        - Python 3.8, min supported CLI core, unit tests
+        - Python 3.8, currently released CLI core, unit tests
+        - Python 3.11, max supported CLI core, unit tests
         - Python 3.11, currently released CLI core, unit tests
 
 
 In order to list all recognized environments, you can type `tox -av`, which will display them all in a list:
-    
+
 ![image](https://user-images.githubusercontent.com/13545962/217683727-1ec36d2c-e055-4677-a5a9-8f87cdcc987b.png)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ DEPENDENCIES = [
     "msrest>=0.6.21",
     "msrestazure>=0.6.3,<2.0.0",
     "jsonschema~=3.2.0",
-    "importlib_metadata;python_version<'3.8'",
     "azure-iot-device~=2.11",
     "tomli~=2.0",
     "tomli-w~=1.0",
@@ -68,7 +67,6 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -80,7 +78,7 @@ short_description = "The Azure IoT extension for Azure CLI."
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     description=short_description,
     long_description="{} Intended for power users and/or automation of IoT solutions at scale.".format(
         short_description

--- a/thirdpartynotice
+++ b/thirdpartynotice
@@ -3,26 +3,9 @@ Third Party Notices for Azure IoT CLI Extension
 This project incorporates material from the project(s) listed below (collectively, “Third Party Code”).
 Microsoft Corporation is not the original author of the Third Party Code.
 
-The original copyright notice and license, under which Microsoft Corporation received such Third Party Code, 
-are set out below.  This Third Party Code is licensed to you under their original license terms set forth below.  
-Microsoft Corporation reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
-
------------------------------------------------------------------------------------------------------------------------
-License notice for importlib_metadata, obtained from https://github.com/python/importlib_metadata/blob/main/LICENSE
-
-Copyright 2017-2019 Jason R. Coombs, Barry Warsaw
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The original copyright notice and license, under which Microsoft Corporation received such Third Party Code,
+are set out below.  This Third Party Code is licensed to you under their original license terms set forth below.
+Microsoft Corporation reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.
 
 -----------------------------------------------------------------------------------------------------------------------
 License notice for jsonschema v3.2.0, obtained from https://github.com/Julian/jsonschema/blob/main/COPYING


### PR DESCRIPTION
Just removing some mentions b/c there aren't really any obvious code snippets for 3.7 only. 

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
