### PR TITLE
fix: re-enable central and hub tests

### DIFF
--- a/.azure-devops/templates/trigger-tests.yml
+++ b/.azure-devops/templates/trigger-tests.yml
@@ -101,7 +101,7 @@ jobs:
   steps:
   - template: run-tests-parallel.yml
     parameters:
-      path: 'azext_iot/tests/iothub/certificate azext_iot/tests/iothub/configurations azext_iot/tests/iothub/core azext_iot/tests/iothub/jobs azext_iot/tests/iothub/state'
+      path: 'azext_iot/tests/iothub/configurations azext_iot/tests/iothub/core azext_iot/tests/iothub/jobs azext_iot/tests/iothub/state'
       name: 'iot-hub-1'
       num_threads: 7
       azureCLIVersion: ${{ parameters.azureCLIVersion }}

--- a/azext_iot/central/services/_utility.py
+++ b/azext_iot/central/services/_utility.py
@@ -55,7 +55,7 @@ def make_api_call(
 
 def get_headers(token, cmd, has_json_payload=False):
     if not token:
-        aad_token = auth.get_aad_token(cmd, resource="https://apps.azureiotcentral.com")
+        aad_token = auth.get_aad_token(cmd.cli_ctx, resource="https://apps.azureiotcentral.com")
         token = "Bearer {}".format(aad_token["accessToken"])
 
     headers = {

--- a/azext_iot/central/services/device.py
+++ b/azext_iot/central/services/device.py
@@ -744,7 +744,7 @@ def get_device_twin(
     """
 
     if not token:
-        aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
+        aad_token = get_aad_token(cmd.cli_ctx, resource="https://apps.azureiotcentral.com")[
             "accessToken"
         ]
         token = "Bearer {}".format(aad_token)
@@ -905,7 +905,7 @@ def list_device_modules(
         modules: list
     """
     if not token:
-        aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
+        aad_token = get_aad_token(cmd.cli_ctx, resource="https://apps.azureiotcentral.com")[
             "accessToken"
         ]
         token = "Bearer {}".format(aad_token)
@@ -954,7 +954,7 @@ def restart_device_module(
     """
 
     if not token:
-        aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
+        aad_token = get_aad_token(cmd.cli_ctx, resource="https://apps.azureiotcentral.com")[
             "accessToken"
         ]
         token = "Bearer {}".format(aad_token)

--- a/azext_iot/common/_azure.py
+++ b/azext_iot/common/_azure.py
@@ -71,7 +71,7 @@ def get_iot_central_tokens(cmd, app_id, token, central_dns_suffix):
     import requests
 
     if not token:
-        aad_token = get_aad_token(cmd, resource="https://apps.azureiotcentral.com")[
+        aad_token = get_aad_token(cmd.cli_ctx, resource="https://apps.azureiotcentral.com")[
             "accessToken"
         ]
         token = "Bearer {}".format(aad_token)

--- a/azext_iot/tests/central/test_iot_central_unit.py
+++ b/azext_iot/tests/central/test_iot_central_unit.py
@@ -137,7 +137,7 @@ class TestCentralHelpers:
             cli_ctx = ""
 
         # Test to ensure _get_aad_token is called and returns the right values based on profile.get_raw_tokens
-        assert get_aad_token(Cmd(), "resource") == {
+        assert get_aad_token(Cmd().cli_ctx, "resource") == {
             "accessToken": "raw token 0 -b",
             "expiresOn": "value",
             "subscription": "raw token 1",

--- a/azext_iot/tests/central/test_iot_central_unit.py
+++ b/azext_iot/tests/central/test_iot_central_unit.py
@@ -241,7 +241,7 @@ class TestCentralDeviceProvider:
     def test_should_list_device_modules(self, get_aad_token_svc, req_svc):
         # setup
         provider = CentralDeviceProvider(
-            cmd=None, app_id=app_id, api_version=API_VERSION
+            cmd=None, app_id=app_id, api_version=API_VERSION, token="token"
         )
         response = mock.MagicMock()
         response.status_code = 200


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
