### PR TITLE
chore: disable ref doc validation

### DIFF
--- a/.azure-devops/create-release.yml
+++ b/.azure-devops/create-release.yml
@@ -144,10 +144,10 @@ stages:
       displayName: 'Evaluate Command Table'
       steps:
       - template: templates/evaluate-command-table.yml
-    - job: 'validate_ref_docs'
-      displayName: 'Validate Reference Document Generation'
-      steps:
-      - template: templates/validate-refdoc-generation.yml
+    # - job: 'validate_ref_docs'
+    #   displayName: 'Validate Reference Document Generation'
+    #   steps:
+    #   - template: templates/validate-refdoc-generation.yml
 
   - stage: 'smokeTest'
     displayName: 'Run smoke tests'

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -141,14 +141,14 @@ jobs:
   steps:
   - template: templates/evaluate-command-table.yml
 
-- job: 'validate_ref_docs'
-  dependsOn: ['build_and_publish_azure_iot_cli_ext']
-  displayName: 'Validate Reference Document Generation'
-  pool:
-    vmImage: ${{ parameters.linuxImage }}
+# - job: 'validate_ref_docs'
+#   dependsOn: ['build_and_publish_azure_iot_cli_ext']
+#   displayName: 'Validate Reference Document Generation'
+#   pool:
+#     vmImage: ${{ parameters.linuxImage }}
 
-  steps:
-  - template: templates/validate-refdoc-generation.yml
+#   steps:
+#   - template: templates/validate-refdoc-generation.yml
 
 - job: CredScan
   displayName: 'Credential Scan'


### PR DESCRIPTION
Dropping like its hot: https://github.com/Azure/azure-cli-extensions/pull/7160

maybe will be replaced by something sometime...

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
