### PR TITLE
IoT Hub state endpoint fix

### DIFF
--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -643,8 +643,8 @@ class StateProvider(IoTHubProvider):
                     cosmos_keys = cli.invoke(
                         "cosmosdb keys list --name {} --resource-group {} --type connection-strings --subscription {}".format(
                             account_name,
-                            ep["resourceGroup"],
-                            ep["subscriptionId"]
+                            ep.get("resourceGroup"),
+                            ep.get("subscriptionId")
                         )
                     ).as_json()
                 except AzCLIError:
@@ -671,10 +671,10 @@ class StateProvider(IoTHubProvider):
                     "cosmosdb sql container show --account-name {} --resource-group {} --database-name {} "
                     "--name {} --subscription {}".format(
                         account_name,
-                        ep["resourceGroup"],
+                        ep.get("resourceGroup"),
                         ep["databaseName"],
                         ep["collectionName"],
-                        ep["subscriptionId"]
+                        ep.get("subscriptionId")
                     )
                 ).success()
                 if not success:
@@ -698,10 +698,10 @@ class StateProvider(IoTHubProvider):
                         "eventhubs eventhub authorization-rule keys list --namespace-name {} --resource-group {} "
                         "--eventhub-name {} --name {}  --subscription {}".format(
                             namespace,
-                            ep["resourceGroup"],
+                            ep.get("resourceGroup"),
                             endpoint_props["EntityPath"],
                             endpoint_props["SharedAccessKeyName"],
-                            ep["subscriptionId"]
+                            ep.get("subscriptionId")
                         )
                     ).as_json()["primaryConnectionString"]
                 except AzCLIError:
@@ -721,9 +721,9 @@ class StateProvider(IoTHubProvider):
                     "eventhubs eventhub show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
                         namespace,
-                        ep["resourceGroup"],
+                        ep.get("resourceGroup"),
                         ep["entityPath"],
-                        ep["subscriptionId"]
+                        ep.get("subscriptionId")
                     )
                 ).success()
                 if not success:
@@ -744,10 +744,10 @@ class StateProvider(IoTHubProvider):
                         "servicebus queue authorization-rule keys list --namespace-name {} --resource-group {} "
                         "--queue-name {} --name {} --subscription {}".format(
                             namespace,
-                            ep["resourceGroup"],
+                            ep.get("resourceGroup"),
                             endpoint_props["EntityPath"],
                             endpoint_props["SharedAccessKeyName"],
-                            ep["subscriptionId"]
+                            ep.get("subscriptionId")
                         )
                     ).as_json()["primaryConnectionString"]
                 except AzCLIError:
@@ -767,9 +767,9 @@ class StateProvider(IoTHubProvider):
                     "servicebus queue show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
                         namespace,
-                        ep["resourceGroup"],
+                        ep.get("resourceGroup"),
                         ep["entityPath"],
-                        ep["subscriptionId"]
+                        ep.get("subscriptionId")
                     )
                 ).success()
                 if not success:
@@ -790,10 +790,10 @@ class StateProvider(IoTHubProvider):
                         "servicebus topic authorization-rule keys list --namespace-name {} --resource-group {} "
                         "--topic-name {} --name {} --subscription {}".format(
                             namespace,
-                            ep["resourceGroup"],
+                            ep.get("resourceGroup", hub_resource["resourcegroup"]),
                             endpoint_props["EntityPath"],
                             endpoint_props["SharedAccessKeyName"],
-                            ep["subscriptionId"]
+                            ep.get("subscriptionId")
                         )
                     ).as_json()["primaryConnectionString"]
                 except AzCLIError:
@@ -815,9 +815,9 @@ class StateProvider(IoTHubProvider):
                     "servicebus topic show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
                         namespace,
-                        ep["resourceGroup"],
+                        ep.get("resourceGroup", hub_resource["resourcegroup"]),
                         ep["entityPath"],
-                        ep["subscriptionId"]
+                        ep.get("subscriptionId")
                     )
                 ).success()
                 if not success:
@@ -838,8 +838,8 @@ class StateProvider(IoTHubProvider):
                     ep["connectionString"] = cli.invoke(
                         "storage account show-connection-string -n {} -g {} --subscription {}".format(
                             endpoint_props["AccountName"],
-                            ep["resourceGroup"],
-                            ep["subscriptionId"]
+                            ep.get("resourceGroup", hub_resource["resourcegroup"]),
+                            ep.get("subscriptionId")
                         )
                     ).as_json()["connectionString"]
                 except AzCLIError:
@@ -860,7 +860,7 @@ class StateProvider(IoTHubProvider):
                 success = cli.invoke(
                     "storage account show --name {} --subscription {}".format(
                         account_name,
-                        ep["subscriptionId"],
+                        ep.get("subscriptionId"),
                     )
                 ).success()
                 if not success:

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -636,7 +636,7 @@ class StateProvider(IoTHubProvider):
 
         # Cosmos Db
         cosmos_endpoints = []
-        for ep in endpoints.get("cosmosDBSqlCollections", []):
+        for ep in endpoints.get("cosmosDBSqlContainers", []):
             account_name = ep["endpointUri"].strip("https://").split(".")[0]
             if ep.get("primaryKey") or ep.get("secondaryKey"):
                 try:
@@ -685,7 +685,7 @@ class StateProvider(IoTHubProvider):
                     continue
 
             cosmos_endpoints.append(ep)
-        endpoints["cosmosDBSqlCollections"] = cosmos_endpoints
+        endpoints["cosmosDBSqlContainers"] = cosmos_endpoints
 
         # Event Hub
         eventhub_endpoints = []

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -790,7 +790,7 @@ class StateProvider(IoTHubProvider):
                         "servicebus topic authorization-rule keys list --namespace-name {} --resource-group {} "
                         "--topic-name {} --name {} --subscription {}".format(
                             namespace,
-                            ep.get("resourceGroup", hub_resource["resourcegroup"]),
+                            ep.get("resourceGroup"),
                             endpoint_props["EntityPath"],
                             endpoint_props["SharedAccessKeyName"],
                             ep.get("subscriptionId")
@@ -815,7 +815,7 @@ class StateProvider(IoTHubProvider):
                     "servicebus topic show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
                         namespace,
-                        ep.get("resourceGroup", hub_resource["resourcegroup"]),
+                        ep.get("resourceGroup"),
                         ep["entityPath"],
                         ep.get("subscriptionId")
                     )
@@ -838,7 +838,7 @@ class StateProvider(IoTHubProvider):
                     ep["connectionString"] = cli.invoke(
                         "storage account show-connection-string -n {} -g {} --subscription {}".format(
                             endpoint_props["AccountName"],
-                            ep.get("resourceGroup", hub_resource["resourcegroup"]),
+                            ep.get("resourceGroup"),
                             ep.get("subscriptionId")
                         )
                     ).as_json()["connectionString"]


### PR DESCRIPTION
Changed endpoint verification to be more robust.

https://dev.azure.com/azureiotdevxp/aziotcli/_build/results?buildId=9378&view=results

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
