### PR TITLE
fix: device-twin --tags fix and ADR test fixes for min-CLI

### DIFF
--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -235,7 +235,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    type=str, help='Specify the minimum TLS version to support for this hub. Can be set to '
                                   '"1.0" or "1.2". For example, minimum TLS version set to "1.2" '
                                   'results in clients that use a TLS version below 1.2 to be rejected.')
-        c.argument('tags', tags_type)
         c.argument('system_identity', options_list=['--mi-system-assigned'],
                    arg_type=get_three_state_flag(),
                    help="Enable system-assigned managed identity for this hub")
@@ -247,6 +246,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('identity_scopes', options_list=['--scopes'], nargs='*',
                    help="Space separated list of scopes to assign the role (--role) "
                    "for the system-assigned managed identity.")
+
+    # Tag-type should only be for hub create/update (conflicts with device-twin update twin tags)
+    for cmd in ["iot hub create", "iot hub update"]:
+        with self.argument_context(cmd) as c:
+            c.argument('tags', tags_type)
 
     with self.argument_context('iot hub identity assign') as c:
         c.argument('system_identity', options_list=['--system-assigned', '--system'],

--- a/azext_iot/tests/adr/test_adr_certmgmt_lifecycle_int.py
+++ b/azext_iot/tests/adr/test_adr_certmgmt_lifecycle_int.py
@@ -38,7 +38,7 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
             # Check if role assignment already exists
             # For object ID checks, we can use either --assignee or --assignee-object-id
             existing_assignment = self.cmd(
-                f"role assignment list --assignee-object-id '{assignee_id}' --scope '{scope}' --role '{role}'"
+                f"role assignment list --assignee '{assignee_id}' --scope '{scope}' --role '{role}'"
             ).get_output_in_json()
 
             if existing_assignment:
@@ -101,7 +101,6 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
         identity_name = generate_identity_name()
         device_id = generate_device_id()
         enrollment_group_id = generate_enrollment_group_id()
-        credential_policy_name = CUSTOM_POLICY_NAME
 
         try:
             # Create user assigned identity
@@ -241,7 +240,7 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
             enrollment_group = self.cmd(
                 f"iot dps enrollment-group create --dps-name {dps_name} -g {rg} "
                 f"--enrollment-id {enrollment_group_id} "
-                f"--credential-policy-name {credential_policy_name}"
+                f"--credential-policy-name {CUSTOM_POLICY_NAME}"
             ).get_output_in_json()
             assert enrollment_group["enrollmentGroupId"] == enrollment_group_id
 
@@ -252,14 +251,14 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
             assert enrollment_group_show["enrollmentGroupId"] == enrollment_group_id
 
             # Validate enrollment group credential policy reference
-            assert enrollment_group_show["credentialPolicyName"] == credential_policy_name
+            assert enrollment_group_show["credentialPolicyName"] == CUSTOM_POLICY_NAME
             assert enrollment_group_show["attestation"]["type"] == "symmetricKey"
 
             # Create individual enrollment with credential policy
             individual_enrollment = self.cmd(
                 f"iot dps enrollment create --dps-name {dps_name} -g {rg} "
                 f"--enrollment-id {device_id} "
-                f"--credential-policy-name {credential_policy_name} "
+                f"--credential-policy-name {CUSTOM_POLICY_NAME} "
                 f"--attestation-type symmetrickey"
             ).get_output_in_json()
             assert individual_enrollment["registrationId"] == device_id
@@ -271,7 +270,7 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
             assert individual_enrollment_show["registrationId"] == device_id
 
             # Validate individual enrollment credential policy reference
-            assert individual_enrollment_show["credentialPolicyName"] == credential_policy_name
+            assert individual_enrollment_show["credentialPolicyName"] == CUSTOM_POLICY_NAME
             assert individual_enrollment_show["attestation"]["type"] == "symmetricKey"
             assert individual_enrollment_show["provisioningStatus"] == "enabled"
 
@@ -288,7 +287,7 @@ class TestADRCertificateManagementLifecycle(CaptureOutputLiveScenarioTest):
             custom_policy_resource_id = (
                 f"/subscriptions/{subscription_id}/resourceGroups/{rg}/providers/"
                 f"Microsoft.DeviceRegistry/namespaces/{namespace_name}/credentials/"
-                f"default/policies/{credential_policy_name}"
+                f"default/policies/{CUSTOM_POLICY_NAME}"
             )
 
             # Find certificate by policy resource ID


### PR DESCRIPTION
This PR fixes:
- Issue where `iot hub` core param config was overriding `tags` argument type for `device-twin update`, solution is to only set `--tags` as `tags_type` under `hub create` and `hub update`.
- ADR test using inconsistent local variable / const value for custom policy name.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
