### PR TITLE
feat: add TLS 1.3 hostname support and --hostname-type flag for IoT Hub

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,10 @@ Release History
 
 **IoT Hub updates**
 
-* New management SDK using `2025-08-01-preview` API version.
+* New management SDK using `2026-03-01-preview` API version.
+* New ``device_host_name`` and ``service_host_name`` read-only properties on IoT Hub for TLS 1.3 support.
+* New ``iot_hub_details`` property with ``gateway_version`` to identify GWv2 hubs.
+* New ``--hostname-type`` flag on connection-string commands to select classic, device, or service hostname for TLS 1.3 support.
 * New Hub `Gen2` SKU to support ADR integration.
 * `Gen2` hub creation now supports linking an ADR namespace using `--ns-resource-id` and `--ns-identity-id` arguments.
 

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -20,6 +20,7 @@ from azext_iot.common.shared import (
     SettleType,
     DeviceAuthType,
     KeyType,
+    HostnameType,
     AttestationType,
     ProtocolType,
     AckType,
@@ -349,6 +350,34 @@ def load_arguments(self, _):
             options_list=["--default-eventhub", "--eh"],
             help="Flag indicating the connection string returned is for the default EventHub endpoint. Default: false.",
         )
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(HostnameType),
+            default=HostnameType.classic.value,
+            help="Type of hostname to use in the connection string. "
+            "'classic' uses the default hostname, "
+            "'device' uses the TLS 1.3 device hostname, "
+            "'service' uses the TLS 1.3 service hostname. "
+            "The 'device' and 'service' options are only available on GWv2 IoT Hubs.",
+        )
+
+    for cs_command in [
+        "iot hub device-identity connection-string",
+        "iot hub module-identity connection-string",
+    ]:
+        with self.argument_context(cs_command) as context:
+            context.argument(
+                "hostname_type",
+                options_list=["--hostname-type", "--ht"],
+                arg_type=get_enum_type(HostnameType),
+                default=HostnameType.classic.value,
+                help="Type of hostname to use in the connection string. "
+                "'classic' uses the default hostname, "
+                "'device' uses the TLS 1.3 device hostname, "
+                "'service' uses the TLS 1.3 service hostname. "
+                "The 'device' and 'service' options are only available on GWv2 IoT Hubs.",
+            )
 
     with self.argument_context("iot hub job") as context:
         context.argument("job_id", options_list=["--job-id"], help="IoT Hub job Id.")

--- a/azext_iot/common/shared.py
+++ b/azext_iot/common/shared.py
@@ -75,6 +75,16 @@ class KeyType(Enum):
     secondary = "secondary"
 
 
