### PR TITLE
fix: send non-nullable disable property in device revoke request

### DIFF
--- a/azext_iot/adr/commands_device.py
+++ b/azext_iot/adr/commands_device.py
@@ -55,7 +55,7 @@ def adr_device_revoke(
     device_name: str,
     namespace_name: str,
     resource_group_name: str,
-    disable: Optional[bool] = None,
+    disable: bool = False,
 ):
     provider = DeviceProvider(cmd)
     return provider.revoke(

--- a/azext_iot/adr/params_adr_management.py
+++ b/azext_iot/adr/params_adr_management.py
@@ -172,7 +172,7 @@ def load_adr_management_arguments(self, _):
         context.argument(
             "disable",
             options_list=["--disable"],
-            arg_type=get_three_state_flag(),
+            action="store_true",
             help="Disable the device after revoking credentials. "
                  "Prevents new credentials from being issued.",
         )

--- a/azext_iot/adr/providers/device.py
+++ b/azext_iot/adr/providers/device.py
@@ -86,13 +86,13 @@ class DeviceProvider(ADRProvider):
         device_name: str,
         namespace_name: str,
         resource_group_name: str,
-        disable: Optional[bool] = None,
+        disable: bool = False,
         **kwargs,
     ):
         """Revoke credentials for a device in the namespace."""
         body = {}
-        if disable is not None:
-            body["disable"] = disable
+        if disable:
+            body["disable"] = True
         with console.status(
             f"Revoking credentials for device '{device_name}' in namespace {namespace_name}..."
         ):

--- a/azext_iot/adr/providers/device.py
+++ b/azext_iot/adr/providers/device.py
@@ -90,6 +90,9 @@ class DeviceProvider(ADRProvider):
         **kwargs,
     ):
         """Revoke credentials for a device in the namespace."""
+        body = {}
+        if disable is not None:
+            body["disable"] = disable
         with console.status(
             f"Revoking credentials for device '{device_name}' in namespace {namespace_name}..."
         ):
@@ -97,6 +100,6 @@ class DeviceProvider(ADRProvider):
                 resource_group_name=resource_group_name,
                 namespace_name=namespace_name,
                 device_name=device_name,
-                body={"disable": disable},
+                body=body,
             )
             return wait_for_terminal_state(poller, **kwargs)

--- a/azext_iot/tests/adr/test_adr_device_unit.py
+++ b/azext_iot/tests/adr/test_adr_device_unit.py
@@ -110,8 +110,14 @@ def test_device_update_all_fields(fixture_device_provider, mock_poller):
     )
 
 
-@pytest.mark.parametrize("disable", [None, True, False])
-def test_device_revoke(fixture_device_provider, mock_poller, disable):
+@pytest.mark.parametrize(
+    "disable, expected_body",
+    [
+        (False, {}),
+        (True, {"disable": True}),
+    ],
+)
+def test_device_revoke(fixture_device_provider, mock_poller, disable, expected_body):
     mock_revoke_result = Mock()
     mock_revoke_result.result = "Succeeded"
     poller = mock_poller(mock_revoke_result)
@@ -129,7 +135,7 @@ def test_device_revoke(fixture_device_provider, mock_poller, disable):
         resource_group_name="test-rg",
         namespace_name="test-namespace",
         device_name="test-device",
-        body={"disable": disable},
+        body=expected_body,
     )
 
 


### PR DESCRIPTION
**Problem:**
The [Swagger spec](https://github.com/Azure/azure-rest-api-specs/blob/e10841fe5bd4efff452e04ca5f4a2685161b4a2d/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/preview/2026-03-01-preview/deviceregistry.json#L5867 ) defines `DeviceCredentialsRevokeRequest.disable` as a non-nullable `boolean` (not required). When the `--disable` flag was omitted by the user, the CLI sent `{"disable": null}` in the request body. 

While the ADR backend accepted the initial POST (202), the `null` value caused the long-running operation to fail during polling with:

```
HttpResponsePayloadAPISpecValidationFailed: Missing required property: result. Paths in payload: '$.result'
```
**Fix:**
Only include `disable` in the request body when explicitly set by the user. When `--disable` is omitted, send `{}` instead of `{"disable": null}`.

The ADR backend also should validate the request payload against the [Swagger spec](https://github.com/Azure/azure-rest-api-specs/blob/e10841fe5bd4efff452e04ca5f4a2685161b4a2d/specification/deviceregistry/resource-manager/Microsoft.DeviceRegistry/preview/2026-03-01-preview/deviceregistry.json#L5867 ) upfront and reject `disable: null` with a clear 400 error on the initial POST, rather than accepting the request and failing silently during the async operation.