### PR TITLE
feat: add Python 3.13 support

### DIFF
--- a/.azure-devops/integration_tests.yml
+++ b/.azure-devops/integration_tests.yml
@@ -16,12 +16,13 @@ parameters:
   - name: pythonVersion
     displayName: "Python version for building wheels, KPIs"
     type: string
-    default: "3.12"
+    default: "3.13"
     values:
       - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
+      - "3.13"
   - name: pythonVersionsTestingMatrix
     type: object
     default: >
@@ -41,6 +42,10 @@ parameters:
         Python312:
         {
           python: '3.12'
+        },
+        Python313:
+        {
+          python: '3.13'
         }
       }
   - name: stageForPublish

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -63,6 +63,8 @@ jobs:
           python.version: "3.11"
         Python312:
           python.version: "3.12"
+        Python313:
+          python.version: "3.13"
 
     steps:
       - bash: sudo rm -R -f /usr/local/lib/azureExtensionDir

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -25,12 +25,13 @@ parameters:
   - name: pythonVersion
     displayName: "Python version for building wheel, KPIs"
     type: string
-    default: "3.12"
+    default: "3.13"
     values:
       - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
+      - "3.13"
   - name: pythonVersionsTestingMatrix
     type: object
     default: >
@@ -39,9 +40,9 @@ parameters:
         {
           python: '3.9'
         },
-        Python312:
+        Python313:
         {
-          python: '3.12'
+          python: '3.13'
         }
       }
   - name: "testCentral"

--- a/.azure-devops/templates/run-tests-parallel.yml
+++ b/.azure-devops/templates/run-tests-parallel.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: pythonVersion
     type: string
-    default: "3.12"
+    default: "3.13"
   - name: runUnitTests
     type: boolean
     default: false

--- a/.azure-devops/templates/run-tests-parallel.yml
+++ b/.azure-devops/templates/run-tests-parallel.yml
@@ -29,7 +29,7 @@ parameters:
     default: 6
   - name: num_reruns
     type: number
-    default: 0  # TODO: set to 2 once we have stable tests
+    default: 2
   - name: reruns_delay
     type: number
     default: 60

--- a/.azure-devops/templates/run-tests-parallel.yml
+++ b/.azure-devops/templates/run-tests-parallel.yml
@@ -29,7 +29,7 @@ parameters:
     default: 6
   - name: num_reruns
     type: number
-    default: 2
+    default: 0  # TODO: set to 2 once we have stable tests
   - name: reruns_delay
     type: number
     default: 60

--- a/.azure-devops/templates/setup-dev-test-env.yml
+++ b/.azure-devops/templates/setup-dev-test-env.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: pythonVersion
     type: string
-    default: "3.12"
+    default: "3.13"
   - name: azureCLIVersion
     type: string
     default: "released"

--- a/.azure-devops/templates/setup-python.yml
+++ b/.azure-devops/templates/setup-python.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: pythonVersion
     type: string
-    default: "3.12"
+    default: "3.13"
 
 steps:
   - task: UsePythonVersion@0

--- a/.azure-devops/tox.yml
+++ b/.azure-devops/tox.yml
@@ -18,6 +18,10 @@ parameters:
     displayName: "Test Python 3.12"
     type: boolean
     default: true
+  - name: python313
+    displayName: "Test Python 3.13"
+    type: boolean
+    default: true
   - name: azdev
     displayName: "Test development CLI"
     type: boolean
@@ -38,7 +42,7 @@ jobs:
     strategy:
       matrix:
         "linters":
-          python: "3.12"
+          python: "3.13"
           toxEnvStr: "lint"
           desc: "Flake8, Pylint"
         ${{ if parameters.python39 }}:
@@ -95,6 +99,17 @@ jobs:
               python: "3.12"
               toxEnvStr: "py3.12-azdev-unit"
               desc: "Python 3.12 tests, dev CLI"
