### PR TITLE
chore: Bump Minimum Python Version from 3.9 to 3.10

### DIFF
--- a/.azure-devops/integration_tests.yml
+++ b/.azure-devops/integration_tests.yml
@@ -21,7 +21,6 @@ parameters:
     type: string
     default: "3.13"
     values:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -30,10 +29,6 @@ parameters:
     type: object
     default: >
       {
-        Python39:
-        {
-          python: '3.9'
-        },
         Python310:
         {
           python: '3.10'

--- a/.azure-devops/merge.yml
+++ b/.azure-devops/merge.yml
@@ -58,8 +58,6 @@ jobs:
       vmImage: ${{ parameters.linuxImage }}
     strategy:
       matrix:
-        Python39:
-          python.version: "3.9"
         Python310:
           python.version: "3.10"
         Python311:

--- a/.azure-devops/nightly.yml
+++ b/.azure-devops/nightly.yml
@@ -30,7 +30,6 @@ parameters:
     type: string
     default: "3.13"
     values:
-      - "3.9"
       - "3.10"
       - "3.11"
       - "3.12"
@@ -39,10 +38,6 @@ parameters:
     type: object
     default: >
       {
-        Python39:
-        {
-          python: '3.9'
-        },
         Python313:
         {
           python: '3.13'

--- a/.azure-devops/tox.yml
+++ b/.azure-devops/tox.yml
@@ -2,10 +2,6 @@ trigger: none
 pr: none
 
 parameters:
-  - name: python39
-    displayName: "Test Python 3.9"
-    type: boolean
-    default: true
   - name: python310
     displayName: "Test Python 3.10"
     type: boolean
@@ -45,22 +41,6 @@ jobs:
           python: "3.13"
           toxEnvStr: "lint"
           desc: "Flake8, Pylint"
-        ${{ if parameters.python39 }}:
-          ${{ if parameters.azmin }}:
-            "python 3.9 tests, min CLI":
-              python: "3.9"
-              toxEnvStr: "py3.9-azmin-unit"
-              desc: "python 3.9 tests, min CLI"
-          ${{ if parameters.azcur }}:
-            "python 3.9 tests, current CLI":
-              python: "3.9"
-              toxEnvStr: "py3.9-azcur-unit"
-              desc: "Python 3.9 tests, current CLI"
-          ${{ if parameters.azdev }}:
-            "python 3.9 tests, dev CLI":
-              python: "3.9"
-              toxEnvStr: "py3.9-azdev-unit"
-              desc: "Python 3.9 tests, dev CLI"
         ${{ if parameters.python310 }}:
           ${{ if parameters.azmin }}:
             "python 3.10 tests, min CLI":

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -34,7 +34,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
     steps:
       - name: Setup python ${{ matrix.py }}
         uses: actions/setup-python@v5

--- a/.github/workflows/trigger_ado_int_tests.yml
+++ b/.github/workflows/trigger_ado_int_tests.yml
@@ -27,7 +27,6 @@ on:
         type: string
         default: >
           "{
-              Python39: { python: '3.9' },
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
               Python312: { python: '3.12' },
@@ -64,7 +63,6 @@ on:
         type: string
         default: >
           "{
-              Python39: { python: '3.9' },
               Python310: { python: '3.10' },
               Python311: { python: '3.11' },
               Python312: { python: '3.12' },

--- a/azext_iot/sdk/deviceupdate/dataplane/models/_models_py3.py
+++ b/azext_iot/sdk/deviceupdate/dataplane/models/_models_py3.py
@@ -6,7 +6,6 @@
 # --------------------------------------------------------------------------
 
 import datetime
-import sys
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from .. import _serialization
@@ -14,11 +13,8 @@ from .. import _serialization
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
     from .. import models as _models
-if sys.version_info >= (3, 9):
-    from collections.abc import MutableMapping
-else:
-    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
-JSON = MutableMapping[str, Any] # pylint: disable=unsubscriptable-object
+from collections.abc import MutableMapping
+JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class AccessCondition(_serialization.Model):

--- a/azext_iot/sdk/deviceupdate/dataplane/models/_models_py3.py
+++ b/azext_iot/sdk/deviceupdate/dataplane/models/_models_py3.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------
 
 import datetime
+import sys
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from .. import _serialization
@@ -13,8 +14,11 @@ from .. import _serialization
 if TYPE_CHECKING:
     # pylint: disable=unused-import,ungrouped-imports
     from .. import models as _models
-from collections.abc import MutableMapping
-JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
+if sys.version_info >= (3, 9):
+    from collections.abc import MutableMapping
+else:
+    from typing import MutableMapping  # type: ignore  # pylint: disable=ungrouped-imports
+JSON = MutableMapping[str, Any] # pylint: disable=unsubscriptable-object
 
 
 class AccessCondition(_serialization.Model):

--- a/docs/tox-testing.md
+++ b/docs/tox-testing.md
@@ -5,7 +5,6 @@
 Currently, our testing matrix is broken up into the following groups:
 
 - Python versions to run tests:
-    - 3.9
     - 3.10
     - 3.11
     - 3.12
@@ -48,13 +47,12 @@ The [current tox config](../tox.ini) supports local test configurations for the 
 - Various Python and AZ CLI Versions
   - The tox environment string (passed to `-e`) will be parsed as such:
 
-        py{thon,3.9...3.13}-az{min,cur,dev}-{int,unit}
+        py{thon,3.10...3.13}-az{min,cur,dev}-{int,unit}
 
     |Python version | CLI version   | Test type     |
     |---------------|---------------|---------------|
     |"python"|"azmin"|"int"|
-    |"py3.9"|"azdev"|"unit"|
-    |"py3.10"|||
+    |"py3.10"|"azdev"|"unit"|
     |"py3.11"|||
     |"py3.12"|||
     |"py3.13"|||
@@ -70,11 +68,11 @@ The [current tox config](../tox.ini) supports local test configurations for the 
         - Run linters, current python/dev CLI unit tests
     tox -e "python-azcur-unit"
         - Current python interpreter, released azure CLI install, unit tests
-    tox -e "py3.9-azmin-unit"
-        - Python 3.9, min supported CLI, unit tests
-    tox -e "py{3.9,3.13}-az{min,cur}-unit"
-        - Python 3.9, min supported CLI core, unit tests
-        - Python 3.9, currently released CLI core, unit tests
+    tox -e "py3.10-azmin-unit"
+        - Python 3.10, min supported CLI, unit tests
+    tox -e "py{3.10,3.13}-az{min,cur}-unit"
+        - Python 3.10, min supported CLI core, unit tests
+        - Python 3.10, currently released CLI core, unit tests
         - Python 3.13, max supported CLI core, unit tests
         - Python 3.13, currently released CLI core, unit tests
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -81,7 +80,7 @@ short_description = "The Azure IoT extension for Azure CLI."
 setup(
     name=PACKAGE_NAME,
     version=VERSION,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     description=short_description,
     long_description="{} Intended for power users and/or automation of IoT solutions at scale.".format(
         short_description

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ description =
 # int/unit determines test suites to run
 # list all available tox environments with: `tox -av`
     python: Local Python
-    py39: Python 3.9
     py310: Python 3.10
     py311: Python 3.11
     py312: Python 3.12


### PR DESCRIPTION
As described in the title, bump the minimum supported version from 3.9 to 3.10.

 **What was done:**

   - Removed Python 3.9 support from azure-iot-extensions (minimum now 3.10)
   - Tested azure-iot-cli-extension against Python 3.14

 ## Results:

   - Our extension code is fully 3.14 compatible, all imports work, no breaking changes, 931 out of 984 unit tests pass
   - The 53 test failures are all in azure-cli-core (the CLI framework), not our code:
   
**Deprecation warnings:**
   - datetime.utcnow() in our certops.py, Python now says "use datetime.now(datetime.UTC) instead." It still works, just prints a warning. 
   - codecs.open() in our utility.py, Python now says "use the built-in open() instead." Same situation, works now, may break eventually.

Conclusion: Our extensions are ready for Python 3.14. Official support is blocked on the azure-cli updating their repo. 