### PR TITLE
fix: fix dps enrollment (and group) update commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 **General updates**
 
 * `az iot hub monitor-events` now supports free SKU IoT Hubs when control plane access is available.
+* Moved `az iot hub devicestream` commands into the extension.
+* Fixed a bug in `az iot dps enrollment update` and `az iot dps enrollment-group update` where the `--initial-twin-tags` and `--initial-twin-properties` parameters were not being set correctly.
 
 
 0.26.0

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -911,17 +911,22 @@ def _get_initial_twin(initial_twin_tags=None, initial_twin_properties=None):
 def _get_updated_inital_twin(
     enrollment_record, initial_twin_tags=None, initial_twin_properties=None
 ):
-    if initial_twin_properties != "" and not initial_twin_tags:
-        if hasattr(enrollment_record, "initial_twin"):
-            if hasattr(enrollment_record.initial_twin, "tags"):
-                initial_twin_tags = enrollment_record.initial_twin.tags
-    if initial_twin_properties != "" and not initial_twin_properties:
-        if hasattr(enrollment_record, "initial_twin"):
-            if hasattr(enrollment_record.initial_twin, "properties"):
-                if hasattr(enrollment_record.initial_twin.properties, "desired"):
-                    initial_twin_properties = (
-                        enrollment_record.initial_twin.properties.desired
-                    )
+    if (
+        initial_twin_tags != "" and not initial_twin_tags
+        and hasattr(enrollment_record, "initial_twin")
+        and hasattr(enrollment_record.initial_twin, "tags")
+    ):
+        initial_twin_tags = enrollment_record.initial_twin.tags.as_dict()
+
+    if (
+        initial_twin_properties != "" and not initial_twin_properties
+        and hasattr(enrollment_record, "initial_twin")
+        and hasattr(enrollment_record.initial_twin, "properties")
+        and hasattr(enrollment_record.initial_twin.properties, "desired")
+    ):
+        initial_twin_properties = (
+            enrollment_record.initial_twin.properties.desired.as_dict()
+        )
     return _get_initial_twin(initial_twin_tags, initial_twin_properties)
 
 

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -161,6 +161,7 @@ def iot_dps_device_enrollment_create(
         resolver = SdkResolver(target=target)
         sdk = resolver.get_sdk(SdkType.dps_sdk)
 
+        attestation = None
         if attestation_type == AttestationType.tpm.value:
             if not endorsement_key:
                 raise RequiredArgumentMissingError("Endorsement key [--endorsement-key] is required")
@@ -464,6 +465,7 @@ def iot_dps_device_enrollment_group_create(
         resolver = SdkResolver(target=target)
         sdk = resolver.get_sdk(SdkType.dps_sdk)
 
+        attestation = None
         if not certificate_path and not secondary_certificate_path:
             if not root_ca_name and not secondary_root_ca_name:
                 attestation = AttestationMechanism(
@@ -911,15 +913,18 @@ def _get_initial_twin(initial_twin_tags=None, initial_twin_properties=None):
 def _get_updated_inital_twin(
     enrollment_record, initial_twin_tags=None, initial_twin_properties=None
 ):
+    # in both cases, we want to grab the original tags and properties
+    # if the parameters are not provided. The user should be able to
+    # empty out tags/properties by passing in an empty string.
     if (
-        initial_twin_tags != "" and not initial_twin_tags
+        initial_twin_tags is None
         and hasattr(enrollment_record, "initial_twin")
         and hasattr(enrollment_record.initial_twin, "tags")
     ):
         initial_twin_tags = enrollment_record.initial_twin.tags.as_dict()
 
     if (
-        initial_twin_properties != "" and not initial_twin_properties
+        initial_twin_properties is None
         and hasattr(enrollment_record, "initial_twin")
         and hasattr(enrollment_record.initial_twin, "properties")
         and hasattr(enrollment_record.initial_twin.properties, "desired")

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
@@ -101,8 +101,8 @@ def test_dps_enrollment_tpm_lifecycle(provisioned_iot_dps_module):
         assert update_enrollment["attestation"]["type"] == attestation_type
         assert update_enrollment["deviceId"] == device_id
         assert update_enrollment["iotHubs"] == [hub_hostname]
-        assert update_enrollment["initialTwin"]["tags"]
-        assert update_enrollment["initialTwin"]["properties"]["desired"]
+        assert update_enrollment["initialTwin"]["tags"] == generic_dict
+        assert update_enrollment["initialTwin"]["properties"]["desired"] == generic_dict
         assert update_enrollment["optionalDeviceInformation"]
         assert update_enrollment["provisioningStatus"] == EntityStatusType.disabled.value
         assert update_enrollment["registrationId"] == enrollment_id
@@ -197,8 +197,8 @@ def test_dps_enrollment_x509_lifecycle(provisioned_iot_dps_module):
         assert update_enrollment["attestation"]["x509"]["clientCertificates"]["primary"] is None
         assert update_enrollment["deviceId"] == device_id
         assert update_enrollment["iotHubs"] == [hub_hostname]
-        assert update_enrollment["initialTwin"]["tags"]
-        assert update_enrollment["initialTwin"]["properties"]["desired"]
+        assert update_enrollment["initialTwin"]["tags"] == generic_dict
+        assert update_enrollment["initialTwin"]["properties"]["desired"] == generic_dict
         assert update_enrollment["optionalDeviceInformation"] == generic_dict
         assert update_enrollment["provisioningStatus"] == EntityStatusType.disabled.value
         assert update_enrollment["registrationId"] == enrollment_id
@@ -299,8 +299,8 @@ def test_dps_enrollment_symmetrickey_lifecycle(provisioned_iot_dps_module):
         assert update_enrollment["customAllocationDefinition"]["apiVersion"] == API_VERSION
         assert update_enrollment["deviceId"] == device_id
         assert update_enrollment["iotHubs"] == [hub_hostname]
-        assert update_enrollment["initialTwin"]["tags"]
-        assert update_enrollment["initialTwin"]["properties"]["desired"]
+        assert update_enrollment["initialTwin"]["tags"] == generic_dict
+        assert update_enrollment["initialTwin"]["properties"]["desired"] == generic_dict
         assert update_enrollment["optionalDeviceInformation"] == generic_dict
         assert update_enrollment["provisioningStatus"] == EntityStatusType.disabled.value
         assert update_enrollment["registrationId"] == enrollment_id

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -305,6 +305,7 @@ def generate_enrollment_show(**kvp):
                            'subjectName': 'test',
                            'version': '3'}}, 'secondary': None},
                          }, 'tpm': None, 'type': 'x509'},
