### PR TITLE
fix: dt job polling for testing

### DIFF
--- a/azext_iot/tests/digitaltwins/test_dt_jobs_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_jobs_int.py
@@ -20,9 +20,9 @@ from azext_iot.digitaltwins.providers.import_job import DEFAULT_IMPORT_JOB_ID_PR
 
 logger = get_logger(__name__)
 CWD = os.path.dirname(os.path.abspath(__file__))
-MAX_TRIES = 5
+MAX_TRIES = 10
 RBAC_SLEEP_INTERVAL = 60
-POLL_SLEEP_INTERVAL = 30
+POLL_SLEEP_INTERVAL = 60
 EXPECTED_MODEL_IDS = [
     "dtmi:com:microsoft:azure:iot:model0;1", "dtmi:com:microsoft:azure:iot:model1;1", "dtmi:com:microsoft:azure:iot:model2;1",
     "dtmi:com:microsoft:azure:iot:model3;1", "dtmi:com:microsoft:azure:iot:model4;1", "dtmi:com:microsoft:azure:iot:model5;1",
@@ -368,6 +368,7 @@ def poll_job_status(
         if import_job_output["status"] == final_status:
             return import_job_output["error"]
         sleep(POLL_SLEEP_INTERVAL)
+    raise Exception(f"Job {job_id} for {instance_name} not finalized.")
 
 
 def assert_job_creation(


### PR DESCRIPTION
Added a line to throw an error if the job has not succeeded after polling.
Increased polling so total max time would be 10 minutes (recommendation from dt service).

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
