### PR TITLE
fix: `az iot hub state export` endpoint fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,10 @@ Release History
 
 * Removal of `az iot product`.
 
+**IoT Hub updates**
+
+* Fix for `az iot hub state export` to support storage account endpoints with system-assigned identity.
+
 
 0.23.1
 +++++++++++++++

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -659,10 +659,10 @@ class StateProvider(IoTHubProvider):
                         ep["primaryKey"] = parse_cosmos_db_connection_string(cs_object["connectionString"])["AccountKey"]
                     if cs_object["description"] == "Secondary SQL Connection String" and ep.get("secondaryKey"):
                         ep["secondaryKey"] = parse_cosmos_db_connection_string(cs_object["connectionString"])["AccountKey"]
-            elif isinstance(ep.get("identity"), dict) and ep["identity"]["userAssignedIdentity"] in removed_identities:
+            elif isinstance(ep.get("identity"), dict) and ep["identity"].get("userAssignedIdentity") in removed_identities:
                 logger.warning(
                     usr_msgs.SAVE_ENDPOINT_UAI_RETRIEVE_FAIL_MSG.format(
-                        "Cosmos DB Sql Collection", ep["name"], ep["identity"]["userAssignedIdentity"]
+                        "Cosmos DB Sql Collection", ep["name"], ep["identity"].get("userAssignedIdentity")
                     )
                 )
                 removed_endpoints.append(ep["name"])
@@ -708,10 +708,10 @@ class StateProvider(IoTHubProvider):
                     logger.warning(usr_msgs.SAVE_ENDPOINT_RETRIEVE_FAIL_MSG.format("Event Hub", ep["name"]))
                     removed_endpoints.append(ep["name"])
                     continue
-            elif isinstance(ep.get("identity"), dict) and ep["identity"]["userAssignedIdentity"] in removed_identities:
+            elif isinstance(ep.get("identity"), dict) and ep["identity"].get("userAssignedIdentity") in removed_identities:
                 logger.warning(
                     usr_msgs.SAVE_ENDPOINT_UAI_RETRIEVE_FAIL_MSG.format(
-                        "Event Hub", ep["name"], ep["identity"]["userAssignedIdentity"]
+                        "Event Hub", ep["name"], ep["identity"].get("userAssignedIdentity")
                     )
                 )
                 removed_endpoints.append(ep["name"])
@@ -754,10 +754,10 @@ class StateProvider(IoTHubProvider):
                     logger.warning(usr_msgs.SAVE_ENDPOINT_RETRIEVE_FAIL_MSG.format("Service Bus Queue", ep["name"]))
                     removed_endpoints.append(ep["name"])
                     continue
-            elif isinstance(ep.get("identity"), dict) and ep["identity"]["userAssignedIdentity"] in removed_identities:
+            elif isinstance(ep.get("identity"), dict) and ep["identity"].get("userAssignedIdentity") in removed_identities:
                 logger.warning(
                     usr_msgs.SAVE_ENDPOINT_UAI_RETRIEVE_FAIL_MSG.format(
-                        "Service Bus Queue", ep["name"], ep["identity"]["userAssignedIdentity"]
+                        "Service Bus Queue", ep["name"], ep["identity"].get("userAssignedIdentity")
                     )
                 )
                 removed_endpoints.append(ep["name"])
@@ -802,10 +802,10 @@ class StateProvider(IoTHubProvider):
                     )
                     removed_endpoints.append(ep["name"])
                     continue
-            elif isinstance(ep.get("identity"), dict) and ep["identity"]["userAssignedIdentity"] in removed_identities:
+            elif isinstance(ep.get("identity"), dict) and ep["identity"].get("userAssignedIdentity") in removed_identities:
                 logger.warning(
                     usr_msgs.SAVE_ENDPOINT_UAI_RETRIEVE_FAIL_MSG.format(
-                        "Service Bus Topic", ep["name"], ep["identity"]["userAssignedIdentity"]
+                        "Service Bus Topic", ep["name"], ep["identity"].get("userAssignedIdentity")
                     )
                 )
                 removed_endpoints.append(ep["name"])
@@ -848,10 +848,10 @@ class StateProvider(IoTHubProvider):
                     )
                     removed_endpoints.append(ep["name"])
                     continue
