### PR TITLE
chore(ci): update runner images

### DIFF
--- a/.azure-devops/integration_tests.yml
+++ b/.azure-devops/integration_tests.yml
@@ -9,9 +9,9 @@ parameters:
     default: "aziotcli_test_primary"
   - name: testAgentVmImage
     type: string
-    default: "ubuntu-22.04"
+    default: "ubuntu-24.04"
     values:
-      - "ubuntu-22.04"
+      - "ubuntu-24.04"
       - "ubuntu-latest"
   - name: pythonVersion
     displayName: "Python version for building wheels, KPIs"

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -23,9 +23,9 @@ variables:
 parameters:
   - name: linuxImage
     type: string
-    default: "ubuntu-22.04"
+    default: "ubuntu-24.04"
     values:
-      - "ubuntu-22.04"
+      - "ubuntu-24.04"
       - "ubuntu-latest"
 
 jobs:
@@ -82,7 +82,7 @@ jobs:
         "build_and_publish_azure_cli_test_sdk",
       ]
     pool:
-      vmImage: "macOS-13"
+      vmImage: "macOS-15"
 
     steps:
       - template: templates/run-tests-parallel.yml

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -82,7 +82,7 @@ jobs:
         "build_and_publish_azure_cli_test_sdk",
       ]
     pool:
-      vmImage: "macos-15-intel"
+      vmImage: "macOS-15"
 
     steps:
       - template: templates/run-tests-parallel.yml

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -82,7 +82,7 @@ jobs:
         "build_and_publish_azure_cli_test_sdk",
       ]
     pool:
-      vmImage: "macOS-15"
+      vmImage: "macos-15-intel"
 
     steps:
       - template: templates/run-tests-parallel.yml
@@ -98,7 +98,7 @@ jobs:
         "build_and_publish_azure_cli_test_sdk",
       ]
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2025"
 
     steps:
       - task: PowerShell@2
@@ -147,7 +147,7 @@ jobs:
   - job: CredScan
     displayName: "Credential Scan"
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2025"
 
     steps:
       - task: CredScan@3

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -129,7 +129,7 @@ stages:
   - stage: "test_msi"
     displayName: "Run all tests against Windows MSI install"
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2025"
     dependsOn: [build, test_min]
     variables:
       pythonVersions: $[variables['msiTestingMatrix']]
@@ -163,7 +163,7 @@ stages:
       pythonVersions: $[variables['msiTestingMatrix']]
     condition: succeeded()
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2025"
     jobs:
       - template: templates/smoke-tests.yml
         parameters:

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -18,9 +18,9 @@ parameters:
     default: "aziotcli_test_nightly"
   - name: vmImage
     type: string
-    default: "ubuntu-22.04"
+    default: "ubuntu-24.04"
     values:
-      - "ubuntu-22.04"
+      - "ubuntu-24.04"
       - "ubuntu-latest"
   - name: pythonVersion
     displayName: "Python version for building wheel, KPIs"

--- a/.azure-devops/reference_markdown.yml
+++ b/.azure-devops/reference_markdown.yml
@@ -10,9 +10,9 @@ parameters:
     default: "iot"
   - name: linuxImage
     type: string
-    default: "ubuntu-22.04"
+    default: "ubuntu-24.04"
     values:
-      - "ubuntu-22.04"
+      - "ubuntu-24.04"
       - "ubuntu-latest"
 
 jobs:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
-          - windows-2022
-          - macos-13
+          - ubuntu-24.04
+          - windows-2025
+          - macos-15
         py:
           - "3.13"
           - "3.12"
@@ -48,7 +48,7 @@ jobs:
       - name: Run test suite
         run: tox r --skip-pkg-install
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.py == '3.13' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.py == '3.13' }}
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,7 +28,7 @@ jobs:
         os:
           - ubuntu-24.04
           - windows-2025
-          - macos-15
+          - macos-15-intel
         py:
           - "3.13"
           - "3.12"


### PR DESCRIPTION
pinning runner images to:
- macos-15 (devops, intel)
- macos-15-intel (github actions)
- ubuntu-24.04
- windows-2025

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