+class HostnameType(Enum):
+    """
+    Type of hostname to use in connection strings.
+    """
+
+    classic = "classic"
+    device = "device"
+    service = "service"
+
+
 class AttestationType(Enum):
     """
     Type of atestation (TMP or certificate based).

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -34,6 +34,7 @@ from azext_iot.common.shared import (
     SdkType,
     ConfigType,
     KeyType,
+    HostnameType,
     RenewKeyType,
     IoTHubStateType,
     DeviceAuthApiType,
@@ -2394,7 +2395,28 @@ def _iot_build_sas_token(
     return SasTokenAuthentication(uri, policy, key, duration)
 
 
-def _build_device_or_module_connection_string(entity, key_type="primary"):
+def _resolve_hostname_by_type(hub, hostname_type):
+    """Resolve the appropriate hostname based on the hostname type."""
+    if hostname_type == HostnameType.device.value:
+        hostname = getattr(hub.properties, "device_host_name", None)
+        if not hostname:
+            raise InvalidArgumentValueError(
+                "The device hostname is not available for this IoT Hub. "
+                "This feature is only supported on GWv2 IoT Hubs."
+            )
+        return hostname
+    elif hostname_type == HostnameType.service.value:
+        hostname = getattr(hub.properties, "service_host_name", None)
+        if not hostname:
+            raise InvalidArgumentValueError(
+                "The service hostname is not available for this IoT Hub. "
+                "This feature is only supported on GWv2 IoT Hubs."
+            )
+        return hostname
+    return hub.properties.host_name
+
+
+def _build_device_or_module_connection_string(entity, key_type="primary", hostname_override=None):
     is_device = entity.get("moduleId") is None
     template = (
         "HostName={};DeviceId={};{}"
@@ -2417,11 +2439,12 @@ def _build_device_or_module_connection_string(entity, key_type="primary"):
     else:
         raise CLIInternalError("Unable to form target connection string")
 
+    hostname = hostname_override or entity.get("hub")
     if is_device:
-        return template.format(entity.get("hub"), entity.get("deviceId"), key)
+        return template.format(hostname, entity.get("deviceId"), key)
     else:
         return template.format(
-            entity.get("hub"), entity.get("deviceId"), entity.get("moduleId"), key
+            hostname, entity.get("deviceId"), entity.get("moduleId"), key
         )
 
 
@@ -2433,6 +2456,7 @@ def iot_get_device_connection_string(
     resource_group_name=None,
     login=None,
     auth_type_dataplane=None,
+    hostname_type=HostnameType.classic.value,
 ):
     result = {}
     device = iot_device_show(
@@ -2443,8 +2467,13 @@ def iot_get_device_connection_string(
         login=login,
         auth_type_dataplane=auth_type_dataplane,
     )
+    hostname_override = None
+    if hostname_type != HostnameType.classic.value:
+        discovery = IotHubDiscovery(cmd)
+        hub = discovery.find_resource(hub_name_or_hostname, resource_group_name)
+        hostname_override = _resolve_hostname_by_type(hub, hostname_type)
     result["connectionString"] = _build_device_or_module_connection_string(
-        device, key_type
+        device, key_type, hostname_override=hostname_override
     )
     return result
 
@@ -2458,6 +2487,7 @@ def iot_get_module_connection_string(
     resource_group_name=None,
     login=None,
     auth_type_dataplane=None,
+    hostname_type=HostnameType.classic.value,
 ):
     result = {}
     module = iot_device_module_show(
@@ -2469,8 +2499,13 @@ def iot_get_module_connection_string(
         login=login,
         auth_type_dataplane=auth_type_dataplane,
     )
+    hostname_override = None
+    if hostname_type != HostnameType.classic.value:
+        discovery = IotHubDiscovery(cmd)
+        hub = discovery.find_resource(hub_name_or_hostname, resource_group_name)
+        hostname_override = _resolve_hostname_by_type(hub, hostname_type)
     result["connectionString"] = _build_device_or_module_connection_string(
-        module, key_type
+        module, key_type, hostname_override=hostname_override
     )
     return result
 
@@ -2863,6 +2898,7 @@ def iot_hub_connection_string_show(
     key_type=KeyType.primary.value,
     show_all=False,
     default_eventhub=False,
+    hostname_type=HostnameType.classic.value,
 ):
     discovery = IotHubDiscovery(cmd)
 
@@ -2873,7 +2909,7 @@ def iot_hub_connection_string_show(
 
         def conn_str_getter(hub):
             return _get_hub_connection_string(
-                discovery, hub, policy_name, key_type, show_all, default_eventhub
+                discovery, hub, policy_name, key_type, show_all, default_eventhub, hostname_type
             )
 
         connection_strings = []
@@ -2905,13 +2941,13 @@ def iot_hub_connection_string_show(
     hub = discovery.find_resource(hub_name_or_hostname, resource_group_name)
     if hub:
         conn_str = _get_hub_connection_string(
-            discovery, hub, policy_name, key_type, show_all, default_eventhub
+            discovery, hub, policy_name, key_type, show_all, default_eventhub, hostname_type
         )
         return {"connectionString": conn_str if show_all else conn_str[0]}
 
 
 def _get_hub_connection_string(
-    discovery, hub, policy_name, key_type, show_all, default_eventhub
+    discovery, hub, policy_name, key_type, show_all, default_eventhub, hostname_type=HostnameType.classic.value
 ):
 
     policies = []
@@ -2949,7 +2985,7 @@ def _get_hub_connection_string(
             )
         ]
 
-    hostname = hub.properties.host_name
+    hostname = _resolve_hostname_by_type(hub, hostname_type)
     cs_template = "HostName={};SharedAccessKeyName={};SharedAccessKey={}"
     return [
         cs_template.format(

--- a/azext_iot/sdk/iothub/mgmt/_configuration.py
+++ b/azext_iot/sdk/iothub/mgmt/_configuration.py
@@ -28,13 +28,13 @@ class IotHubClientConfiguration:  # pylint: disable=too-many-instance-attributes
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The subscription identifier. Required.
     :type subscription_id: str
-    :keyword api_version: Api Version. Default value is "2025-08-01-preview". Note that overriding
+    :keyword api_version: Api Version. Default value is "2026-03-01-preview". Note that overriding
      this default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, credential: "TokenCredential", subscription_id: str, **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2025-08-01-preview")
+        api_version: str = kwargs.pop("api_version", "2026-03-01-preview")
 
         if credential is None:
             raise ValueError("Parameter 'credential' must not be None.")

--- a/azext_iot/sdk/iothub/mgmt/models/__init__.py
+++ b/azext_iot/sdk/iothub/mgmt/models/__init__.py
@@ -34,6 +34,8 @@ from ._models import GroupIdInformationProperties
 from ._models import ImportDevicesRequest
 from ._models import IotHubCapacity
 from ._models import IotHubDescription
+from ._models import IotHubDescriptionListResult
+from ._models import IotHubDetails
 from ._models import IotHubLocationDescription
 from ._models import IotHubNameAvailabilityInfo
 from ._models import IotHubProperties
@@ -93,6 +95,7 @@ from ._enums import Capabilities
 from ._enums import CreatedByType
 from ._enums import DefaultAction
 from ._enums import EndpointHealthStatus
+from ._enums import GatewayVersion
 from ._enums import IotHubNameUnavailabilityReason
 from ._enums import IotHubReplicaRoleType
 from ._enums import IotHubScaleType
@@ -143,6 +146,8 @@ __all__ = [
     "ImportDevicesRequest",
     "IotHubCapacity",
     "IotHubDescription",
+    "IotHubDescriptionListResult",
+    "IotHubDetails",
     "IotHubLocationDescription",
     "IotHubNameAvailabilityInfo",
     "IotHubProperties",
@@ -201,6 +206,7 @@ __all__ = [
     "CreatedByType",
     "DefaultAction",
     "EndpointHealthStatus",
+    "GatewayVersion",
     "IotHubNameUnavailabilityReason",
     "IotHubReplicaRoleType",
     "IotHubScaleType",

--- a/azext_iot/sdk/iothub/mgmt/models/_enums.py
+++ b/azext_iot/sdk/iothub/mgmt/models/_enums.py
@@ -62,6 +62,13 @@ class DefaultAction(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     ALLOW = "Allow"
 
 
+class GatewayVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """The IoT hub Gateway version."""
+
+    V1 = "V1"
+    V2 = "V2"
+
+
 class EndpointHealthStatus(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Health statuses have following meanings. The 'healthy' status shows that the endpoint is
     accepting messages as expected. The 'unhealthy' status shows that the endpoint is not accepting

--- a/azext_iot/sdk/iothub/mgmt/models/_models.py
+++ b/azext_iot/sdk/iothub/mgmt/models/_models.py
@@ -1504,6 +1504,28 @@ class IotHubDescriptionListResult(_serialization.Model):
         self.next_link = None
 
 
+class IotHubDetails(_serialization.Model):
+    """Set of additional read-only properties for the IoT hub.
+
+    Variables are only populated by the server, and will be ignored when sending a request.
+
+    :ivar gateway_version: The IoT hub Gateway version. Known values are: "V1" and "V2".
+    :vartype gateway_version: str or ~iothub.mgmt.models.GatewayVersion
+    """
+
+    _validation = {
+        "gateway_version": {"readonly": True},
+    }
+
+    _attribute_map = {
+        "gateway_version": {"key": "gatewayVersion", "type": "str"},
+    }
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.gateway_version: Optional[Union[str, "_models.GatewayVersion"]] = None
+
+
 class IotHubLocationDescription(_serialization.Model):
     """Public representation of one of the locations where a resource is provisioned.
 
