### PR TITLE
feat: move `az iot hub devicestream` to extension

### DIFF
--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -955,3 +955,22 @@ def load_iothub_help():
             text: >
               az iot hub message-route fallback set -n {iothub_name} --enabled false
     """
+
+    helps[
+        "iot hub devicestream"
+    ] = """
+        type: group
+        short-summary: Manage device streams of an IoT hub.
+    """
+
+    helps[
+        "iot hub devicestream show"
+    ] = """
+        type: command
+        short-summary: Get IoT Hub's device streams endpoints.
+        long-summary: Get IoT Hub's device streams endpoints.
+        examples:
+          - name: Get all the device streams from "MyIotHub" IoT Hub.
+            text: >
+                az iot hub devicestream show -n MyIotHub
+    """

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -157,7 +157,7 @@ def load_iothub_commands(self, _):
         cmd_group.command("set", "message_fallback_route_set")
 
     with self.command_group("iot hub devicestream", command_type=iothub_devicestream_ops, is_preview=True) as cmd_group:
-        cmd_group.command("show", "show_device_stream")
+        cmd_group.show_command("show", "show_device_stream")
 
     with self.command_group("iot device", command_type=device_messaging_ops) as cmd_group:
         cmd_group.command("send-d2c-message", "iot_device_send_message")

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -23,8 +23,8 @@ iothub_state_ops = CliCommandType(operations_tmpl="azext_iot.iothub.commands_sta
 device_identity_ops = CliCommandType(
     operations_tmpl="azext_iot.iothub.commands_device_identity#{}"
 )
-iothub_resource_ops = CliCommandType(
-    operations_tmpl="azext_iot.iothub.commands_certificate#{}"
+iothub_devicestream_ops = CliCommandType(
+    operations_tmpl="azext_iot.iothub.commands_device_stream#{}"
 )
 
 
@@ -155,6 +155,9 @@ def load_iothub_commands(self, _):
     with self.command_group("iot hub message-route fallback", command_type=iothub_message_route_ops) as cmd_group:
         cmd_group.show_command("show", "message_fallback_route_show")
         cmd_group.command("set", "message_fallback_route_set")
+
+    with self.command_group("iot hub devicestream", command_type=iothub_devicestream_ops, is_preview=True) as cmd_group:
+        cmd_group.command("show", "show_device_stream")
 
     with self.command_group("iot device", command_type=device_messaging_ops) as cmd_group:
         cmd_group.command("send-d2c-message", "iot_device_send_message")

--- a/azext_iot/iothub/commands_device_stream.py
+++ b/azext_iot/iothub/commands_device_stream.py
@@ -13,7 +13,6 @@ def show_device_stream(
     hub_name: str,
     resource_group_name: Optional[str] = None,
 ) -> List[dict]:
-    print("in extension")
     return DeviceStreamProvider(
         cmd=cmd, hub_name=hub_name, rg=resource_group_name
     ).show()

--- a/azext_iot/iothub/commands_device_stream.py
+++ b/azext_iot/iothub/commands_device_stream.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azext_iot.iothub.providers.device_stream import DeviceStreamProvider
+from typing import Optional, List
+
+
+def show_device_stream(
+    cmd,
+    hub_name: str,
+    resource_group_name: Optional[str] = None,
+) -> List[dict]:
+    print("in extension")
+    return DeviceStreamProvider(
+        cmd=cmd, hub_name=hub_name, rg=resource_group_name
+    ).show()

--- a/azext_iot/iothub/commands_device_stream.py
+++ b/azext_iot/iothub/commands_device_stream.py
@@ -5,14 +5,14 @@
 # --------------------------------------------------------------------------------------------
 
 from azext_iot.iothub.providers.device_stream import DeviceStreamProvider
-from typing import Optional, List
+from typing import Optional
 
 
 def show_device_stream(
     cmd,
     hub_name: str,
     resource_group_name: Optional[str] = None,
-) -> List[dict]:
+) -> Optional[dict]:
     return DeviceStreamProvider(
         cmd=cmd, hub_name=hub_name, rg=resource_group_name
     ).show()

--- a/azext_iot/iothub/providers/device_stream.py
+++ b/azext_iot/iothub/providers/device_stream.py
@@ -8,7 +8,6 @@ from typing import Optional
 from knack.log import get_logger
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.iothub.providers.base import IoTHubProvider
-from azure.cli.core.azclierror import InvalidArgumentValueError
 from azext_iot.iothub.common import HUB_PROVIDER
 
 logger = get_logger(__name__)

--- a/azext_iot/iothub/providers/device_stream.py
+++ b/azext_iot/iothub/providers/device_stream.py
@@ -33,5 +33,5 @@ class DeviceStreamProvider(IoTHubProvider):
         ).as_json()
         device_streams = result.get("properties", {}).get("deviceStreams")
         if not device_streams:
-            raise InvalidArgumentValueError("Device streams are not enabled for this IoT Hub.")
+            logger.warning("Device streams are not enabled for this IoT Hub.")
         return device_streams

--- a/azext_iot/iothub/providers/device_stream.py
+++ b/azext_iot/iothub/providers/device_stream.py
@@ -24,7 +24,7 @@ class DeviceStreamProvider(IoTHubProvider):
         super(DeviceStreamProvider, self).__init__(cmd, hub_name, rg)
         self.cli = EmbeddedCLI(cli_ctx=self.cmd.cli_ctx)
 
-    def show(self) -> dict:
+    def show(self) -> Optional[dict]:
         result = self.cli.invoke(
             f"resource show -n {self.target['name']} -g {self.target['resourcegroup']} "
             f"--api-version {DEVICE_STREAMS_API_VERSION} --resource-type {HUB_PROVIDER}",

--- a/azext_iot/iothub/providers/device_stream.py
+++ b/azext_iot/iothub/providers/device_stream.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Optional
+from knack.log import get_logger
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.iothub.providers.base import IoTHubProvider
+from azure.cli.core.azclierror import InvalidArgumentValueError
+from azext_iot.iothub.common import HUB_PROVIDER
+
+logger = get_logger(__name__)
+DEVICE_STREAMS_API_VERSION = "2023-06-30-preview"
+
+
+class DeviceStreamProvider(IoTHubProvider):
+    def __init__(
+        self,
+        cmd,
+        hub_name: str,
+        rg: Optional[str] = None,
+    ):
+        super(DeviceStreamProvider, self).__init__(cmd, hub_name, rg)
+        self.cli = EmbeddedCLI(cli_ctx=self.cmd.cli_ctx)
+
+    def show(self) -> dict:
+        result = self.cli.invoke(
+            f"resource show -n {self.target["name"]} -g {self.target["resourcegroup"]} "
+            f"--api-version {DEVICE_STREAMS_API_VERSION} --resource-type {HUB_PROVIDER}",
+            capture_stderr=True
+        ).as_json()
+        device_streams = result.get("properties", {}).get("deviceStreams")
+        if not device_streams:
+            raise InvalidArgumentValueError("Device streams are not enabled for this IoT Hub.")
+        return device_streams

--- a/azext_iot/iothub/providers/device_stream.py
+++ b/azext_iot/iothub/providers/device_stream.py
@@ -27,7 +27,7 @@ class DeviceStreamProvider(IoTHubProvider):
 
     def show(self) -> dict:
         result = self.cli.invoke(
-            f"resource show -n {self.target["name"]} -g {self.target["resourcegroup"]} "
+            f"resource show -n {self.target['name']} -g {self.target['resourcegroup']} "
             f"--api-version {DEVICE_STREAMS_API_VERSION} --resource-type {HUB_PROVIDER}",
             capture_stderr=True
         ).as_json()

--- a/azext_iot/tests/iothub/device_stream/__init__.py
+++ b/azext_iot/tests/iothub/device_stream/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
@@ -18,10 +18,6 @@ def test_device_stream(provisioned_only_iot_hubs_module):
     hub_name = provisioned_only_iot_hubs_module[0]["name"]
     rg = provisioned_only_iot_hubs_module[0]["rg"]
 
-    if not device_stream:
-        # just in case
-        pytest.skip("Device streams are not enabled for this IoT Hub.")
-
     result = cli.invoke(
         f"iot hub devicestream show -n {hub_name} -g {rg}",
         capture_stderr=True

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
@@ -27,9 +27,7 @@ def provisioned_preview_hub():
 
 @pytest.mark.hub_infrastructure(location="northeurope")
 def test_device_stream(provisioned_preview_hub):
-    device_stream = provisioned_preview_hub["properties"].get(
-        "deviceStreams", None
-    )
+    device_stream = provisioned_preview_hub["properties"]["deviceStreams"]
     hub_name = provisioned_preview_hub["name"]
 
     result = cli.invoke(

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+from azext_iot.common.embedded_cli import EmbeddedCLI
+
+cli = EmbeddedCLI()
+
+
+@pytest.mark.hub_infrastructure(location="northeurope")
+def test_device_stream(provisioned_only_iot_hubs_module):
+    device_stream = provisioned_only_iot_hubs_module[0]["hub"]["properties"].get(
+        "deviceStreams", None
+    )
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
+    rg = provisioned_only_iot_hubs_module[0]["rg"]
+
+    if not device_stream:
+        # just in case
+        pytest.skip("Device streams are not enabled for this IoT Hub.")
+
+    result = cli.invoke(
+        f"iot hub devicestream show -n {hub_name} -g {rg}",
+        capture_stderr=True
+    ).as_json()
+    assert result == device_stream

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_int.py
@@ -6,20 +6,34 @@
 
 import pytest
 from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.tests.iothub.conftest import generate_hub_id, RG
 
 cli = EmbeddedCLI()
+DEVICE_STREAMS_API_VERSION = "2023-06-30-preview"
+
+
+@pytest.fixture()
+def provisioned_preview_hub():
+    name = generate_hub_id()
+    hub_resource = cli.invoke(
+        f"resource create --name {name} -g {RG} --properties "
+        "'{\"sku\": {\"capacity\": 1, \"name\": \"S1\", \"tier\": \"Standard\"}, \"location\": \"northeurope\"}' "
+        f"--resource-type Microsoft.Devices/IotHubs --is-full-object --api-version \"{DEVICE_STREAMS_API_VERSION}\"",
+        capture_stderr=True
+    )
+    yield hub_resource.as_json()
+    cli.invoke(f"iot hub delete -n {name} -g {RG} --no-wait", capture_stderr=True)
 
 
 @pytest.mark.hub_infrastructure(location="northeurope")
-def test_device_stream(provisioned_only_iot_hubs_module):
-    device_stream = provisioned_only_iot_hubs_module[0]["hub"]["properties"].get(
+def test_device_stream(provisioned_preview_hub):
+    device_stream = provisioned_preview_hub["properties"].get(
         "deviceStreams", None
     )
-    hub_name = provisioned_only_iot_hubs_module[0]["name"]
-    rg = provisioned_only_iot_hubs_module[0]["rg"]
+    hub_name = provisioned_preview_hub["name"]
 
     result = cli.invoke(
-        f"iot hub devicestream show -n {hub_name} -g {rg}",
+        f"iot hub devicestream show -n {hub_name} -g {RG}",
         capture_stderr=True
     ).as_json()
     assert result == device_stream

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_unit.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_unit.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azure.cli.core.azclierror import InvalidArgumentValueError
+from azext_iot.iothub.commands_device_stream import show_device_stream
+from azext_iot.tests.generators import generate_names
+
+cli = EmbeddedCLI()
+
+
+@pytest.mark.parametrize("has_device_streams", [True, False])
+def test_device_stream(fixture_cmd, fixture_ghcs, mocker, has_device_streams):
+    # patch embedded CLI to return a mock IoT Hub body
+    hub_body = {"properties": {}}
+    if has_device_streams:
+        hub_body["properties"]["deviceStreams"] = {
+            "streamingEndpoints": ["https://db-001.northeurope-001.streams.azure-devices.net"]
+        }
+    patched_cli = mocker.patch(
+        "azext_iot.iothub.providers.device_stream.EmbeddedCLI",
+        autospec=True
+    )
+    patched_cli.return_value.invoke.return_value.as_json.return_value = hub_body
+
+    if not has_device_streams:
+        with pytest.raises(InvalidArgumentValueError) as e:
+            show_device_stream(
+                cmd=fixture_cmd,
+                hub_name=generate_names(),
+                resource_group_name=generate_names()
+            )
+        assert "Device streams are not enabled for this IoT Hub." in str(e.value)
+        return
+
+    result = show_device_stream(
+        cmd=fixture_cmd,
+        hub_name=generate_names(),
+        resource_group_name=generate_names()
+    )
+    assert result == hub_body["properties"]["deviceStreams"]

--- a/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_unit.py
+++ b/azext_iot/tests/iothub/device_stream/test_iothub_device_stream_unit.py
@@ -6,7 +6,6 @@
 
 import pytest
 from azext_iot.common.embedded_cli import EmbeddedCLI
-from azure.cli.core.azclierror import InvalidArgumentValueError
 from azext_iot.iothub.commands_device_stream import show_device_stream
 from azext_iot.tests.generators import generate_names
 
@@ -27,19 +26,18 @@ def test_device_stream(fixture_cmd, fixture_ghcs, mocker, has_device_streams):
     )
     patched_cli.return_value.invoke.return_value.as_json.return_value = hub_body
 
-    if not has_device_streams:
-        with pytest.raises(InvalidArgumentValueError) as e:
-            show_device_stream(
-                cmd=fixture_cmd,
-                hub_name=generate_names(),
-                resource_group_name=generate_names()
-            )
-        assert "Device streams are not enabled for this IoT Hub." in str(e.value)
-        return
+    patched_logger = mocker.patch(
+        "azext_iot.iothub.providers.device_stream.logger.warning"
+    )
 
     result = show_device_stream(
         cmd=fixture_cmd,
         hub_name=generate_names(),
         resource_group_name=generate_names()
     )
-    assert result == hub_body["properties"]["deviceStreams"]
+    if has_device_streams:
+        assert result == hub_body["properties"]["deviceStreams"]
+    else:
+        patched_logger.assert_called_once_with("Device streams are not enabled for this IoT Hub.")
+        # if device streams are not enabled, the result should be None
+        assert result is None


### PR DESCRIPTION
Moving the devicestream command group to extension so we don't need to worry about mixing api versions in azure-cli

Note that to get this to pop up - you will need to have a version of the azure cli that does not have this command

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