+               'initialTwin': {'tags': {}, 'properties': {'desired': {}}},
                'registrationId': enrollment_id, 'etag': etag,
                'provisioningStatus': 'disabled', 'iotHubHostName': 'myHub',
                'deviceId': 'myDevice'}
@@ -423,6 +424,8 @@ class TestEnrollmentUpdate():
         assert get_request.method == 'GET'
         assert "{}/enrollments/{}?".format(mock_dps_target['entity'], enrollment_id) in get_request.url
 
+        initial_enrollment = json.loads(serviceclient.calls[0].response.content)
+
         update_request = serviceclient.calls[1].request
         url = update_request.url
 
@@ -448,8 +451,12 @@ class TestEnrollmentUpdate():
             assert body['provisioningStatus'] == req['provisioning_status']
         if req['initial_twin_properties']:
             assert body['initialTwin']['properties']['desired'] == req['initial_twin_properties']
+        else:
+            assert body['initialTwin']['properties']['desired'] == initial_enrollment['initialTwin']['properties']['desired']
         if req['initial_twin_tags']:
             assert body['initialTwin']['tags'] == req['initial_twin_tags']
+        else:
+            assert body['initialTwin']['tags'] == initial_enrollment['initialTwin']['tags']
         if req['device_id']:
             assert body['deviceId'] == req['device_id']
         if req['reprovision_policy'] == 'reprovisionandmigratedata':

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
@@ -249,8 +249,8 @@ def test_dps_enrollment_group_symmetrickey_lifecycle(provisioned_iot_dps_module)
         assert enrollment_update["customAllocationDefinition"]["apiVersion"] == API_VERSION
         assert enrollment_update["enrollmentGroupId"] == enrollment_id
         assert enrollment_update["iotHubs"] == [hub_hostname]
-        assert enrollment_update["initialTwin"]["tags"]
-        assert enrollment_update["initialTwin"]["properties"]["desired"]
+        assert enrollment_update["initialTwin"]["tags"] == generic_dict
+        assert enrollment_update["initialTwin"]["properties"]["desired"] == generic_dict
         assert enrollment_update["provisioningStatus"] == EntityStatusType.disabled.value
 
         # Use service generated keys


### PR DESCRIPTION
Fixing issue https://github.com/Azure/azure-cli/issues/31673

When the enrollment record has an additional property already (aka anything not version, count, metadata), it is moved into it's own dictionary called additional properties
<img width="874" height="45" alt="image" src="https://github.com/user-attachments/assets/2f9927c5-3a99-4e42-b867-97887aaeb018" />

So in the normal update, this gets nested as so:
<img width="1119" height="47" alt="image" src="https://github.com/user-attachments/assets/0365e553-5925-4b0c-acbd-0050b3c6e08f" />

We use as_dict() to unwrap this additional property (it becomes the same level as version, count, metadata)
<img width="622" height="46" alt="image" src="https://github.com/user-attachments/assets/3927684a-0b26-4bc8-b91b-85b9187f0994" />

Also fixed the tests to make sure this is tested (we may have altered these tests before to be more flexible)

This issue was noted to be in initial twin tags too (also some if logic was a bit off) + enrollment groups

Tests do be passing
<img width="1250" height="178" alt="image" src="https://github.com/user-attachments/assets/cc04c854-cde9-4f75-92ae-c019f80f8aec" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
