### PR TITLE
fix: add `--no-progress` to key regeneration commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 
 **IoT Hub updates**
 
+* Fix `az iot hub message-endpoint create` to correctly pass the endpoint subscription when provided.
+
 * Deprecate use of SHA1 hashes for certificate thumbprints. SHA256 hashes will be used for all certificate thumbprints.
 
 * Addition of bulk key regeneration for `az iot hub device-identity renew-key` and `az iot hub module-identity renew-key`.

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -486,6 +486,12 @@ def load_arguments(self, _):
             help="Etag or entity tag corresponding to the last state of the resource. "
             "If no etag is provided the value '*' is used. This arguement only applies to `swap`.",
         )
+        context.argument(
+            "no_progress",
+            options_list=["--no-progress"],
+            arg_type=get_three_state_flag(),
+            help="Hide the progress bar for bulk key regeneration.",
+        )
 
     with self.argument_context("iot hub device-identity export") as context:
         context.argument(
@@ -645,6 +651,12 @@ def load_arguments(self, _):
             options_list=["--etag", "-e"],
             help="Etag or entity tag corresponding to the last state of the resource. "
             "If no etag is provided the value '*' is used. This arguement only applies to `swap`.",
+        )
+        context.argument(
+            "no_progress",
+            options_list=["--no-progress"],
+            arg_type=get_three_state_flag(),
+            help="Hide the progress bar for bulk key regeneration.",
         )
 
     with self.argument_context("iot hub distributed-tracing update") as context:

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -505,6 +505,7 @@ def iot_device_key_regenerate(
     device_ids,
     renew_key_type,
     include_modules=False,
+    no_progress=False,
     resource_group_name=None,
     login=None,
     etag=None,
@@ -567,6 +568,7 @@ def iot_device_key_regenerate(
         service_sdk=service_sdk,
         renew_key_type=renew_key_type,
         items=devices + modules,
+        no_progress=no_progress
     )
 
     # avoid breaking changes by having one device return the device identity
@@ -990,6 +992,7 @@ def iot_device_module_key_regenerate(
     device_id,
     module_ids,
     renew_key_type,
+    no_progress=None,
     resource_group_name=None,
     login=None,
     etag=None,
@@ -1042,7 +1045,8 @@ def iot_device_module_key_regenerate(
         service_sdk=service_sdk,
         renew_key_type=renew_key_type,
         items=modules,
-        device_id=device_id
+        device_id=device_id,
+        no_progress=no_progress
     )
 
     if len(module_ids) == 1 and module_ids[0] != "*":
@@ -1074,6 +1078,7 @@ def _iot_key_regenerate_batch(
     renew_key_type,
     items,
     device_id=None,
+    no_progress=False,
 ):
     from time import sleep
     overall_result = {
@@ -1093,7 +1098,7 @@ def _iot_key_regenerate_batch(
         else:
             batches.append(items[:])
             items = []
-    for batch in tqdm(batches, desc="Bulk key regeneration is in progress", ascii=' #'):
+    for batch in tqdm(batches, desc="Bulk key regeneration is in progress", ascii=' #', disable=no_progress):
         # call
         result = None
         tries = 0

--- a/scripts/smoke_tests/commands_test.ps1
+++ b/scripts/smoke_tests/commands_test.ps1
@@ -107,7 +107,7 @@ $commands += "az iot hub configuration show -g $resource_group_name -c $hub_conf
 # IoT Hub Device
 $commands += "az iot hub device-identity create -g $resource_group_name -n $iothub_name -d $device_id --ee"
 $commands += "az iot hub device-identity show -g $resource_group_name -n $iothub_name -d $device_id"
-$commands += "az iot hub device-identity renew-key -g $resource_group_name -n $iothub_name -d $device_id --kt primary"
+$commands += "az iot hub device-identity renew-key -g $resource_group_name -n $iothub_name -d $device_id --kt primary --no-progress"
 $commands += "az iot hub device-twin show -g $resource_group_name -n $iothub_name -d $device_id"
 $commands += "az iot hub device-twin update -g $resource_group_name -n $iothub_name -d $device_id --desired $desired_twin_properties"
 $commands += "az iot hub generate-sas-token -g $resource_group_name -d $device_id -n $iothub_name"


### PR DESCRIPTION
The tqdm output gets put into stderr making the smoke tests unhappy...

command without `--no-progress` and with `--no-progress`
![image](https://github.com/user-attachments/assets/269f63c2-4764-4f33-843c-8cf6ae5881dd)

showing that the tqdm is not getting into piping
![image](https://github.com/user-attachments/assets/6ac98b2e-23f5-4c46-a358-c105999c6a99)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
