### PR TITLE
fix: solve SDL task warnings

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -23,6 +23,7 @@ jobs:
   security:
     permissions:
       # needed to write security info to repository
+      id-token: write
       security-events: write
       contents: read
     uses: ./.github/workflows/security_checks.yml

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - dev
       - feature/*
+      - release/*
   workflow_call:
     inputs:
       continue-on-error:
@@ -20,6 +21,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       # needed to write security info to repository
+      id-token: write
       security-events: write
       contents: read
     steps:

--- a/.github/workflows/trigger_ado_int_tests.yml
+++ b/.github/workflows/trigger_ado_int_tests.yml
@@ -161,12 +161,12 @@ jobs:
           # if status is not completed, or the result is one of failed, canceled; then fail the job
           if [[ "$status" != "completed" || "$result" =~ (failed|canceled) ]]; then
             echo "::error::Pipeline did not complete successfully"
-            echo "# ❌ ${PIPELINE:-$DEFAULT_TITLE} Failed ❌" >> $GITHUB_STEP_SUMMARY
+            echo "# [FAILED] ${PIPELINE:-$DEFAULT_TITLE} Failed [FAILED]" >> $GITHUB_STEP_SUMMARY
             echo "The pipeline did not complete successfully. Please check the logs [here](${PORTAL_URL})" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 
-          echo "# ✅ ${PIPELINE:-$DEFAULT_TITLE} Completed ✅" >> $GITHUB_STEP_SUMMARY
+          echo "# [SUCCESS] ${PIPELINE:-$DEFAULT_TITLE} Completed [SUCCESS]" >> $GITHUB_STEP_SUMMARY
           echo "The pipeline completed successfully. You can check the logs [here](${PORTAL_URL})" >> $GITHUB_STEP_SUMMARY
   CancelPipeline:
     runs-on: ubuntu-latest
@@ -191,5 +191,5 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{"status": "cancelling"}' \
             "${RUN_URL}?api-version=7.2-preview.7"
-          echo "# ❌ ${PIPELINE:-$DEFAULT_TITLE} Cancelled ❌" >> $GITHUB_STEP_SUMMARY
+          echo "# [CANCELLED] ${PIPELINE:-$DEFAULT_TITLE} Cancelled [CANCELLED]" >> $GITHUB_STEP_SUMMARY
           echo "The pipeline was cancelled. You can check the logs [here](${PORTAL_URL})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- SDL task is warning about missing `id_token: write` perms
- Bandit is having trouble parsing unicode emoji chars in our pipeline YAML
- runs security checks automatically on updates to `release/` branches

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
