### PR TITLE
test: fix digital twins integration tests

### DIFF
--- a/azext_iot/tests/digitaltwins/__init__.py
+++ b/azext_iot/tests/digitaltwins/__init__.py
@@ -19,8 +19,7 @@ logger = get_logger(__name__)
 
 MOCK_RESOURCE_TAGS = "a=b c=d"
 MOCK_RESOURCE_TAGS_DICT = {"a": "b", "c": "d"}
-MOCK_DEAD_LETTER_ENDPOINT = "https://accountname.blob.core.windows.net/containerName"
-MOCK_DEAD_LETTER_SECRET = "{}?sasToken".format(MOCK_DEAD_LETTER_ENDPOINT)
+MOCK_DEAD_LETTER_PLACEHOLDER = "(PLACEHOLDER)"
 REGION_RESOURCE_LIMIT = 9  # Actual value is 10 but this is to limit race condition
 REGION_LIST = ["westus2", "westcentralus", "eastus2", "eastus", "eastus2euap"]
 MAX_ADX_RETRIES = 5

--- a/azext_iot/tests/digitaltwins/__init__.py
+++ b/azext_iot/tests/digitaltwins/__init__.py
@@ -19,7 +19,6 @@ logger = get_logger(__name__)
 
 MOCK_RESOURCE_TAGS = "a=b c=d"
 MOCK_RESOURCE_TAGS_DICT = {"a": "b", "c": "d"}
-MOCK_DEAD_LETTER_PLACEHOLDER = "(PLACEHOLDER)"
 REGION_RESOURCE_LIMIT = 9  # Actual value is 10 but this is to limit race condition
 REGION_LIST = ["westus2", "westcentralus", "eastus2", "eastus", "eastus2euap"]
 MAX_ADX_RETRIES = 5

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -25,7 +25,6 @@ from . import (
     EP_SERVICEBUS_TOPIC,
     MOCK_RESOURCE_TAGS,
     MOCK_RESOURCE_TAGS_DICT,
-    MOCK_DEAD_LETTER_PLACEHOLDER,
     generate_resource_id,
 )
 

--- a/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
+++ b/azext_iot/tests/digitaltwins/test_dt_resource_lifecycle_int.py
@@ -25,8 +25,7 @@ from . import (
     EP_SERVICEBUS_TOPIC,
     MOCK_RESOURCE_TAGS,
     MOCK_RESOURCE_TAGS_DICT,
-    MOCK_DEAD_LETTER_SECRET,
-    MOCK_DEAD_LETTER_ENDPOINT,
+    MOCK_DEAD_LETTER_PLACEHOLDER,
     generate_resource_id,
 )
 
@@ -343,6 +342,26 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_RG,
             )
         ).as_json()["id"]
+
+        self._create_storage_account()
+        storage_account_uri = self.embedded_cli.invoke(
+            "storage account show -n {} -g {}".format(
+                self.storage_account_name,
+                self.rg
+            )
+        ).as_json()["primaryEndpoints"]["blob"]
+
+        storage_account_sas = self.embedded_cli.invoke(
+            "storage container generate-sas -n {} --account-key {} --account-name {}".format(
+                self.storage_container,
+                self.storage_cstring,
+                self.storage_account_name,
+            )
+        ).output.strip('"\n')
+
+        storage_account_uri = f"{storage_account_uri}{self.storage_container}"
+        storage_account_full_sas = f'"{storage_account_uri}?{storage_account_sas}"'
+
         endpoint_instance = self.cmd(
             "dt create -n {} -g {} -l {} --mi-system-assigned --scopes {} {} --role {}".format(
                 endpoints_instance_name,
@@ -381,7 +400,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 "" if EP_RG == self.rg else f"--egg {EP_RG}",
                 EP_EVENTGRID_TOPIC,
                 eventgrid_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         )
         endpoint_tuple_collection.append(
@@ -403,7 +422,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_SERVICEBUS_POLICY,
                 EP_SERVICEBUS_TOPIC,
                 servicebus_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         )
         endpoint_tuple_collection.append(
@@ -426,7 +445,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint_msi,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
             )
         )
 
@@ -527,6 +546,25 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             )
         ).as_json()["id"]
 
+        self._create_storage_account()
+        storage_account_uri = self.embedded_cli.invoke(
+            "storage account show -n {} -g {}".format(
+                self.storage_account_name,
+                self.rg
+            )
+        ).as_json()["primaryEndpoints"]["blob"]
+
+        storage_account_sas = self.embedded_cli.invoke(
+            "storage container generate-sas -n {} --account-key {} --account-name {}".format(
+                self.storage_container,
+                self.storage_cstring,
+                self.storage_account_name,
+            )
+        ).output.strip('"\n')
+
+        storage_account_uri = f"{storage_account_uri}{self.storage_container}"
+        storage_account_full_sas = f'"{storage_account_uri}?{storage_account_sas}"'
+
         eh_resource_id = self.embedded_cli.invoke(
             "eventhubs eventhub show --namespace-name {} -n {} -g {}".format(
                 EP_EVENTHUB_NAMESPACE,
@@ -575,7 +613,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_RG,
                 EP_EVENTGRID_TOPIC,
                 eventgrid_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         ).get_output_in_json()
 
@@ -591,7 +629,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             add_ep_output,
             eventgrid_endpoint,
             ADTEndpointType.eventgridtopic,
-            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+            dead_letter_secret=storage_account_full_sas,
         )
 
         # Delete and re-add endpoint with no wait
@@ -610,7 +648,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_RG,
                 EP_EVENTGRID_TOPIC,
                 eventgrid_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         )
 
@@ -634,7 +672,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             show_ep_output,
             eventgrid_endpoint,
             ADTEndpointType.eventgridtopic,
