### PR TITLE
test: update the IoT Hub Cosmos Db custom endpoint tests to use the actual partition key

### DIFF
--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -707,6 +707,7 @@ def _cosmos_db_provisioner():
         "cosmosdb": cosmos_obj,
         "database": database_obj,
         "container": container_obj,
+        "partitionKey": partition_key_path,
         "connectionString": _cosmos_db_get_cstring(account_name)
     }
 

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_int.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_int.py
@@ -918,7 +918,7 @@ def test_iot_cosmos_endpoint_lifecycle(provisioned_cosmosdb_with_identity_module
     endpoint_names = generate_ep_names(3)
     partition_template = "{iothub}-{device_id}-{DD}-{MM}-{YYYY}"
     partition_template_default = "{deviceid}-{YYYY}-{MM}"
-    partition_path = "example"
+    partition_path = cosmosdb_obj["partitionKey"]
     # use connection string - no pkn or pkt
     cli.invoke(
         "iot hub message-endpoint create cosmosdb-container -n {} -g {} --en {} --erg {} -c {} --container {} "


### PR DESCRIPTION
hub now enforces the partition key - if it is invalid the response is quick enough. 

hub also has plans on fixing an error when the key is provided as none. So tests fail for now :).

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
