### PR TITLE
feat(tools): initial devcontainer config

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,73 @@
+# Welcome to the Azure IoT CLI Extension codespace!
+
+This codespace has everything you need to get started developing with Python and the Azure CLI.
+
+Included VSCode Extensions:
+
+- [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+- [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)
+- [Python isort](https://marketplace.visualstudio.com/items?itemName=ms-python.isort)
+- [VSCode Github Actions](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions)
+- [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+
+Included Azure CLI extensions:
+
+- [azure-devops](https://github.com/Azure/azure-devops-cli-extension)
+
+Additional software:
+
+- **Azure CLI** (and a locally installed copy of this extension)
+
+## Validate codespace setup:
+
+<details>
+<summary>
+Validate local dev extension configuration
+</summary>
+
+- Ensure your local Python virtual environment is active:
+
+  `az -v` should show you a local `Python location` path in your `env` folder:
+
+  `/workspaces/azure-iot-cli-extension/env/bin/python`
+
+- Ensure your development extension is added to the CLI:
+
+  `az extension list -o table` should show your installed extensions.
+  
+  Look for the extension `azure-iot`, with `/workspaces/azure-iot-cli-extension` as the `Path` and `dev` as the `ExtensionType`
+
+- Ensure you can lint and unit test your local code:
+
+  `tox` will run these checks, more info in our [tox guide](../docs/tox-testing.md)
+
+</details>
+
+<details>
+<summary>
+Validate local dev environment
+</summary>
+
+- Ensure you can run commands from the extension:
+
+  `az iot hub device-identity create -h` should display help text without asking you to install the extension
+
+</details>
+
+<details open>
+<summary>Validate CLI login and Azure connection</summary>
+
+- Login to azure CLI (choose one):
+
+  1. Login with `az login --use-device-code`
+  2. Open codespace in desktop: `Ctrl/Cmd + Shift + P > Codespaces: Open in VS Code Desktop` and run `az login`
+
+- Ensure you have a valid subscription selected:
+
+  `az account show -o table`
+
+- List all IoT Hubs in your subscription:
+
+  `az iot hub list -o table`
+
+</details>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+	"name": "Azure IoT CLI devcontainer",
+	"image": "mcr.microsoft.com/devcontainers/universal:linux",
+	"hostRequirements": {
+		"cpus": 2,
+		"memory": "8gb",
+		"storage": "32gb"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {
+			"installUsingPython": true,
+			"version": "latest",
+			"extensions": [
+				"azure-devops"
+			]
+		}
+	},
+	"secrets": {
+		"SUBSCRIPTION_ID": {
+			"description": "Your Azure subscription ID"
+		},
+		"RESOURCE_GROUP": {
+			"description": "Your Azure resource group"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// python language support
+				"ms-python.python",
+				// python linting
+				"ms-python.black-formatter",
+				// import ordering
+				"ms-python.isort",
+				// github actions support
+				"github.vscode-github-actions",
+				// yaml
+				"redhat.vscode-yaml"
+			],
+			"settings": {
+				"python.terminal.activateEnvironment": true,
+				"python.terminal.activateEnvInCurrentTerminal": true,
+				"python.defaultInterpreterPath": "./env/bin/python",
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter"
+				}
+			}
+		}
+	},
+	"onCreateCommand": "bash ./.devcontainer/on_create_commands.sh"
+}

--- a/.devcontainer/on_create_commands.sh
+++ b/.devcontainer/on_create_commands.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+echo "Setting up CLI dev environment"
+
+# Install virtualenv
+python -m venv env
+source env/bin/activate
+
+# Install azdev
+echo "Install AZDEV"
+pip install azdev
+
+# Install CLI core (EDGE) and configure extension repo
+echo "azdev setup"
+azdev setup -c EDGE
+
+# install dev requirements (overrides setuptools)
+echo "Installing extension and dev requirements..."
+pip install -r dev_requirements
+pip install -U --target ~/.azure/cliextensions/azure-iot .
+
+# setup tox environment dependencies in parallel, but don't run tests
+echo "Creating local tox environments..."
+python -m pip install tox
+tox -np


### PR DESCRIPTION
Enables this extension repo with a ready-to-develop devcontainer setup for codespaces.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
