### PR TITLE
chore: set SHA256 as default hash for certificate thumbprint generation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 
 **IoT Hub updates**
 
+* Deprecate use of SHA1 hashes for certificate thumbprints. SHA256 hashes will be used for all certificate thumbprints.
+
 * Addition of bulk key regeneration for `az iot hub device-identity renew-key` and `az iot hub module-identity renew-key`.
 
 * Fix for `az iot hub monitor-events` when the IoT Hub has no partition Id's populated.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,10 +4,12 @@ Release History
 ===============
 
 
-0.24.1
+0.25.0
 +++++++++++++++
 
-** IoT Hub updates **
+**IoT Hub updates**
+
+* Addition of bulk key regeneration for `az iot hub device-identity renew-key` and `az iot hub module-identity renew-key`.
 
 * Fix for `az iot hub monitor-events` when the IoT Hub has no partition Id's populated.
 

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -40,8 +40,6 @@ def create_self_signed_certificate(
         cert_putput_dir (str): string value of output directory.
         cert_only (bool): generate certificate only; no private key or thumbprint.
         file_prefix (str): Certificate file name if it needs to be different from the subject.
-        sha_version (int): The SHA version to use for generating the thumbprint. For
-            IoT Hub and DPS, SHA256 has to be used.
 
     Returns:
         result (dict): dict with certificate value, private key and thumbprint.

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -29,7 +29,7 @@ def create_self_signed_certificate(
     key_size: int = 2048,
     cert_only: bool = False,
     file_prefix: str = None,
-    sha_version: int = SHAHashVersions.SHA1.value,
+    sha_version: int = SHAHashVersions.SHA256.value,
     v3_extensions: bool = False,
 ) -> Dict[str, str]:
     """

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -29,7 +29,6 @@ def create_self_signed_certificate(
     key_size: int = 2048,
     cert_only: bool = False,
     file_prefix: str = None,
-    sha_version: int = SHAHashVersions.SHA256.value,
     v3_extensions: bool = False,
 ) -> Dict[str, str]:
     """
@@ -43,7 +42,7 @@ def create_self_signed_certificate(
         cert_only (bool): generate certificate only; no private key or thumbprint.
         file_prefix (str): Certificate file name if it needs to be different from the subject.
         sha_version (int): The SHA version to use for generating the thumbprint. For
-            IoT Hub, SHA1 is currently used. For DPS, SHA256 has to be used.
+            IoT Hub and DPS, SHA256 has to be used.
 
     Returns:
         result (dict): dict with certificate value, private key and thumbprint.
@@ -110,16 +109,8 @@ def create_self_signed_certificate(
     # certificate string
     cert_dump = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
 
-    hash = None
-    if sha_version == SHAHashVersions.SHA1.value:
-        hash = hashes.SHA1()
-    elif sha_version == SHAHashVersions.SHA256.value:
-        hash = hashes.SHA256()
-    else:
-        raise ValueError("Only SHA1 and SHA256 supported for now.")
-
     # thumbprint
-    thumbprint = cert.fingerprint(hash).hex().upper()
+    thumbprint = cert.fingerprint(hashes.SHA256()).hex().upper()
 
     if cert_output_dir and exists(cert_output_dir):
         cert_file = (file_prefix or subject) + "-cert.pem"

--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -19,7 +19,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from azext_iot.common.fileops import write_content_to_file
 from azext_iot.common.utility import read_file_content
 from azure.cli.core.azclierror import FileOperationError
-from azext_iot.common.shared import SHAHashVersions
 
 
 def create_self_signed_certificate(

--- a/azext_iot/common/shared.py
+++ b/azext_iot/common/shared.py
@@ -308,6 +308,4 @@ class SHAHashVersions(Enum):
     """
     Supported SHA types for generating the certificate thumbprint.
     """
-
-    SHA1 = 1
     SHA256 = 256

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.24.1"
+VERSION = "0.25.0"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -272,7 +272,6 @@ class DeviceIdentityProvider(IoTHubProvider):
                     subject=device_id,
                     valid_days=365,
                     key_size=4096,
-                    sha_version=256,
                     v3_extensions=True
                 )
                 device_pk = signed_device_cert["thumbprint"]

--- a/azext_iot/iothub/providers/helpers/edge_device_config.py
+++ b/azext_iot/iothub/providers/helpers/edge_device_config.py
@@ -376,7 +376,6 @@ def process_edge_devices_config_file_content(
         root_cert = create_self_signed_certificate(
             subject=EDGE_ROOT_CERTIFICATE_SUBJECT,
             key_size=4096,
-            sha_version=256,
             v3_extensions=True
         )
 
@@ -520,7 +519,6 @@ def process_edge_devices_config_args(
         else create_self_signed_certificate(
             subject=EDGE_ROOT_CERTIFICATE_SUBJECT,
             key_size=4096,
-            sha_version=256,
             v3_extensions=True
         )
     )

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -305,7 +305,6 @@ def create_test_cert(
         cert_output_dir=output_dir,
         cert_only=cert_only,
         file_prefix=file_prefix,
-        sha_version=256,
     )["thumbprint"]
     name = file_prefix or subject
     tracked_certs.append(name + CERT_ENDING)

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -622,7 +622,6 @@ class TestHierarchyCreateConfig:
             root_cert = create_self_signed_certificate(
                 subject=EDGE_ROOT_CERTIFICATE_SUBJECT,
                 key_size=4096,
-                sha_version=256,
                 v3_extensions=True
             )
             write_content_to_file(
@@ -717,7 +716,6 @@ class TestEdgeHierarchyConfigFunctions:
         root_cert = create_self_signed_certificate(
             subject=EDGE_ROOT_CERTIFICATE_SUBJECT,
             key_size=4096,
-            sha_version=256,
             v3_extensions=True
         )
         write_content_to_file(


### PR DESCRIPTION
commands that are affected:
![image](https://github.com/user-attachments/assets/a86e6e46-80c5-48b9-9521-cb1d35656c6d)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
