### PR TITLE
fix: ensure endpoint subscription is used in `az iot hub message-endpoint create`

### DIFF
--- a/azext_iot/iothub/providers/message_endpoint.py
+++ b/azext_iot/iothub/providers/message_endpoint.py
@@ -122,7 +122,8 @@ class MessageEndpoint(IoTHubProvider):
                     rg=endpoint_resource_group,
                     sub=endpoint_subscription_id
                 )
-            new_endpoint["entityPath"] = entity_path
+            else:
+                new_endpoint["entityPath"] = entity_path
             endpoints.event_hubs.append(new_endpoint)
         elif endpoint_type.lower() == EndpointType.ServiceBusQueue.value:
             if fetch_connection_string:
@@ -559,9 +560,10 @@ def get_eventhub_cstring(
 ) -> str:
     return cmd.invoke(
         "eventhubs eventhub authorization-rule keys list --namespace-name {} --resource-group {} "
-        "--eventhub-name {} --name {} --subscription {}".format(
-            namespace_name, rg, eventhub_name, policy_name, sub
-        )
+        "--eventhub-name {} --name {}".format(
+            namespace_name, rg, eventhub_name, policy_name
+        ),
+        subscription=sub
     ).as_json()["primaryConnectionString"]
 
 
@@ -570,9 +572,10 @@ def get_servicebus_topic_cstring(
 ) -> str:
     return cmd.invoke(
         "servicebus topic authorization-rule keys list --namespace-name {} --resource-group {} "
-        "--topic-name {} --name {} --subscription {}".format(
-            namespace_name, rg, topic_name, policy_name, sub
-        )
+        "--topic-name {} --name {}".format(
+            namespace_name, rg, topic_name, policy_name
+        ),
+        subscription=sub
     ).as_json()["primaryConnectionString"]
 
 
@@ -581,9 +584,10 @@ def get_servicebus_queue_cstring(
 ) -> str:
     return cmd.invoke(
         "servicebus queue authorization-rule keys list --namespace-name {} --resource-group {} "
-        "--queue-name {} --name {}  --subscription {}".format(
-            namespace_name, rg, queue_name, policy_name, sub
-        )
+        "--queue-name {} --name {}".format(
+            namespace_name, rg, queue_name, policy_name
+        ),
+        subscription=sub
     ).as_json()["primaryConnectionString"]
 
 
@@ -591,9 +595,10 @@ def get_cosmos_db_cstring(
     cmd, account_name: str, rg: str, sub: str
 ) -> str:
     output = cmd.invoke(
-        'cosmosdb keys list --resource-group {} --name {} --type connection-strings --subscription {}'.format(
-            rg, account_name, sub
-        )
+        'cosmosdb keys list --resource-group {} --name {} --type connection-strings'.format(
+            rg, account_name
+        ),
+        subscription=sub
     ).as_json()
 
     for cs_object in output["connectionStrings"]:
@@ -603,7 +608,8 @@ def get_cosmos_db_cstring(
 
 def get_storage_cstring(cmd, account_name: str, rg: str, sub: str) -> str:
     return cmd.invoke(
-        "storage account show-connection-string -n {} -g {}  --subscription {}".format(
-            account_name, rg, sub
-        )
+        "storage account show-connection-string -n {} -g {}".format(
+            account_name, rg
+        ),
+        subscription=sub
     ).as_json()["connectionString"]

--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -684,7 +684,7 @@ def _cosmos_db_provisioner():
     database_name = generate_hub_depenency_id()
     collection_name = generate_hub_depenency_id()
     partition_key_path = "/test"
-    location = "eastus"
+    location = "westus"
     cosmos_obj = cli.invoke(
         "cosmosdb create --name {} --resource-group {} --locations regionName={} failoverPriority=0".format(
             account_name, RG, location


### PR DESCRIPTION
includes changing cosmos db test creation location to westus


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
