### PR TITLE
fix: pass cloud-specific credential_scopes

### DIFF
--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -50,6 +50,12 @@ def _get_default_logging_policy():
     return http_logging_policy
 
 
+def _get_credential_scopes(cli_ctx):
+    """Get cloud-specific credential scopes for management plane authentication."""
+    from azure.cli.core.auth.util import resource_to_scopes
+    return resource_to_scopes(cli_ctx.cloud.endpoints.active_directory_resource_id)
+
+
 def iot_hub_service_factory(cli_ctx, *_):
     """
     Factory for importing deps and getting service client resources.
@@ -72,6 +78,7 @@ def iot_hub_service_factory(cli_ctx, *_):
         credential=AZURE_CLI_CREDENTIAL,
         subscription_id=subscription_id,
         endpoint=cli_ctx.cloud.endpoints.resource_manager,
+        credential_scopes=_get_credential_scopes(cli_ctx),
         user_agent_policy=UserAgentPolicy(user_agent=USER_AGENT),
         http_logging_policy=_get_default_logging_policy(),
     )
@@ -99,6 +106,7 @@ def iot_service_provisioning_factory(cli_ctx, *_):
         credential=AZURE_CLI_CREDENTIAL,
         subscription_id=subscription_id,
         endpoint=cli_ctx.cloud.endpoints.resource_manager,
+        credential_scopes=_get_credential_scopes(cli_ctx),
         user_agent_policy=UserAgentPolicy(user_agent=USER_AGENT),
         http_logging_policy=_get_default_logging_policy(),
     )
@@ -126,6 +134,7 @@ def adr_service_factory(cli_ctx, *_):
         credential=AZURE_CLI_CREDENTIAL,
         subscription_id=subscription_id,
         endpoint=cli_ctx.cloud.endpoints.resource_manager,
+        credential_scopes=_get_credential_scopes(cli_ctx),
         user_agent_policy=UserAgentPolicy(user_agent=USER_AGENT),
         http_logging_policy=_get_default_logging_policy(),
     )

--- a/azext_iot/tests/test_factory_unit.py
+++ b/azext_iot/tests/test_factory_unit.py
@@ -13,13 +13,13 @@ CLOUD_CONFIGS = [
         "id": "public",
         "resource_manager": "https://management.azure.com",
         "active_directory_resource_id": "https://management.core.windows.net/",
-        "expected_scopes": ["https://management.core.windows.net/.default"],
+        "expected_scopes": ["https://management.core.windows.net//.default"],
     },
     {
         "id": "usgov",
         "resource_manager": "https://management.usgovcloudapi.net",
         "active_directory_resource_id": "https://management.core.usgovcloudapi.net/",
-        "expected_scopes": ["https://management.core.usgovcloudapi.net/.default"],
+        "expected_scopes": ["https://management.core.usgovcloudapi.net//.default"],
     },
 ]
 

--- a/azext_iot/tests/test_factory_unit.py
+++ b/azext_iot/tests/test_factory_unit.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------------------------
 
 import pytest
-from unittest.mock import MagicMock, patch
 
 
 CLOUD_CONFIGS = [
@@ -24,8 +23,8 @@ CLOUD_CONFIGS = [
 ]
 
 
-def _build_cli_ctx(cloud_config):
-    cli_ctx = MagicMock()
+def _build_cli_ctx(mocker, cloud_config):
+    cli_ctx = mocker.MagicMock()
     cli_ctx.cloud.endpoints.resource_manager = cloud_config["resource_manager"]
     cli_ctx.cloud.endpoints.active_directory_resource_id = cloud_config["active_directory_resource_id"]
     cli_ctx.data = {"subscription_id": "test-sub-id"}
@@ -36,13 +35,14 @@ def _build_cli_ctx(cloud_config):
 class TestFactoryCredentialScopes:
     """Ensure management client factories pass cloud-specific credential_scopes."""
 
-    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
-    @patch("azext_iot.sdk.iothub.mgmt.IotHubClient")
-    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
-    def test_iot_hub_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+    def test_iot_hub_factory(self, mocker, cloud_config):
+        mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+        mock_client_cls = mocker.patch("azext_iot.sdk.iothub.mgmt.IotHubClient")
+        mocker.patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+
         from azext_iot._factory import iot_hub_service_factory
 
-        cli_ctx = _build_cli_ctx(cloud_config)
+        cli_ctx = _build_cli_ctx(mocker, cloud_config)
         iot_hub_service_factory(cli_ctx)
 
         mock_client_cls.assert_called_once()
@@ -50,13 +50,14 @@ class TestFactoryCredentialScopes:
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
         assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
 
-    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
-    @patch("azext_iot.sdk.dps.mgmt.IotDpsClient")
-    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
-    def test_dps_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+    def test_dps_factory(self, mocker, cloud_config):
+        mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+        mock_client_cls = mocker.patch("azext_iot.sdk.dps.mgmt.IotDpsClient")
+        mocker.patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+
         from azext_iot._factory import iot_service_provisioning_factory
 
-        cli_ctx = _build_cli_ctx(cloud_config)
+        cli_ctx = _build_cli_ctx(mocker, cloud_config)
         iot_service_provisioning_factory(cli_ctx)
 
         mock_client_cls.assert_called_once()
@@ -64,13 +65,14 @@ class TestFactoryCredentialScopes:
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
         assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
 
-    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
-    @patch("azext_iot.sdk.deviceregistry.mgmt.DeviceRegistryMgmtClient")
-    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
-    def test_adr_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+    def test_adr_factory(self, mocker, cloud_config):
+        mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+        mock_client_cls = mocker.patch("azext_iot.sdk.deviceregistry.mgmt.DeviceRegistryMgmtClient")
+        mocker.patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+
         from azext_iot._factory import adr_service_factory
 
-        cli_ctx = _build_cli_ctx(cloud_config)
+        cli_ctx = _build_cli_ctx(mocker, cloud_config)
         adr_service_factory(cli_ctx)
 
         mock_client_cls.assert_called_once()

--- a/azext_iot/tests/test_factory_unit.py
+++ b/azext_iot/tests/test_factory_unit.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+CLOUD_CONFIGS = [
+    {
+        "id": "public",
+        "resource_manager": "https://management.azure.com",
+        "active_directory_resource_id": "https://management.core.windows.net/",
+        "expected_scopes": ["https://management.core.windows.net/.default"],
+    },
+    {
+        "id": "usgov",
+        "resource_manager": "https://management.usgovcloudapi.net",
+        "active_directory_resource_id": "https://management.core.usgovcloudapi.net/",
+        "expected_scopes": ["https://management.core.usgovcloudapi.net/.default"],
+    },
+]
+
+
+def _build_cli_ctx(cloud_config):
+    cli_ctx = MagicMock()
+    cli_ctx.cloud.endpoints.resource_manager = cloud_config["resource_manager"]
+    cli_ctx.cloud.endpoints.active_directory_resource_id = cloud_config["active_directory_resource_id"]
+    cli_ctx.data = {"subscription_id": "test-sub-id"}
+    return cli_ctx
+
+
+@pytest.mark.parametrize("cloud_config", CLOUD_CONFIGS, ids=[c["id"] for c in CLOUD_CONFIGS])
+class TestFactoryCredentialScopes:
+    """Ensure management client factories pass cloud-specific credential_scopes."""
+
+    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+    @patch("azext_iot.sdk.iothub.mgmt.IotHubClient")
+    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+    def test_iot_hub_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+        from azext_iot._factory import iot_hub_service_factory
+
+        cli_ctx = _build_cli_ctx(cloud_config)
+        iot_hub_service_factory(cli_ctx)
+
+        mock_client_cls.assert_called_once()
+        call_kwargs = mock_client_cls.call_args.kwargs
+        assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
+        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
+
+    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+    @patch("azext_iot.sdk.dps.mgmt.IotDpsClient")
+    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+    def test_dps_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+        from azext_iot._factory import iot_service_provisioning_factory
+
+        cli_ctx = _build_cli_ctx(cloud_config)
+        iot_service_provisioning_factory(cli_ctx)
+
+        mock_client_cls.assert_called_once()
+        call_kwargs = mock_client_cls.call_args.kwargs
+        assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
+        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
+
+    @patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
+    @patch("azext_iot.sdk.deviceregistry.mgmt.DeviceRegistryMgmtClient")
+    @patch("azure.cli.core.commands.client_factory.get_subscription_id", return_value="test-sub")
+    def test_adr_factory(self, mock_get_sub, mock_client_cls, mock_cred, cloud_config):
+        from azext_iot._factory import adr_service_factory
+
+        cli_ctx = _build_cli_ctx(cloud_config)
+        adr_service_factory(cli_ctx)
+
+        mock_client_cls.assert_called_once()
+        call_kwargs = mock_client_cls.call_args.kwargs
+        assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
+        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]


### PR DESCRIPTION
The management SDK clients were missing credential_scopes, so they defaulted to management.azure.com. In US Gov cloud, tokens need to be scoped to management.usgovcloudapi.net, causing authentication failures.

Fix: read the correct scopes from the CLI's cloud config and pass them to each client.

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