-            elif isinstance(ep.get("identity"), dict) and ep["identity"]["userAssignedIdentity"] in removed_identities:
+            elif isinstance(ep.get("identity"), dict) and ep["identity"].get("userAssignedIdentity") in removed_identities:
                 logger.warning(
                     usr_msgs.SAVE_ENDPOINT_UAI_RETRIEVE_FAIL_MSG.format(
-                        "Storage Container", ep["name"], ep["identity"]["userAssignedIdentity"]
+                        "Storage Container", ep["name"], ep["identity"].get("userAssignedIdentity")
                     )
                 )
                 removed_endpoints.append(ep["name"])
@@ -888,10 +888,10 @@ class StateProvider(IoTHubProvider):
         file_upload = hub_resource["properties"]["storageEndpoints"].get("$default", {})
         if (
             isinstance(file_upload.get("identity"), dict)
-            and file_upload["identity"]["userAssignedIdentity"] in removed_identities
+            and file_upload["identity"].get("userAssignedIdentity") in removed_identities
         ):
             logger.warning(
-                usr_msgs.SAVE_FILE_UPLOAD_UAI_RETRIEVE_FAIL_MSG.format(file_upload["identity"]["userAssignedIdentity"])
+                usr_msgs.SAVE_FILE_UPLOAD_UAI_RETRIEVE_FAIL_MSG.format(file_upload["identity"].get("userAssignedIdentity"))
             )
             file_upload["authenticationType"] = None
             file_upload["connectionString"] = None

--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -114,6 +114,7 @@ def setup_hub_controlplane_states(
     provisioned_storage = provisioned_iot_hubs_with_storage_user_module[0]["storage"]
     storage_cstring = provisioned_storage["connectionString"]
     storage_container = provisioned_storage["container"]["name"]
+    storage_endpoint_uri = provisioned_storage["storage"]["primaryEndpoints"]["blob"]
 
     cosmosdb_container_name = provisioned_cosmos_db_module["container"]["name"]
     cosmosdb_database_name = provisioned_cosmos_db_module["database"]["name"]
@@ -176,7 +177,14 @@ def setup_hub_controlplane_states(
 
     cli.invoke(
         f"iot hub message-endpoint create storage-container --en storagecontainer-key -g {hub_rg} -n {hub_name} -c "
-        f"{storage_cstring} --container {storage_container}  -b 350 -w 250 --encoding json")
+        f"{storage_cstring} --container {storage_container}  -b 350 -w 250 --encoding json"
+    )
+
+    cli.invoke(
+        f"iot hub message-endpoint create storage-container --en storagecontainer-{suffix} -g {hub_rg} -n {hub_name} "
+        f"--identity {user_identity_parameter} --endpoint-uri {storage_endpoint_uri} --container {storage_container} "
+        "-b 350 -w 250 --encoding json"
+    )
 
     cli.invoke(
         f"iot hub message-endpoint create cosmosdb-container --en cosmosdb-key -g {hub_rg} -n {hub_name} --container "

--- a/azext_iot/tests/iothub/state/test_hub_state_int.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_int.py
@@ -260,7 +260,7 @@ def delete_system_endpoints(hub_name, rg):
         f"iot hub routing-endpoint delete --hub-name {hub_name} -g {rg} -n queue-systemid"
     )
     cli.invoke(
-        f"iot hub routing-endpoint delete --hub-name {hub_name} -g {rg} -n storage-systemid"
+        f"iot hub routing-endpoint delete --hub-name {hub_name} -g {rg} -n storagecontainer-systemid"
     )
 
 

--- a/azext_iot/tests/iothub/state/test_hub_state_int.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_int.py
@@ -259,6 +259,9 @@ def delete_system_endpoints(hub_name, rg):
     cli.invoke(
         f"iot hub routing-endpoint delete --hub-name {hub_name} -g {rg} -n queue-systemid"
     )
+    cli.invoke(
+        f"iot hub routing-endpoint delete --hub-name {hub_name} -g {rg} -n storage-systemid"
+    )
 
 
 @pytest.mark.hub_infrastructure(count=2, sys_identity=True, user_identity=True, storage=True, desired_tags="abc=def")


### PR DESCRIPTION
idk how this was not caught before but added in an explicit test

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
