### PR TITLE
fix: add paging to `az iot dps enrollment-group registration list`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ Release History
 ===============
 
 
+0.24.1
++++++++++++++++
+
+**DPS updates**
+
+* Fix for `az iot dps enrollement-group registration list` to support paging.
+
+
 0.24.0
 +++++++++++++++
 

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.24.0"
+VERSION = "0.24.1"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -816,15 +816,13 @@ def _get_dps_connection_string(
 
 
 # DPS Registration
-
-
 def iot_dps_registration_list(
-    cmd, 
-    enrollment_id, 
-    dps_name=None, 
-    resource_group_name=None, 
+    cmd,
+    enrollment_id,
+    dps_name=None,
+    resource_group_name=None,
     top=None,
-    login=None, 
+    login=None,
     auth_type_dataplane=None,
 ):
     discovery = DPSDiscovery(cmd)

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -834,23 +834,10 @@ def iot_dps_registration_list(
         login=login,
         auth_type=auth_type_dataplane,
     )
-    registrations = []
     try:
         resolver = SdkResolver(target=target)
         sdk = resolver.get_sdk(SdkType.dps_sdk)
-        cont_token = None
-        while True:
-            result = sdk.device_registration_state.query(
-                enrollment_id, x_ms_continuation=cont_token, raw=True
-            )
-            registrations.extend(result.response.json())
-            cont_token = result.headers.get("x-ms-continuation")
-            if top and len(registrations) > top:
-                registrations = registrations[:top]
-                cont_token = None
-            if not cont_token:
-                break
-        return registrations
+        return _execute_query([enrollment_id], sdk.device_registration_state.query, top)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 

--- a/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
+++ b/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
@@ -195,6 +195,15 @@ def test_dps_device_registration_symmetrickey_lifecycle(provisioned_iot_dps_modu
         assert registration["status"] == "assigned"
 
         # Check for both registration from service side
+        random_registration = cli.invoke(
+            set_cmd_auth_type(
+                f"iot dps enrollment-group registration list --dps-name {dps_name} -g {dps_rg} --group-id {group_id} --top 1",
+                auth_type=auth_phase,
+                cstring=dps_cstring
+            ),
+        ).as_json()
+        assert len(random_registration) == 1
+
         service_side_registrations = cli.invoke(
             set_cmd_auth_type(
                 f"iot dps enrollment-group registration list --dps-name {dps_name} -g {dps_rg} --group-id {group_id}",


### PR DESCRIPTION
Response to Issue: https://github.com/Azure/azure-iot-cli-extension/issues/707

example:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/c85e6aa5-33fc-4a82-a67a-583d6e0af85f)

with top:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/0b2301b3-5112-4f45-95d1-28305ad69da4)

enrollment group tests not broken:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/574430be-866d-4f7c-9b54-ea56b3a17ba6)

registration tests not broken:
![image](https://github.com/Azure/azure-iot-cli-extension/assets/73560279/c71d29d1-a4ea-46c6-987d-0c90ce640d78)

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
