### PR TITLE
ci(sbom): use clean venv for runtime dependencies only

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -47,16 +47,19 @@ jobs:
           echo "version=$version" >> $GITHUB_ENV
       - name: Generate SBOM
         run: |
-          # Generate frozen requirements for sbom-tool to scan (avoids setup.py parsing issues with pip 25.x)
-          pip freeze > ./dist/requirements.txt
+          # Create clean venv with only runtime dependencies (excludes dev/test deps)
+          python -m venv $RUNNER_TEMP/sbom-venv
+          $RUNNER_TEMP/sbom-venv/bin/pip install --upgrade pip
+          $RUNNER_TEMP/sbom-venv/bin/pip install ${{ env.wheel }}
+          $RUNNER_TEMP/sbom-venv/bin/pip freeze > ./dist/requirements.txt
           # Add Windows-specific azure-iot-device version (not installed on Linux CI, but needed for complete SBOM)
           # Note: This causes a pip conflict warning in sbom-tool but both versions are correctly included in SBOM
           echo "azure-iot-device>=2.15.0rc1,<3.0.0dev0" >> ./dist/requirements.txt
           curl -Lo $RUNNER_TEMP/sbom-tool https://github.com/microsoft/sbom-tool/releases/download/v4.1.5/sbom-tool-linux-x64
           chmod +x $RUNNER_TEMP/sbom-tool
           $RUNNER_TEMP/sbom-tool generate -b ./dist -bc ./dist -pn "Azure IoT CLI Extension" -pv "${{ env.version }}" -ps Microsoft
-          # Clean up temporary file
-          rm ./dist/requirements.txt
+          # Clean up temporary files
+          rm -rf ./dist/requirements.txt $RUNNER_TEMP/sbom-venv
 
       - name: Upload Wheel Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Local env testing for new approach and earlier approach:
<img width="1768" height="1295" alt="image" src="https://github.com/user-attachments/assets/1e157230-cd27-425e-8ff4-b2a9d4ac88da" />



---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
