### PR TITLE
fix: ensure IoT Hub list persists over DPS enrollment (group) updates

### DIFF
--- a/azext_iot/_help.py
+++ b/azext_iot/_help.py
@@ -1114,7 +1114,7 @@ helps[
       text: >
         az iot dps enrollment create -g {resource_group_name} --dps-name {dps_name}
         --enrollment-id {enrollment_id} --attestation-type tpm --allocation-policy hashed
-        --endorsement-key 14963E8F3BA5B3984110B3C1CA8E8B89 --iot-hubs "{iot_hub_host_name1} {iot_hub_host_name2}"
+        --endorsement-key 14963E8F3BA5B3984110B3C1CA8E8B89 --iot-hubs {iot_hub_host_name1} {iot_hub_host_name2}
     - name: Create an enrollment 'MyEnrollment' with custom allocation policy,
       text: >
         az iot dps enrollment create -g {resource_group_name} --dps-name {dps_name}
@@ -1161,7 +1161,7 @@ helps[
       text: >
         az iot dps enrollment update -g {resource_group_name} --dps-name {dps_name}
         --enrollment-id {enrollment_id} --allocation-policy geolatency
-        --etag AAAAAAAAAAA= --iot-hubs "{iot_hub_host_name1} {iot_hub_host_name2} {iot_hub_host_name3}"
+        --etag AAAAAAAAAAA= --iot-hubs {iot_hub_host_name1} {iot_hub_host_name2} {iot_hub_host_name3}
     - name: Update enrollment '{enrollment_id}' in the Azure IoT Device Provisioning Service '{dps_name}'
             in the resource group '{resource_group_name}' with
             initial twin properties '{"location":{"region":"USA"}}', initial twin tags '{"version":"2"}',

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -1006,6 +1006,8 @@ def load_arguments(self, _):
             options_list=["--iot-hubs", "--ih"],
             help="Host name of target IoT Hub associated with the allocation policy. Use space-separated "
             "list for multiple IoT Hubs.",
+            nargs="+",
+            action="extend",
             arg_group="Allocation Policy"
         )
         context.argument(

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -181,7 +181,7 @@ def iot_dps_device_enrollment_create(
             )
         reprovision = _get_reprovision_policy(reprovision_policy)
         initial_twin = _get_initial_twin(initial_twin_tags, initial_twin_properties)
-        iot_hub_list = iot_hubs.split() if iot_hubs else iot_hubs
+        iot_hub_list = iot_hubs.split() if isinstance(iot_hubs, str) else iot_hubs
         _validate_allocation_policy_for_enrollment(
             allocation_policy, iot_hub_host_name, iot_hub_list, webhook_url, api_version
         )
@@ -303,9 +303,15 @@ def iot_dps_device_enrollment_update(
         enrollment_record.initial_twin = _get_updated_inital_twin(
             enrollment_record, initial_twin_tags, initial_twin_properties
         )
-        iot_hub_list = iot_hubs.split() if iot_hubs else iot_hubs
+        iot_hub_list = iot_hubs.split() if isinstance(iot_hubs, str) else iot_hubs
+        if not iot_hub_list:
+            iot_hub_list = enrollment_record.iot_hubs
         _validate_allocation_policy_for_enrollment(
-            allocation_policy, iot_hub_host_name, iot_hub_list, webhook_url, api_version
+            allocation_policy or enrollment_record.allocation_policy,
+            iot_hub_host_name,
+            iot_hub_list,
+            webhook_url,
+            api_version
         )
         if allocation_policy:
             enrollment_record.allocation_policy = allocation_policy
@@ -481,7 +487,7 @@ def iot_dps_device_enrollment_group_create(
             )
         reprovision = _get_reprovision_policy(reprovision_policy)
         initial_twin = _get_initial_twin(initial_twin_tags, initial_twin_properties)
-        iot_hub_list = iot_hubs.split() if iot_hubs else iot_hubs
+        iot_hub_list = iot_hubs.split() if isinstance(iot_hubs, str) else iot_hubs
         _validate_allocation_policy_for_enrollment(
             allocation_policy, iot_hub_host_name, iot_hub_list, webhook_url, api_version
         )
@@ -621,9 +627,15 @@ def iot_dps_device_enrollment_group_update(
         enrollment_record.initial_twin = _get_updated_inital_twin(
             enrollment_record, initial_twin_tags, initial_twin_properties
         )
-        iot_hub_list = iot_hubs.split() if iot_hubs else iot_hubs
+        iot_hub_list = iot_hubs.split() if isinstance(iot_hubs, str) else iot_hubs
+        if not iot_hub_list:
+            iot_hub_list = enrollment_record.iot_hubs
         _validate_allocation_policy_for_enrollment(
-            allocation_policy, iot_hub_host_name, iot_hub_list, webhook_url, api_version
+            allocation_policy or enrollment_record.allocation_policy,
+            iot_hub_host_name,
+            iot_hub_list,
+            webhook_url,
+            api_version
         )
         if allocation_policy:
             enrollment_record.allocation_policy = allocation_policy

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
@@ -298,7 +298,7 @@ def test_dps_enrollment_symmetrickey_lifecycle(provisioned_iot_dps_module):
         assert update_enrollment["customAllocationDefinition"]["webhookUrl"] == WEBHOOK_URL
         assert update_enrollment["customAllocationDefinition"]["apiVersion"] == API_VERSION
         assert update_enrollment["deviceId"] == device_id
-        assert update_enrollment["iotHubs"] is None
+        assert update_enrollment["iotHubs"] == [hub_hostname]
         assert update_enrollment["initialTwin"]["tags"]
         assert update_enrollment["initialTwin"]["properties"]["desired"]
         assert update_enrollment["optionalDeviceInformation"] == generic_dict

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -127,6 +127,12 @@ class TestEnrollmentCreate():
                                         primary_key='primarykey',
                                         secondary_key='secondarykey',
                                         reprovision_policy='never',
+                                        allocation_policy='hashed',
+                                        iot_hubs=['hub1', 'hub2'])),
+        (generate_enrollment_create_req(attestation_type='symmetricKey',
+                                        primary_key='primarykey',
+                                        secondary_key='secondarykey',
+                                        reprovision_policy='never',
                                         allocation_policy='geoLatency')),
         (generate_enrollment_create_req(attestation_type='symmetricKey',
                                         primary_key='primarykey',
@@ -227,7 +233,9 @@ class TestEnrollmentCreate():
                 assert body['customAllocationDefinition']['webhookUrl'] == req['webhook_url']
                 assert body['customAllocationDefinition']['apiVersion'] == req['api_version']
         if req['iot_hubs']:
-            assert body['iotHubs'] == req['iot_hubs'].split()
+            assert body['iotHubs'] == (
+                req['iot_hubs'].split() if isinstance(req['iot_hubs'], str) else req['iot_hubs']
+            )
         if req['edge_enabled']:
             assert body['capabilities']['iotEdge']
 
@@ -376,6 +384,7 @@ class TestEnrollmentUpdate():
         (generate_enrollment_update_req(reprovision_policy='never')),
         (generate_enrollment_update_req(allocation_policy='static', iot_hubs='hub1')),
         (generate_enrollment_update_req(allocation_policy='hashed', iot_hubs='hub1 hub2')),
+        (generate_enrollment_update_req(allocation_policy='hashed', iot_hubs=['hub1', 'hub2'])),
         (generate_enrollment_update_req(allocation_policy='geoLatency')),
         (generate_enrollment_update_req(allocation_policy='custom',
                                         webhook_url="https://www.test.test",
@@ -383,7 +392,8 @@ class TestEnrollmentUpdate():
         (generate_enrollment_update_req(edge_enabled=True)),
         (generate_enrollment_update_req(edge_enabled=False))
     ])
-    def test_enrollment_update(self, serviceclient, fixture_cmd, req):
+    def test_enrollment_update(self, mocker, serviceclient, fixture_cmd, req):
+        mocker.patch("azext_iot.operations.dps._validate_allocation_policy_for_enrollment")
         subject.iot_dps_device_enrollment_update(
             cmd=fixture_cmd,
             enrollment_id=req['enrollment_id'],
@@ -457,7 +467,9 @@ class TestEnrollmentUpdate():
                 assert body['customAllocationDefinition']['webhookUrl'] == req['webhook_url']
                 assert body['customAllocationDefinition']['apiVersion'] == req['api_version']
         if req['iot_hubs']:
-            assert body['iotHubs'] == req['iot_hubs'].split()
+            assert body['iotHubs'] == (
+                req['iot_hubs'].split() if isinstance(req['iot_hubs'], str) else req['iot_hubs']
+            )
         if req['edge_enabled'] is not None:
             assert body['capabilities']['iotEdge'] == req['edge_enabled']
 

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
@@ -248,7 +248,7 @@ def test_dps_enrollment_group_symmetrickey_lifecycle(provisioned_iot_dps_module)
         assert enrollment_update["customAllocationDefinition"]["webhookUrl"] == WEBHOOK_URL
         assert enrollment_update["customAllocationDefinition"]["apiVersion"] == API_VERSION
         assert enrollment_update["enrollmentGroupId"] == enrollment_id
-        assert enrollment_update["iotHubs"] is None
+        assert enrollment_update["iotHubs"] == [hub_hostname]
         assert enrollment_update["initialTwin"]["tags"]
         assert enrollment_update["initialTwin"]["properties"]["desired"]
         assert enrollment_update["provisioningStatus"] == EntityStatusType.disabled.value

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
@@ -97,6 +97,9 @@ class TestEnrollmentGroupCreate():
                                               allocation_policy='hashed',
                                               iot_hubs='hub1 hub2')),
         (generate_enrollment_group_create_req(certificate_path='myCert',
+                                              allocation_policy='hashed',
+                                              iot_hubs=['hub1', 'hub2'])),
+        (generate_enrollment_group_create_req(certificate_path='myCert',
                                               allocation_policy='geoLatency')),
         (generate_enrollment_group_create_req(certificate_path='myCert',
                                               allocation_policy='custom',
@@ -190,7 +193,9 @@ class TestEnrollmentGroupCreate():
                 assert body['customAllocationDefinition']['webhookUrl'] == req['webhook_url']
                 assert body['customAllocationDefinition']['apiVersion'] == req['api_version']
         if req['iot_hubs']:
-            assert body['iotHubs'] == req['iot_hubs'].split()
+            assert body['iotHubs'] == ((
+                req['iot_hubs'].split() if isinstance(req['iot_hubs'], str) else req['iot_hubs'])
+            )
         if req['edge_enabled']:
             assert body['capabilities']['iotEdge']
 
@@ -362,12 +367,14 @@ class TestEnrollmentGroupUpdate():
                                               webhook_url="https://www.test.test",
                                               api_version="2019-03-31")),
         (generate_enrollment_group_update_req(allocation_policy='hashed', iot_hubs='hub1 hub2')),
+        (generate_enrollment_group_update_req(allocation_policy='hashed', iot_hubs=['hub1', 'hub2'])),
         (generate_enrollment_group_update_req(allocation_policy='geoLatency')),
         (generate_enrollment_group_update_req(iot_hub_host_name='hub1')),
         (generate_enrollment_group_update_req(edge_enabled=True)),
         (generate_enrollment_group_update_req(edge_enabled=False))
     ])
-    def test_enrollment_group_update(self, serviceclient, fixture_cmd, req):
+    def test_enrollment_group_update(self, mocker, serviceclient, fixture_cmd, req):
+        mocker.patch("azext_iot.operations.dps._validate_allocation_policy_for_enrollment")
         subject.iot_dps_device_enrollment_group_update(
             cmd=fixture_cmd,
             enrollment_id=req['enrollment_id'],
@@ -445,7 +452,9 @@ class TestEnrollmentGroupUpdate():
                 assert body['customAllocationDefinition']['webhookUrl'] == req['webhook_url']
                 assert body['customAllocationDefinition']['apiVersion'] == req['api_version']
         if req['iot_hubs']:
-            assert body['iotHubs'] == req['iot_hubs'].split()
+            assert body['iotHubs'] == ((
+                req['iot_hubs'].split() if isinstance(req['iot_hubs'], str) else req['iot_hubs'])
+            )
         if req['edge_enabled'] is not None:
             assert body['capabilities']['iotEdge'] == req['edge_enabled']
 


### PR DESCRIPTION
With respect to https://github.com/Azure/azure-cli/issues/29002

Fixing some weirdness in DPS enrollments and enrollment groups:
1. fix the iot hub param to allow multiple uses

create a new enrollment group with 2 iot hubs (here I just use the same one):
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/4efaba39-8c24-494a-a77e-53baed879f48)

2. ensure that update will keep the iot hub list unless a new list is given

re-use the enrollment; update the allocation policy and see that the hubs are still there:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/f7b33f88-aabe-4f93-9c89-2d9cfeb5fa9e)

try to update to static, get expected failure because there are 2 hubs:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/80d8e02b-553f-477a-bdd1-6176194b1ce4)

get it to work when a single hub is defined:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/47030081-7bb4-41bc-8ef6-08102e3879fa)

3. minimize the number of inputs needed to update custom allocation policy enrollments

going from static to custom, all inputs are still needed:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/cf4d25ae-f576-4d33-8000-faace75d93e9)

![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/6f41ba55-8ad5-4096-9df1-750dd2c7856b)

only want to update the url:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/62b87302-22ec-4e34-a9a5-377feffe8eed)

tests
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/fe0309b1-0f8b-453d-8c88-c7c673c5729e)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