@@ -1619,6 +1641,11 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
     :vartype state: str
     :ivar host_name: The name of the host.
     :vartype host_name: str
+    :ivar device_host_name: The name of the device host. Supports secure connections over TLS 1.3.
+    :vartype device_host_name: str
+    :ivar service_host_name: The name of the service host. Supports secure connections over TLS
+     1.3.
+    :vartype service_host_name: str
     :ivar event_hub_endpoints: The Event Hub-compatible endpoint properties. The only possible keys
      to this dictionary is events. This key has to be present in the dictionary while making create
      or update calls for the IoT hub.
@@ -1660,13 +1687,18 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
     :vartype ip_version: str or ~iothub.mgmt.models.IpVersion
     :ivar device_registry: Represents properties related to the Azure Device Registry (ADR).
     :vartype device_registry: ~iothub.mgmt.models.DeviceRegistry
+    :ivar iot_hub_details: Set of additional read-only properties for the IoT hub.
+    :vartype iot_hub_details: ~iothub.mgmt.models.IotHubDetails
     """
 
     _validation = {
         "provisioning_state": {"readonly": True},
         "state": {"readonly": True},
         "host_name": {"readonly": True},
+        "device_host_name": {"readonly": True},
+        "service_host_name": {"readonly": True},
         "locations": {"readonly": True},
+        "iot_hub_details": {"readonly": True},
     }
 
     _attribute_map = {
@@ -1684,6 +1716,8 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
         "provisioning_state": {"key": "provisioningState", "type": "str"},
         "state": {"key": "state", "type": "str"},
         "host_name": {"key": "hostName", "type": "str"},
+        "device_host_name": {"key": "deviceHostName", "type": "str"},
+        "service_host_name": {"key": "serviceHostName", "type": "str"},
         "event_hub_endpoints": {"key": "eventHubEndpoints", "type": "{EventHubProperties}"},
         "routing": {"key": "routing", "type": "RoutingProperties"},
         "storage_endpoints": {"key": "storageEndpoints", "type": "{StorageEndpointProperties}"},
@@ -1699,6 +1733,7 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
         "root_certificate": {"key": "rootCertificate", "type": "RootCertificateProperties"},
         "ip_version": {"key": "ipVersion", "type": "str"},
         "device_registry": {"key": "deviceRegistry", "type": "DeviceRegistry"},
+        "iot_hub_details": {"key": "iotHubDetails", "type": "IotHubDetails"},
     }
 
     def __init__(  # pylint: disable=too-many-locals
@@ -1818,6 +1853,8 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
         self.provisioning_state = None
         self.state = None
         self.host_name = None
+        self.device_host_name = None
+        self.service_host_name = None
         self.event_hub_endpoints = event_hub_endpoints
         self.routing = routing
         self.storage_endpoints = storage_endpoints
@@ -1833,6 +1870,7 @@ class IotHubProperties(_serialization.Model):  # pylint: disable=too-many-instan
         self.root_certificate = root_certificate
         self.ip_version = ip_version
         self.device_registry = device_registry
+        self.iot_hub_details = None
 
 
 class IotHubPropertiesDeviceStreams(_serialization.Model):

--- a/azext_iot/tests/iothub/core/test_iot_hub_hostname_type_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_hostname_type_unit.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import Mock
+
+import pytest
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+from azext_iot.common.shared import HostnameType
+from azext_iot.operations.hub import (
+    _build_device_or_module_connection_string,
+    _resolve_hostname_by_type,
+)
+
+
+class TestResolveHostnameByType:
+    """Tests for _resolve_hostname_by_type helper."""
+
+    def _make_hub(self, host_name="myhub.azure-devices.net", device_host_name=None, service_host_name=None):
+        hub = Mock()
+        hub.properties.host_name = host_name
+        hub.properties.device_host_name = device_host_name
+        hub.properties.service_host_name = service_host_name
+        return hub
+
+    def test_classic_returns_host_name(self):
+        hub = self._make_hub()
+        result = _resolve_hostname_by_type(hub, HostnameType.classic.value)
+        assert result == "myhub.azure-devices.net"
+
+    def test_device_returns_device_host_name(self):
+        hub = self._make_hub(device_host_name="myhub.device.azure-devices.net")
+        result = _resolve_hostname_by_type(hub, HostnameType.device.value)
+        assert result == "myhub.device.azure-devices.net"
+
+    def test_service_returns_service_host_name(self):
+        hub = self._make_hub(service_host_name="myhub.service.azure-devices.net")
+        result = _resolve_hostname_by_type(hub, HostnameType.service.value)
+        assert result == "myhub.service.azure-devices.net"
+
+    def test_device_raises_when_not_available(self):
+        hub = self._make_hub(device_host_name=None)
+        with pytest.raises(InvalidArgumentValueError, match="device hostname is not available"):
+            _resolve_hostname_by_type(hub, HostnameType.device.value)
+
+    def test_service_raises_when_not_available(self):
+        hub = self._make_hub(service_host_name=None)
+        with pytest.raises(InvalidArgumentValueError, match="service hostname is not available"):
+            _resolve_hostname_by_type(hub, HostnameType.service.value)
+
+
+class TestBuildConnectionStringHostnameOverride:
+    """Tests for _build_device_or_module_connection_string with hostname_override."""
+
+    def _make_device_entity(self):
+        return {
+            "hub": "myhub.azure-devices.net",
+            "deviceId": "device1",
+            "authentication": {
+                "type": "sas",
+                "symmetricKey": {
+                    "primaryKey": "primary123",
+                    "secondaryKey": "secondary456",
+                },
+            },
+        }
+
+    def _make_module_entity(self):
+        entity = self._make_device_entity()
+        entity["moduleId"] = "module1"
+        return entity
+
+    def test_device_default_uses_entity_hub(self):
+        entity = self._make_device_entity()
+        cs = _build_device_or_module_connection_string(entity)
+        assert cs.startswith("HostName=myhub.azure-devices.net;")
+        assert "DeviceId=device1" in cs
+
+    def test_device_with_hostname_override(self):
+        entity = self._make_device_entity()
+        cs = _build_device_or_module_connection_string(
+            entity, hostname_override="myhub.device.azure-devices.net"
+        )
+        assert cs.startswith("HostName=myhub.device.azure-devices.net;")
+        assert "DeviceId=device1" in cs
+
+    def test_module_with_hostname_override(self):
+        entity = self._make_module_entity()
+        cs = _build_device_or_module_connection_string(
+            entity, hostname_override="myhub.service.azure-devices.net"
+        )
+        assert cs.startswith("HostName=myhub.service.azure-devices.net;")
+        assert "DeviceId=device1" in cs
+        assert "ModuleId=module1" in cs
+
+    def test_device_secondary_key(self):
+        entity = self._make_device_entity()
+        cs = _build_device_or_module_connection_string(entity, key_type="secondary")
+        assert "SharedAccessKey=secondary456" in cs
+
+    def test_device_override_does_not_affect_key(self):
+        entity = self._make_device_entity()
+        cs = _build_device_or_module_connection_string(
+            entity, hostname_override="override.host.net"
+        )
+        assert "SharedAccessKey=primary123" in cs
+
+
+class TestHostnameTypeEnum:
+    """Tests for HostnameType enum."""
+
+    def test_enum_values(self):
+        assert HostnameType.classic.value == "classic"
+        assert HostnameType.device.value == "device"
+        assert HostnameType.service.value == "service"
+
+    def test_enum_has_three_members(self):
+        assert len(HostnameType) == 3

--- a/azext_iot/tests/iothub/core/test_iot_hub_tls13_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_tls13_unit.py
@@ -63,6 +63,6 @@ class TestIotHubTls13Models:
         assert gv.value == version
 
     def test_gateway_version_enum_case_insensitive(self):
-        """GatewayVersion enum should be case insensitive."""
-        assert GatewayVersion("v1") == GatewayVersion.V1
-        assert GatewayVersion("v2") == GatewayVersion.V2
+        """GatewayVersion enum should support case-insensitive attribute access."""
+        assert GatewayVersion["v1"] == GatewayVersion.V1
+        assert GatewayVersion["v2"] == GatewayVersion.V2

--- a/azext_iot/tests/iothub/core/test_iot_hub_tls13_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_tls13_unit.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+
+from azext_iot.sdk.iothub.mgmt.models import GatewayVersion, IotHubDetails, IotHubProperties
+
+
+class TestIotHubTls13Models:
+    """Tests for TLS 1.3 related model properties (device_host_name, service_host_name, iot_hub_details)."""
+
+    def test_iot_hub_properties_has_new_hostname_fields(self):
+        """IotHubProperties should have device_host_name and service_host_name as read-only fields."""
+        props = IotHubProperties()
+        assert props.device_host_name is None
+        assert props.service_host_name is None
+
+    def test_iot_hub_properties_has_iot_hub_details(self):
+        """IotHubProperties should have iot_hub_details as a read-only field."""
+        props = IotHubProperties()
+        assert props.iot_hub_details is None
+
+    def test_iot_hub_properties_hostname_fields_in_attribute_map(self):
+        """New hostname fields should map to correct JSON keys."""
+        attr_map = IotHubProperties._attribute_map
+        assert "device_host_name" in attr_map
+        assert attr_map["device_host_name"]["key"] == "deviceHostName"
+        assert "service_host_name" in attr_map
+        assert attr_map["service_host_name"]["key"] == "serviceHostName"
+        assert "iot_hub_details" in attr_map
+        assert attr_map["iot_hub_details"]["key"] == "iotHubDetails"
+
+    def test_iot_hub_properties_hostname_fields_are_readonly(self):
+        """New hostname and iot_hub_details fields should be marked as read-only."""
+        validation = IotHubProperties._validation
+        assert validation["device_host_name"] == {"readonly": True}
+        assert validation["service_host_name"] == {"readonly": True}
+        assert validation["iot_hub_details"] == {"readonly": True}
+
+    def test_iot_hub_details_model(self):
+        """IotHubDetails should have a read-only gateway_version field."""
+        details = IotHubDetails()
+        assert details.gateway_version is None
+
+    def test_iot_hub_details_gateway_version_attribute_map(self):
+        """IotHubDetails gateway_version should map to correct JSON key."""
+        attr_map = IotHubDetails._attribute_map
+        assert "gateway_version" in attr_map
+        assert attr_map["gateway_version"]["key"] == "gatewayVersion"
+
+    def test_iot_hub_details_gateway_version_is_readonly(self):
+        """IotHubDetails gateway_version should be read-only."""
+        validation = IotHubDetails._validation
+        assert validation["gateway_version"] == {"readonly": True}
+
+    @pytest.mark.parametrize("version", ["V1", "V2"])
+    def test_gateway_version_enum_values(self, version):
+        """GatewayVersion enum should have V1 and V2 values."""
+        gv = GatewayVersion(version)
+        assert gv.value == version
+
+    def test_gateway_version_enum_case_insensitive(self):
+        """GatewayVersion enum should be case insensitive."""
+        assert GatewayVersion("v1") == GatewayVersion.V1
+        assert GatewayVersion("v2") == GatewayVersion.V2


### PR DESCRIPTION
Add TLS 1.3 hostname support and --hostname-type flag for IoT Hub

   - Update management SDK to 2026-03-01-preview API version
   - Add deviceHostName, serviceHostName, and iotHubDetails.gatewayVersion
     read-only properties to IotHubProperties model
   - Add new IotHubDetails model and GatewayVersion enum
   - Add --hostname-type flag (classic/device/service) to connection-string
     commands: hub, device-identity, and module-identity
   - Add unit tests for new models and hostname-type logic


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [x] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [x] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [x] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [x] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [x] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [x] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
