### PR TITLE
chore: temporarily disable IP filters for IoT Hub State tests

### DIFF
--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -165,6 +165,7 @@ def get_agent_public_ip():
     """
     Poke the Wikipedia website to get Public IP.
     """
+    # TODO: use a different website since Wikipedia changed it's headers
     import requests
     return requests.head("https://www.wikipedia.org").headers["X-Client-IP"]
 

--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -15,7 +15,7 @@ from knack.log import get_logger
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.tests.generators import generate_generic_id
 from azext_iot.common.certops import create_self_signed_certificate
-from azext_iot.tests.helpers import assign_role_assignment, clean_up_iothub_device_config, get_closest_marker, get_agent_public_ip
+from azext_iot.tests.helpers import assign_role_assignment, clean_up_iothub_device_config, get_closest_marker
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
 
 logger = get_logger(__name__)
@@ -215,18 +215,18 @@ def setup_hub_controlplane_states(
     if os.path.isfile(cert_file):
         os.remove(cert_file)
 
-    # add ip filter rule - make sure to add public ip address so dataplane isn't screwed up
-    public_ip = get_agent_public_ip()
-    cli.invoke(
-        f"resource update --name {hub_name} -g {hub_rg} --resource-type "
-        "\"Microsoft.Devices/IotHubs\" --set properties.networkRuleSets='{}'"
-    )
-    cli.invoke(
-        f"resource update --name {hub_name} -g {hub_rg} --resource-type Microsoft.Devices/IotHubs "
-        "--add properties.networkRuleSets.ipRules '{\"action\":\"Allow\",\"filterName\":\"Trusted\",\"ipMask\":\""
-        f"{public_ip}"
-        "\"}'"
-    )
+    # # add ip filter rule - make sure to add public ip address so dataplane isn't screwed up
+    # public_ip = get_agent_public_ip()
+    # cli.invoke(
+    #     f"resource update --name {hub_name} -g {hub_rg} --resource-type "
+    #     "\"Microsoft.Devices/IotHubs\" --set properties.networkRuleSets='{}'"
+    # )
+    # cli.invoke(
+    #     f"resource update --name {hub_name} -g {hub_rg} --resource-type Microsoft.Devices/IotHubs "
+    #     "--add properties.networkRuleSets.ipRules '{\"action\":\"Allow\",\"filterName\":\"Trusted\",\"ipMask\":\""
+    #     f"{public_ip}"
+    #     "\"}'"
+    # )
     yield provisioned_iot_hubs_with_storage_user_module
 
 

--- a/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
@@ -47,14 +47,13 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                 ),
                 checks=[
                     self.check("jobId", self.job_ids[0]),
-                    # TODO: some properties from the result are missing now. Need to double check with service
-                    # self.check("queryCondition", query_condition),
+                    self.check("queryCondition", query_condition),
                     self.check("status", "completed"),
-                    # self.check("updateTwin.etag", "*"),
-                    # self.check(
-                    #     "updateTwin.tags",
-                    #     json.loads(self.kwargs["twin_patch_tags"])["tags"],
-                    # ),
+                    self.check("updateTwin.etag", "*"),
+                    self.check(
+                        "updateTwin.tags",
+                        json.loads(self.kwargs["twin_patch_tags"])["tags"],
+                    ),
                     self.check("type", "scheduleUpdateTwin"),
                 ],
             )
@@ -82,13 +81,13 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                 ),
                 checks=[
                     self.check("jobId", self.job_ids[1]),
-                    # self.check("queryCondition", query_condition),
+                    self.check("queryCondition", query_condition),
                     self.check("status", "completed"),
-                    # self.check("updateTwin.etag", "*"),
-                    # self.check(
-                    #     "updateTwin.properties",
-                    #     json.loads(self.kwargs["twin_patch_props"])["properties"],
-                    # ),
+                    self.check("updateTwin.etag", "*"),
+                    self.check(
+                        "updateTwin.properties",
+                        json.loads(self.kwargs["twin_patch_props"])["properties"],
+                    ),
                     self.check("type", "scheduleUpdateTwin"),
                 ],
             )

--- a/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
@@ -47,13 +47,14 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                 ),
                 checks=[
                     self.check("jobId", self.job_ids[0]),
-                    self.check("queryCondition", query_condition),
+                    # TODO: some properties from the result are missing now. Need to double check with service
+                    # self.check("queryCondition", query_condition),
                     self.check("status", "completed"),
-                    self.check("updateTwin.etag", "*"),
-                    self.check(
-                        "updateTwin.tags",
-                        json.loads(self.kwargs["twin_patch_tags"])["tags"],
-                    ),
+                    # self.check("updateTwin.etag", "*"),
+                    # self.check(
+                    #     "updateTwin.tags",
+                    #     json.loads(self.kwargs["twin_patch_tags"])["tags"],
+                    # ),
                     self.check("type", "scheduleUpdateTwin"),
                 ],
             )
@@ -81,13 +82,13 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                 ),
                 checks=[
                     self.check("jobId", self.job_ids[1]),
-                    self.check("queryCondition", query_condition),
+                    # self.check("queryCondition", query_condition),
                     self.check("status", "completed"),
-                    self.check("updateTwin.etag", "*"),
-                    self.check(
-                        "updateTwin.properties",
-                        json.loads(self.kwargs["twin_patch_props"])["properties"],
-                    ),
+                    # self.check("updateTwin.etag", "*"),
+                    # self.check(
+                    #     "updateTwin.properties",
+                    #     json.loads(self.kwargs["twin_patch_props"])["properties"],
+                    # ),
                     self.check("type", "scheduleUpdateTwin"),
                 ],
             )


### PR DESCRIPTION
---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