-            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+            dead_letter_secret=storage_account_full_sas,
         )
 
         endpoint_tuple_collection.append(
@@ -658,7 +696,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_SERVICEBUS_POLICY,
                 EP_SERVICEBUS_TOPIC,
                 servicebus_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         ).get_output_in_json()
 
@@ -675,7 +713,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             servicebus_endpoint,
             endpoint_type=ADTEndpointType.servicebus,
             auth_type=ADTEndpointAuthType.keybased,
-            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+            dead_letter_secret=storage_account_full_sas,
         )
 
         # Delete and re-add endpoint with no wait
@@ -695,7 +733,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_SERVICEBUS_POLICY,
                 EP_SERVICEBUS_TOPIC,
                 servicebus_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         )
 
@@ -720,7 +758,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             servicebus_endpoint,
             endpoint_type=ADTEndpointType.servicebus,
             auth_type=ADTEndpointAuthType.keybased,
-            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+            dead_letter_secret=storage_account_full_sas,
         )
         endpoint_tuple_collection.append(
             EndpointTuple(
@@ -738,7 +776,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_SERVICEBUS_NAMESPACE,
                 EP_SERVICEBUS_TOPIC,
                 servicebus_endpoint_msi,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
             )
         ).get_output_in_json()
 
@@ -755,7 +793,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             servicebus_endpoint_msi,
             endpoint_type=ADTEndpointType.servicebus,
             auth_type=ADTEndpointAuthType.identitybased,
-            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+            dead_letter_endpoint=storage_account_uri,
         )
         endpoint_tuple_collection.append(
             EndpointTuple(
@@ -773,7 +811,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_SERVICEBUS_NAMESPACE,
                 EP_SERVICEBUS_TOPIC,
                 servicebus_endpoint_uai,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
                 user_identity_id
             )
         ).get_output_in_json()
@@ -791,7 +829,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             servicebus_endpoint_uai,
             endpoint_type=ADTEndpointType.servicebus,
             auth_type=ADTEndpointAuthType.identitybased,
-            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+            dead_letter_endpoint=storage_account_uri,
         )
 
         # Delete endpoint to avoid endpoint limits
@@ -810,7 +848,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
         # Cannot use both system and user identities
         add_ep_output = self.cmd(
             "dt endpoint create eventhub -n {} --ehg {} --ehn {} --ehp {} --eh {} --ehs {} --en {}"
-            " --dsu '{}' --system --user {}".format(
+            " --dsu {} --system --user {}".format(
                 endpoints_instance_name,
                 EP_RG,
                 EP_EVENTHUB_NAMESPACE,
@@ -818,7 +856,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
                 user_identity_id
             ),
             expect_failure=True
@@ -826,7 +864,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
 
         logger.debug("Adding key based eventhub endpoint...")
         add_ep_output = self.cmd(
-            "dt endpoint create eventhub -n {} --ehg {} --ehn {} --ehp {} --eh {} --ehs {} --en {} --dsu '{}'".format(
+            "dt endpoint create eventhub -n {} --ehg {} --ehn {} --ehp {} --eh {} --ehs {} --en {} --dsu {}".format(
                 endpoints_instance_name,
                 EP_RG,
                 EP_EVENTHUB_NAMESPACE,
@@ -834,7 +872,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint,
-                MOCK_DEAD_LETTER_SECRET,
+                storage_account_full_sas,
             )
         ).get_output_in_json()
 
@@ -851,7 +889,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             eventhub_endpoint,
             ADTEndpointType.eventhub,
             auth_type=ADTEndpointAuthType.keybased,
-            dead_letter_secret=MOCK_DEAD_LETTER_SECRET,
+            dead_letter_secret=storage_account_full_sas,
         )
         endpoint_tuple_collection.append(
             EndpointTuple(
@@ -871,7 +909,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint_msi,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
             )
         ).get_output_in_json()
 
@@ -888,7 +926,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             eventhub_endpoint_msi,
             endpoint_type=ADTEndpointType.eventhub,
             auth_type=ADTEndpointAuthType.identitybased,
-            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+            dead_letter_endpoint=storage_account_uri,
         )
 
         # Delete and re-add endpoint with no wait
@@ -909,7 +947,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint_msi,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
             )
         )
 
@@ -934,7 +972,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             eventhub_endpoint_msi,
             endpoint_type=ADTEndpointType.eventhub,
             auth_type=ADTEndpointAuthType.identitybased,
-            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+            dead_letter_endpoint=storage_account_uri,
         )
         endpoint_tuple_collection.append(
             EndpointTuple(
@@ -954,7 +992,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
                 EP_EVENTHUB_TOPIC,
                 self.current_subscription,
                 eventhub_endpoint_uai,
-                MOCK_DEAD_LETTER_ENDPOINT,
+                storage_account_uri,
                 user_identity_id
             )
         ).get_output_in_json()
@@ -972,7 +1010,7 @@ class TestDTResourceLifecycle(DTLiveScenarioTest):
             eventhub_endpoint_uai,
             endpoint_type=ADTEndpointType.eventhub,
             auth_type=ADTEndpointAuthType.identitybased,
-            dead_letter_endpoint=MOCK_DEAD_LETTER_ENDPOINT,
+            dead_letter_endpoint=storage_account_uri,
         )
         endpoint_tuple_collection.append(
             EndpointTuple(


### PR DESCRIPTION
Only the endpoint tests are failing. The issue is that the deadletter uri + secret is now supposed to be valid (it was not checked before). Added in a storage account to give a valid uri + sas keys.

![image](https://github.com/user-attachments/assets/40f3d943-e2e3-4160-a993-9ea2e0cd55ed)


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