+        ${{ if parameters.python313 }}:
+          ${{ if parameters.azcur }}:
+            "python 3.13 tests, current CLI":
+              python: "3.13"
+              toxEnvStr: "py3.13-azcur-unit"
+              desc: "Python 3.13 tests, current CLI"
+          ${{ if parameters.azdev }}:
+            "python 3.13 tests, dev CLI":
+              python: "3.13"
+              toxEnvStr: "py3.13-azdev-unit"
+              desc: "Python 3.13 tests, dev CLI"
     steps:
       - template: templates/setup-python.yml
         parameters:

--- a/.github/workflows/azdev_linter.yml
+++ b/.github/workflows/azdev_linter.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Setup python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       # Lint
       - name: azdev linter

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Build Wheel
         run: |
           pip install -r dev_requirements

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - uses: actions/checkout@v4
       - name: "Az CLI login"

--- a/.github/workflows/stage_release.yml
+++ b/.github/workflows/stage_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-            python-version: "3.12"
+            python-version: "3.13"
       - name: Install and determine version
         run: |
           wheel=$(find ./release/*.whl)

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,6 +30,7 @@ jobs:
           - windows-2022
           - macos-13
         py:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -47,7 +48,7 @@ jobs:
       - name: Run test suite
         run: tox r --skip-pkg-install
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.py == '3.12' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.py == '3.13' }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/trigger_ado_int_tests.yml
+++ b/.github/workflows/trigger_ado_int_tests.yml
@@ -31,7 +31,7 @@ on:
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
               Python312: { python: '3.12' },
-              Python312: { python: '3.13' }
+              Python313: { python: '3.13' }
           }"
     secrets:
       ADO_PAT:
@@ -68,7 +68,7 @@ on:
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
               Python312: { python: '3.12' },
-              Python312: { python: '3.13' }
+              Python313: { python: '3.13' }
           }"
 env:
   DEFAULT_TITLE: "Azure DevOps Pipeline"

--- a/.github/workflows/trigger_ado_int_tests.yml
+++ b/.github/workflows/trigger_ado_int_tests.yml
@@ -30,7 +30,8 @@ on:
               Python39: { python: '3.9' },
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
-              Python312: { python: '3.12' }
+              Python312: { python: '3.12' },
+              Python312: { python: '3.13' }
           }"
     secrets:
       ADO_PAT:
@@ -66,7 +67,8 @@ on:
               Python39: { python: '3.9' },
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
-              Python312: { python: '3.12' }
+              Python312: { python: '3.12' },
+              Python312: { python: '3.13' }
           }"
 env:
   DEFAULT_TITLE: "Azure DevOps Pipeline"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ===============
 
-0.26.1
+0.27.0
 +++++++++++++++
 
 **General updates**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ The **Azure IoT extension for Azure CLI** aims to accelerate the development, ma
 
 - Azure CLI `2.77.0` requires an `azure-iot` extension update to `0.26.1` or later for IoT Hub commands to work properly. Updating the extension can be done with `az extension update --name azure-iot`.
 
-- Starting with version `0.26.1` of the IoT extension, you will need an Azure CLI core version of `2.54.0` or higher.
+- Azure CLI `2.24.0` requires an `azure-iot` extension update to `0.10.11` or later for IoT Hub commands to work properly. However **we recommend** at least `azure-iot` `0.10.14`. Updating the extension can be done with `az extension update --name azure-iot`.
+
+> Note: A common error that arises when using an older `azure-iot` with Azure CLI `2.24.0+` shows as follows: `AttributeError: 'IotHubResourceOperations' object has no attribute 'config'`.
+- Starting with version `0.10.13` of the IoT extension, you will need an Azure CLI core version of `2.17.1` or higher. IoT extension version `0.10.11` remains on the extension index to support environments that cannot upgrade core CLI versions.
 
 - The legacy IoT extension Id `azure-cli-iot-ext` is deprecated in favor of the new modern Id `azure-iot`. `azure-iot` is a superset of `azure-cli-iot-ext` and any new features or fixes will apply to `azure-iot` only. Also the legacy and modern IoT extension should **never** co-exist in the same CLI environment.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ The **Azure IoT extension for Azure CLI** aims to accelerate the development, ma
 
 - ❗ When upgrading your Azure CLI core version, for the best experience and to avoid breaking changes, we recommend updating your `azure-iot` extension to the [latest available](https://github.com/Azure/azure-iot-cli-extension/releases).
 
-- Azure CLI `2.77.0` requires an `azure-iot` extension update to `0.26.1` or later for IoT Hub commands to work properly. Updating the extension can be done with `az extension update --name azure-iot`.
+- Azure CLI `2.77.0` requires an `azure-iot` extension update to `0.27.0` or later for IoT Hub commands to work properly. Updating the extension can be done with `az extension update --name azure-iot`.
 
 - Azure CLI `2.24.0` requires an `azure-iot` extension update to `0.10.11` or later for IoT Hub commands to work properly. However **we recommend** at least `azure-iot` `0.10.14`. Updating the extension can be done with `az extension update --name azure-iot`.
 
 > Note: A common error that arises when using an older `azure-iot` with Azure CLI `2.24.0+` shows as follows: `AttributeError: 'IotHubResourceOperations' object has no attribute 'config'`.
+
 - Starting with version `0.10.13` of the IoT extension, you will need an Azure CLI core version of `2.17.1` or higher. IoT extension version `0.10.11` remains on the extension index to support environments that cannot upgrade core CLI versions.
 
 - The legacy IoT extension Id `azure-cli-iot-ext` is deprecated in favor of the new modern Id `azure-iot`. `azure-iot` is a superset of `azure-cli-iot-ext` and any new features or fixes will apply to `azure-iot` only. Also the legacy and modern IoT extension should **never** co-exist in the same CLI environment.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ The **Azure IoT extension for Azure CLI** aims to accelerate the development, ma
 
 - ❗ When upgrading your Azure CLI core version, for the best experience and to avoid breaking changes, we recommend updating your `azure-iot` extension to the [latest available](https://github.com/Azure/azure-iot-cli-extension/releases).
 
-- Azure CLI `2.24.0` requires an `azure-iot` extension update to `0.10.11` or later for IoT Hub commands to work properly. However **we recommend** at least `azure-iot` `0.10.14`. Updating the extension can be done with `az extension update --name azure-iot`.
+- Azure CLI `2.77.0` requires an `azure-iot` extension update to `0.26.1` or later for IoT Hub commands to work properly. Updating the extension can be done with `az extension update --name azure-iot`.
 
-> Note: A common error that arises when using an older `azure-iot` with Azure CLI `2.24.0+` shows as follows: `AttributeError: 'IotHubResourceOperations' object has no attribute 'config'`.
-
-- Starting with version `0.10.13` of the IoT extension, you will need an Azure CLI core version of `2.17.1` or higher. IoT extension version `0.10.11` remains on the extension index to support environments that cannot upgrade core CLI versions.
+- Starting with version `0.26.1` of the IoT extension, you will need an Azure CLI core version of `2.54.0` or higher.
 
 - The legacy IoT extension Id `azure-cli-iot-ext` is deprecated in favor of the new modern Id `azure-iot`. `azure-iot` is a superset of `azure-cli-iot-ext` and any new features or fixes will apply to `azure-iot` only. Also the legacy and modern IoT extension should **never** co-exist in the same CLI environment.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ The **Azure IoT extension for Azure CLI** aims to accelerate the development, ma
 
 - ❗ When upgrading your Azure CLI core version, for the best experience and to avoid breaking changes, we recommend updating your `azure-iot` extension to the [latest available](https://github.com/Azure/azure-iot-cli-extension/releases).
 
-- Azure CLI `2.77.0` requires an `azure-iot` extension update to `0.27.0` or later for IoT Hub commands to work properly. Updating the extension can be done with `az extension update --name azure-iot`.
-
 - Azure CLI `2.24.0` requires an `azure-iot` extension update to `0.10.11` or later for IoT Hub commands to work properly. However **we recommend** at least `azure-iot` `0.10.14`. Updating the extension can be done with `az extension update --name azure-iot`.
 
 > Note: A common error that arises when using an older `azure-iot` with Azure CLI `2.24.0+` shows as follows: `AttributeError: 'IotHubResourceOperations' object has no attribute 'config'`.

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.26.1"
+VERSION = "0.27.0"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -93,7 +93,6 @@ def load_iothub_commands(self, _):
             "message_endpoint_create_cosmos_db_container",
             transform=EndpointUpdateResultTransform(self.cli_ctx),
             resource_type=ResourceType.MGMT_IOTHUB,
-            min_api="2022-04-30-preview"
         )
         cmd_group.command(
             "storage-container",
@@ -125,7 +124,6 @@ def load_iothub_commands(self, _):
             "message_endpoint_update_cosmos_db_container",
             transform=EndpointUpdateResultTransform(self.cli_ctx),
             resource_type=ResourceType.MGMT_IOTHUB,
-            min_api="2022-04-30-preview"
         )
         cmd_group.command(
             "storage-container",

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -927,7 +927,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         )
 
         # wait for API to catch up before fetching twin
-        sleep(10)
+        sleep(15)
 
         # get device twin
         result = self.cmd(
@@ -938,6 +938,8 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
 
         assert result is not None
         for key in test_twin_props:
+            assert key in result["properties"]["desired"]
+            assert key in result["properties"]["reported"]
             assert result["properties"]["reported"][key] == result["properties"]["desired"][key]
 
         token.set()

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -927,7 +927,7 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         )
 
         # wait for API to catch up before fetching twin
-        sleep(15)
+        sleep(10)
 
         # get device twin
         result = self.cmd(

--- a/azext_iot/tests/iothub/modules/test_iothub_module_twin_int.py
+++ b/azext_iot/tests/iothub/modules/test_iothub_module_twin_int.py
@@ -7,7 +7,6 @@
 import json
 import os
 from pathlib import Path
-from time import sleep
 
 from azext_iot.common.utility import read_file_content
 from azext_iot.tests.iothub import IoTLiveScenarioTest
@@ -20,9 +19,6 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 class TestIoTHubModuleTwin(IoTLiveScenarioTest):
     def __init__(self, test_case):
         super(TestIoTHubModuleTwin, self).__init__(test_case)
-
-        # Ensure role assignment is complete
-        sleep(30)
 
     def test_iothub_module_twin(self):
         for auth_phase in DATAPLANE_AUTH_TYPES:

--- a/azext_iot/tests/iothub/modules/test_iothub_module_twin_int.py
+++ b/azext_iot/tests/iothub/modules/test_iothub_module_twin_int.py
@@ -7,6 +7,7 @@
 import json
 import os
 from pathlib import Path
+from time import sleep
 
 from azext_iot.common.utility import read_file_content
 from azext_iot.tests.iothub import IoTLiveScenarioTest
@@ -19,6 +20,9 @@ CWD = os.path.dirname(os.path.abspath(__file__))
 class TestIoTHubModuleTwin(IoTLiveScenarioTest):
     def __init__(self, test_case):
         super(TestIoTHubModuleTwin, self).__init__(test_case)
+
+        # Ensure role assignment is complete
+        sleep(30)
 
     def test_iothub_module_twin(self):
         for auth_phase in DATAPLANE_AUTH_TYPES:

--- a/docs/tox-testing.md
+++ b/docs/tox-testing.md
@@ -9,6 +9,7 @@ Currently, our testing matrix is broken up into the following groups:
     - 3.10
     - 3.11
     - 3.12
+    - 3.13
 - Azure CLI Core versions to test extension against:
     - `azmin` installs the minimum supported CLI version (currently `2.46.0`)
     - `azcur` installs the latest released CLI version from PyPi
@@ -47,7 +48,7 @@ The [current tox config](../tox.ini) supports local test configurations for the 
 - Various Python and AZ CLI Versions
   - The tox environment string (passed to `-e`) will be parsed as such:
 
-        py{thon,3.9...3.12}-az{min,cur,dev}-{int,unit}
+        py{thon,3.9...3.13}-az{min,cur,dev}-{int,unit}
 
     |Python version | CLI version   | Test type     |
     |---------------|---------------|---------------|
@@ -56,6 +57,7 @@ The [current tox config](../tox.ini) supports local test configurations for the 
     |"py3.10"|||
     |"py3.11"|||
     |"py3.12"|||
+    |"py3.13"|||
 
 **If you choose not to select a specific python version (which is also the current default), you can use `python` instead, to invoke whichever interpreter version `python` invokes in your environment.**
 
@@ -70,11 +72,11 @@ The [current tox config](../tox.ini) supports local test configurations for the 
         - Current python interpreter, released azure CLI install, unit tests
     tox -e "py3.9-azmin-unit"
         - Python 3.9, min supported CLI, unit tests
-    tox -e "py{3.9,3.12}-az{min,cur}-unit"
+    tox -e "py{3.9,3.13}-az{min,cur}-unit"
         - Python 3.9, min supported CLI core, unit tests
         - Python 3.9, currently released CLI core, unit tests
-        - Python 3.12, max supported CLI core, unit tests
-        - Python 3.12, currently released CLI core, unit tests
+        - Python 3.13, max supported CLI core, unit tests
+        - Python 3.13, currently released CLI core, unit tests
 
 
 In order to list all recognized environments, you can type `tox -av`, which will display them all in a list:

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ DEPENDENCIES = [
     "tomli-w~=1.0",
     "tqdm~=4.62",
     "treelib~=1.6",
-    "packaging"
+    "packaging>=23.2"
 ]
 EXTRAS = {"uamqp": ["uamqp>=1.2,<=1.6.8"]}
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ setenv =
 passenv =
     azext_*
 deps =
+    # for python 3.13 - we need a dev build of pymsalruntime to install azure-cli
+    py313: https://github.com/AzureAD/microsoft-authentication-library-for-python/archive/refs/heads/dev.zip
     # base deps
     {[base]deps}
     # azure-cli deps

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ description =
     py39: Python 3.9
     py310: Python 3.10
     py311: Python 3.11
-    py311: Python 3.12
+    py312: Python 3.12
+    py313: Python 3.13
     azmin: min azure-cli
     azcur: current azure-cli
     azdev: dev azure-cli
@@ -45,7 +46,7 @@ commands =
     flake8 azext_iot/ --statistics --config=setup.cfg
     pylint azext_iot/ --rcfile=.pylintrc
 
-[testenv:py{thon,38,39,310,311,312}-az{min,cur,dev}-unit]
+[testenv:py{thon,38,39,310,311,312,313}-az{min,cur,dev}-unit]
 skip_install = True
 description =
     {[base]description}
@@ -55,8 +56,6 @@ setenv =
 passenv =
     azext_*
 deps =
-    # for python 3.13 - we need a dev build of pymsalruntime to install azure-cli
-    py313: https://github.com/AzureAD/microsoft-authentication-library-for-python/archive/refs/heads/dev.zip
     # base deps
     {[base]deps}
     # azure-cli deps


### PR DESCRIPTION
Decided to do test fixing later since the same tests seem to break as in other python versions.

No need to bump the version of the azure-cli, the min version already only supports azure-mgmt-iothub 3.0.0, so we can remove the min_api safely.

If a customer has issues with their iot cli extension not working properly (they upgraded core), we will need to tell them to upgrade the extension to the latest release (see the readme changes).


I have thought about updating the ensure uamqp code to allow the py3.13 folks to use 1.6.11 but it does create a weird gap in supported versions for uamqp. 1.6.6 works well enough with py3.13.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
