### PR TITLE
fix(monitor): wire HTTP_PROXY/HTTPS_PROXY env vars to EventHub consumer client

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -432,6 +432,16 @@ def load_arguments(self, _):
             help="Number of telemetry messages to capture before the monitor is terminated. "
             "If not specified, monitor keeps running until meeting the timeout threshold of not receiving messages from hub.",
         )
+        context.argument(
+            "transport",
+            options_list=["--transport", "--tr"],
+            arg_type=get_enum_type(["amqp", "amqp_ws"]),
+            help="Underlying transport protocol for the Event Hub client. "
+            "'amqp_ws' (AMQP over WebSocket) is required when routing through an HTTP proxy "
+            "and may also be preferred in environments where port 5671 is blocked. "
+            "Defaults to 'amqp'. When a proxy is configured via HTTPS_PROXY or HTTP_PROXY "
+            "environment variables, 'amqp_ws' is used automatically.",
+        )
 
     with self.argument_context("iot hub monitor-feedback") as context:
         context.argument(

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -36,6 +36,7 @@ from azext_iot.common.shared import (
 )
 from azext_iot._validators import mode2_iot_login_handler, process_top
 from azext_iot.assets.user_messages import info_param_properties_device
+from azext_iot.monitor.models.enum import Transport
 
 
 dps_auth_type_dataplane_param_type = CLIArgumentType(
@@ -435,7 +436,7 @@ def load_arguments(self, _):
         context.argument(
             "transport",
             options_list=["--transport", "--tr"],
-            arg_type=get_enum_type(["amqp", "amqp_ws"]),
+            arg_type=get_enum_type(Transport),
             help="Underlying transport protocol for the Event Hub client. "
             "'amqp_ws' (AMQP over WebSocket) is required when routing through an HTTP proxy "
             "and may also be preferred in environments where port 5671 is blocked. "

--- a/azext_iot/central/commands_monitor.py
+++ b/azext_iot/central/commands_monitor.py
@@ -35,6 +35,7 @@ def validate_messages(
     minimum_severity=Severity.warning.name,
     token=None,
     central_dns_suffix=CENTRAL_ENDPOINT,
+    transport=None,
 ):
     telemetry_args = TelemetryArguments(
         cmd,
@@ -67,6 +68,7 @@ def validate_messages(
         consumer_group=consumer_group,
         central_dns_suffix=central_dns_suffix,
         central_handler_args=central_handler_args,
+        transport=transport,
     )
     provider.start_validate_messages(telemetry_args)
 

--- a/azext_iot/central/commands_monitor.py
+++ b/azext_iot/central/commands_monitor.py
@@ -84,6 +84,7 @@ def monitor_events(
     yes=False,
     token=None,
     central_dns_suffix=CENTRAL_ENDPOINT,
+    transport=None,
 ):
     telemetry_args = TelemetryArguments(
         cmd,
@@ -116,6 +117,7 @@ def monitor_events(
         consumer_group=consumer_group,
         central_dns_suffix=central_dns_suffix,
         central_handler_args=central_handler_args,
+        transport=transport,
     )
     provider.start_monitor_events(telemetry_args)
 

--- a/azext_iot/central/params.py
+++ b/azext_iot/central/params.py
@@ -18,7 +18,7 @@ from azext_iot.central.common import (
     EnrollmentGroupAttestationType,
 )
 from azure.cli.core.commands.parameters import get_three_state_flag, get_enum_type
-from azext_iot.monitor.models.enum import Severity
+from azext_iot.monitor.models.enum import Severity, Transport
 from azext_iot.central.models.enum import ApiVersion
 from azext_iot._params import event_msg_prop_type, event_timeout_type
 
@@ -339,6 +339,16 @@ def load_central_arguments(self, _):
             "module_id",
             options_list=["--module-id", "-m"],
             help="The IoT Edge Module ID if the device type is IoT Edge.",
+        )
+        context.argument(
+            "transport",
+            options_list=["--transport", "--tr"],
+            arg_type=get_enum_type(Transport),
+            help="Underlying transport protocol for the Event Hub client. "
+            "'amqp_ws' (AMQP over WebSocket) is required when routing through an HTTP proxy "
+            "and may also be preferred in environments where port 5671 is blocked. "
+            "Defaults to 'amqp'. When a proxy is configured via HTTPS_PROXY or HTTP_PROXY "
+            "environment variables, 'amqp_ws' is used automatically.",
         )
 
     with self.argument_context("iot central role") as context:

--- a/azext_iot/central/providers/monitor_provider.py
+++ b/azext_iot/central/providers/monitor_provider.py
@@ -31,6 +31,7 @@ class MonitorProvider:
         consumer_group: str,
         central_handler_args: CentralHandlerArguments,
         central_dns_suffix: str,
+        transport: str = None,
     ):
         central_device_provider = CentralDeviceProvider(
             cmd=cmd, app_id=app_id, token=token, api_version=ApiVersion.ga.value
@@ -44,6 +45,7 @@ class MonitorProvider:
             token=token,
             consumer_group=consumer_group,
             central_dns_suffix=central_dns_suffix,
+            transport=transport,
         )
         self._handler = self._build_handler(
             central_device_provider=central_device_provider,
@@ -81,11 +83,12 @@ class MonitorProvider:
         token: str,
         consumer_group: str,
         central_dns_suffix: str,
+        transport: str = None,
     ):
         from azext_iot.monitor.builders import central_target_builder
 
         targets = central_target_builder.build_central_event_hub_targets(
-            cmd, app_id, token, central_dns_suffix
+            cmd, app_id, token, central_dns_suffix, transport=transport
         )
         [target.add_consumer_group(consumer_group) for target in targets]
 

--- a/azext_iot/central/providers/monitor_provider.py
+++ b/azext_iot/central/providers/monitor_provider.py
@@ -47,6 +47,7 @@ class MonitorProvider:
             central_dns_suffix=central_dns_suffix,
             transport=transport,
         )
+        self._transport = transport
         self._handler = self._build_handler(
             central_device_provider=central_device_provider,
             central_template_provider=central_template_provider,
@@ -63,6 +64,7 @@ class MonitorProvider:
             on_start_string=self._handler.generate_startup_string("Monitoring"),
             on_message_received=self._handler.parse_message,
             timeout=telemetry_args.timeout,
+            transport=self._transport,
         )
 
     def start_validate_messages(self, telemetry_args: TelemetryArguments):
@@ -74,6 +76,7 @@ class MonitorProvider:
             on_start_string=self._handler.generate_startup_string("Validating"),
             on_message_received=self._handler.validate_message,
             timeout=telemetry_args.timeout,
+            transport=self._transport,
         )
 
     def _build_targets(

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -43,54 +43,31 @@ class IotHubDiscovery(BaseDiscovery):
 
     @classmethod
     def get_target_by_cstring(cls, connection_string: str) -> Dict[str, str]:
-        return IotHubTarget.from_connection_string(cstring=connection_string).as_dict()
-
-    def get_target(
-        self, resource_name: str, resource_group_name: str = None, **kwargs
-    ) -> Dict[str, str]:
-        target = super().get_target(
-            resource_name=resource_name,
-            resource_group_name=resource_group_name,
-            **kwargs,
-        )
-
-        if not (
-            kwargs.get("login")
-            and kwargs.get("include_events")
-            and resource_name
-            and "events" not in target
-        ):
-            return target
-
-        try:
-            normalized_name = resource_name
-            if normalized_name.lower().startswith("https://"):
-                normalized_name = normalized_name[len("https://") :]
-            elif normalized_name.lower().startswith("http://"):
-                normalized_name = normalized_name[len("http://") :]
-
-            if "." in normalized_name:
-                normalized_name = normalized_name.split(".")[0]
-
-            resource = self.find_resource(
-                resource_name=normalized_name, rg=resource_group_name
-            )
-            events = resource.properties.event_hub_endpoints["events"]
-
-            target["events"] = {
-                "endpoint": trim_from_start(events.endpoint, "sb://").strip("/"),
-                "partition_count": events.partition_count,
-                "path": events.path,
-                "partition_ids": events.partition_ids,
+        # If this is an Event Hub connection string (e.g. the IoT Hub built-in endpoint
+        # connection string from the Azure portal), parse it directly.  An EH connection
+        # string uses "Endpoint=" and "EntityPath=" rather than "HostName=", so
+        # IotHubTarget.from_connection_string would raise a ValueError on it.
+        if "EntityPath=" in connection_string and "servicebus.windows.net" in connection_string:
+            from azext_iot.common._azure import parse_event_hub_connection_string
+            parsed = parse_event_hub_connection_string(connection_string)
+            endpoint_raw = parsed.get("Endpoint", "")
+            for prefix in ("sb://", "amqps://"):
+                if endpoint_raw.lower().startswith(prefix):
+                    endpoint_raw = endpoint_raw[len(prefix):]
+                    break
+            hostname = endpoint_raw.rstrip("/")
+            return {
+                "cs": connection_string,
+                "entity": hostname,
+                "name": hostname.split(".")[0],
+                "policy": parsed["SharedAccessKeyName"],
+                "primarykey": parsed["SharedAccessKey"],
+                "events": {
+                    "endpoint": hostname,
+                    "path": parsed["EntityPath"],
+                },
             }
-        except Exception as e:
-            logger.debug(
-                "Unable to hydrate events metadata from ARM for login target '%s': %s",
-                resource_name,
-                e,
-            )
-
-        return target
+        return IotHubTarget.from_connection_string(cstring=connection_string).as_dict()
 
     def _build_target_from_hostname(self, resource_hostname: str) -> Dict[str, str]:
         login = AuthenticationTypeDataplane.login.value

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -44,24 +44,17 @@ class IotHubDiscovery(BaseDiscovery):
     @classmethod
     def get_target_by_cstring(cls, connection_string: str) -> Dict[str, str]:
         # If this is an Event Hub connection string (e.g. the IoT Hub built-in endpoint
-        # connection string from the Azure portal), return a minimal target.  The CS uses
-        # "Endpoint=" and "EntityPath=" rather than "HostName=", so IotHubTarget would
-        # raise a ValueError on it.  Endpoint resolution happens later in EventTargetBuilder.
+        # connection string from the Azure portal), return a minimal placeholder.  The CS
+        # uses "Endpoint=" and "EntityPath=" rather than "HostName=", so IotHubTarget would
+        # raise a ValueError on it.  All parsing and Target construction is deferred to
+        # EventTargetBuilder which detects the EH CS via the "cs" field.
         if "EntityPath=" in connection_string and "servicebus.windows.net" in connection_string:
-            from azext_iot.common._azure import parse_event_hub_connection_string
-            parsed = parse_event_hub_connection_string(connection_string)
-            endpoint_raw = parsed.get("Endpoint", "")
-            for prefix in ("sb://", "amqps://"):
-                if endpoint_raw.lower().startswith(prefix):
-                    endpoint_raw = endpoint_raw[len(prefix):]
-                    break
-            hostname = endpoint_raw.rstrip("/")
             return {
                 "cs": connection_string,
-                "entity": hostname,
-                "name": hostname.split(".")[0],
-                "policy": parsed["SharedAccessKeyName"],
-                "primarykey": parsed["SharedAccessKey"],
+                "entity": "eventhub",
+                "name": "eventhub",
+                "policy": "",
+                "primarykey": "",
             }
         return IotHubTarget.from_connection_string(cstring=connection_string).as_dict()
 

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -44,9 +44,9 @@ class IotHubDiscovery(BaseDiscovery):
     @classmethod
     def get_target_by_cstring(cls, connection_string: str) -> Dict[str, str]:
         # If this is an Event Hub connection string (e.g. the IoT Hub built-in endpoint
-        # connection string from the Azure portal), parse it directly.  An EH connection
-        # string uses "Endpoint=" and "EntityPath=" rather than "HostName=", so
-        # IotHubTarget.from_connection_string would raise a ValueError on it.
+        # connection string from the Azure portal), return a minimal target.  The CS uses
+        # "Endpoint=" and "EntityPath=" rather than "HostName=", so IotHubTarget would
+        # raise a ValueError on it.  Endpoint resolution happens later in EventTargetBuilder.
         if "EntityPath=" in connection_string and "servicebus.windows.net" in connection_string:
             from azext_iot.common._azure import parse_event_hub_connection_string
             parsed = parse_event_hub_connection_string(connection_string)
@@ -62,10 +62,6 @@ class IotHubDiscovery(BaseDiscovery):
                 "name": hostname.split(".")[0],
                 "policy": parsed["SharedAccessKeyName"],
                 "primarykey": parsed["SharedAccessKey"],
-                "events": {
-                    "endpoint": hostname,
-                    "path": parsed["EntityPath"],
-                },
             }
         return IotHubTarget.from_connection_string(cstring=connection_string).as_dict()
 

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -45,6 +45,53 @@ class IotHubDiscovery(BaseDiscovery):
     def get_target_by_cstring(cls, connection_string: str) -> Dict[str, str]:
         return IotHubTarget.from_connection_string(cstring=connection_string).as_dict()
 
+    def get_target(
+        self, resource_name: str, resource_group_name: str = None, **kwargs
+    ) -> Dict[str, str]:
+        target = super().get_target(
+            resource_name=resource_name,
+            resource_group_name=resource_group_name,
+            **kwargs,
+        )
+
+        if not (
+            kwargs.get("login")
+            and kwargs.get("include_events")
+            and resource_name
+            and "events" not in target
+        ):
+            return target
+
+        try:
+            normalized_name = resource_name
+            if normalized_name.lower().startswith("https://"):
+                normalized_name = normalized_name[len("https://") :]
+            elif normalized_name.lower().startswith("http://"):
+                normalized_name = normalized_name[len("http://") :]
+
+            if "." in normalized_name:
+                normalized_name = normalized_name.split(".")[0]
+
+            resource = self.find_resource(
+                resource_name=normalized_name, rg=resource_group_name
+            )
+            events = resource.properties.event_hub_endpoints["events"]
+
+            target["events"] = {
+                "endpoint": trim_from_start(events.endpoint, "sb://").strip("/"),
+                "partition_count": events.partition_count,
+                "path": events.path,
+                "partition_ids": events.partition_ids,
+            }
+        except Exception as e:
+            logger.debug(
+                "Unable to hydrate events metadata from ARM for login target '%s': %s",
+                resource_name,
+                e,
+            )
+
+        return target
+
     def _build_target_from_hostname(self, resource_hostname: str) -> Dict[str, str]:
         login = AuthenticationTypeDataplane.login.value
         target = {}

--- a/azext_iot/monitor/builders/_common.py
+++ b/azext_iot/monitor/builders/_common.py
@@ -40,7 +40,7 @@ async def _query_partition_count(hostname, path, credential, transport=None):
         "consumer_group": "$Default",
         "credential": credential,
     }
-    if transport == Transport.amqp_ws or proxy_settings:
+    if transport == Transport.AMQP_WS or proxy_settings:
         create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
     if proxy_settings:
         create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/builders/_common.py
+++ b/azext_iot/monitor/builders/_common.py
@@ -12,7 +12,7 @@ from azext_iot.monitor.models.target import Target
 from azext_iot.monitor.utility import get_http_proxy_settings
 
 
-async def convert_token_to_target(tokens) -> Target:
+async def convert_token_to_target(tokens, transport=None) -> Target:
     event_hub_token = tokens["eventhubSasToken"]
 
     sas_token = event_hub_token["sasToken"]
@@ -23,13 +23,13 @@ async def convert_token_to_target(tokens) -> Target:
     hostname = url.hostname
 
     credential = AzureSasCredential(sas_token)
-    partition_count = await _query_partition_count(hostname, path, credential)
+    partition_count = await _query_partition_count(hostname, path, credential, transport=transport)
     partitions = [str(i) for i in range(partition_count)]
 
     return Target(hostname=hostname, path=path, partitions=partitions, sas_credential=credential)
 
 
-async def _query_partition_count(hostname, path, credential):
+async def _query_partition_count(hostname, path, credential, transport=None):
     fully_qualified_namespace = hostname
     proxy_settings = get_http_proxy_settings()
 
@@ -39,9 +39,10 @@ async def _query_partition_count(hostname, path, credential):
         "consumer_group": "$Default",
         "credential": credential,
     }
+    if transport == "amqp_ws" or proxy_settings:
+        create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
     if proxy_settings:
         create_kwargs["http_proxy"] = proxy_settings
-        create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
 
     client = EventHubConsumerClient(**create_kwargs)
 

--- a/azext_iot/monitor/builders/_common.py
+++ b/azext_iot/monitor/builders/_common.py
@@ -8,6 +8,7 @@ import urllib
 from azure.eventhub.aio import EventHubConsumerClient
 from azure.eventhub import TransportType
 from azure.core.credentials import AzureSasCredential
+from azext_iot.monitor.models.enum import Transport
 from azext_iot.monitor.models.target import Target
 from azext_iot.monitor.utility import get_http_proxy_settings
 
@@ -39,7 +40,7 @@ async def _query_partition_count(hostname, path, credential, transport=None):
         "consumer_group": "$Default",
         "credential": credential,
     }
-    if transport == "amqp_ws" or proxy_settings:
+    if transport == Transport.amqp_ws or proxy_settings:
         create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
     if proxy_settings:
         create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/builders/_common.py
+++ b/azext_iot/monitor/builders/_common.py
@@ -6,8 +6,10 @@
 
 import urllib
 from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub import TransportType
 from azure.core.credentials import AzureSasCredential
 from azext_iot.monitor.models.target import Target
+from azext_iot.monitor.utility import get_http_proxy_settings
 
 
 async def convert_token_to_target(tokens) -> Target:
@@ -29,13 +31,19 @@ async def convert_token_to_target(tokens) -> Target:
 
 async def _query_partition_count(hostname, path, credential):
     fully_qualified_namespace = hostname
+    proxy_settings = get_http_proxy_settings()
 
-    client = EventHubConsumerClient(
-        fully_qualified_namespace=fully_qualified_namespace,
-        eventhub_name=path,
-        consumer_group="$Default",
-        credential=credential,
-    )
+    create_kwargs = {
+        "fully_qualified_namespace": fully_qualified_namespace,
+        "eventhub_name": path,
+        "consumer_group": "$Default",
+        "credential": credential,
+    }
+    if proxy_settings:
+        create_kwargs["http_proxy"] = proxy_settings
+        create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
+
+    client = EventHubConsumerClient(**create_kwargs)
 
     try:
         async with client:

--- a/azext_iot/monitor/builders/central_target_builder.py
+++ b/azext_iot/monitor/builders/central_target_builder.py
@@ -13,20 +13,20 @@ from azext_iot.monitor.builders._common import convert_token_to_target
 
 
 def build_central_event_hub_targets(
-    cmd, app_id, aad_token, central_dns_suffix
+    cmd, app_id, aad_token, central_dns_suffix, transport=None
 ) -> List[Target]:
     event_loop = asyncio.get_event_loop()
     return event_loop.run_until_complete(
         _build_central_event_hub_targets_async(
-            cmd, app_id, aad_token, central_dns_suffix
+            cmd, app_id, aad_token, central_dns_suffix, transport=transport
         )
     )
 
 
 async def _build_central_event_hub_targets_async(
-    cmd, app_id, aad_token, central_dns_suffix
+    cmd, app_id, aad_token, central_dns_suffix, transport=None
 ):
     all_tokens = get_iot_central_tokens(cmd, app_id, aad_token, central_dns_suffix)
-    targets = [await convert_token_to_target(token) for token in all_tokens.values()]
+    targets = [await convert_token_to_target(token, transport=transport) for token in all_tokens.values()]
 
     return targets

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -12,6 +12,7 @@ from azure.eventhub.aio import EventHubConsumerClient
 from knack.log import get_logger
 from azext_iot.common.sas_token_auth import SasTokenAuthentication
 from azext_iot.common.utility import url_encode_str
+from azext_iot.monitor.models.enum import Transport
 from azext_iot.monitor.models.target import Target
 from azext_iot.monitor.utility import get_http_proxy_settings
 
@@ -95,7 +96,7 @@ class EventTargetBuilder:
             "eventhub_name": path,
         }
         proxy_settings = get_http_proxy_settings()
-        if transport == "amqp_ws" or proxy_settings:
+        if transport == Transport.amqp_ws or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
@@ -144,7 +145,7 @@ class EventTargetBuilder:
             "consumer_group": "$Default",
         }
         proxy_settings = get_http_proxy_settings()
-        if transport == "amqp_ws" or proxy_settings:
+        if transport == Transport.amqp_ws or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -96,7 +96,7 @@ class EventTargetBuilder:
             "eventhub_name": path,
         }
         proxy_settings = get_http_proxy_settings()
-        if transport == Transport.amqp_ws or proxy_settings:
+        if transport == Transport.AMQP_WS or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
@@ -145,7 +145,7 @@ class EventTargetBuilder:
             "consumer_group": "$Default",
         }
         proxy_settings = get_http_proxy_settings()
-        if transport == Transport.amqp_ws or proxy_settings:
+        if transport == Transport.AMQP_WS or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -42,6 +42,13 @@ class EventTargetBuilder:
         )
 
     async def _build_iot_hub_target_async(self, target):
+        cs = target.get("cs", "")
+        # If the connection string is an Event Hub connection string (e.g. from IoT Hub's
+        # built-in endpoint in the Azure portal), skip the AMQP redirect and connect
+        # directly.  This also ensures proxy settings are applied correctly.
+        if "EntityPath=" in cs and "servicebus.windows.net" in cs and "events" not in target:
+            return await self._build_from_eh_connection_string(cs)
+
         # If events metadata not provided, attempt to discover it via AMQP redirect
         if "events" not in target:
             event_info = await self._evaluate_redirect(target)
@@ -110,6 +117,54 @@ class EventTargetBuilder:
         except Exception as e:
             raise CLIInternalError(
                 f"Unable to query partitions for '{target['entity'].split('.')[0]}': {e}"
+            )
+
+    async def _build_from_eh_connection_string(self, cs: str) -> Target:
+        """Build a Target directly from an Event Hub connection string.
+
+        Parses and connects to the Event Hub endpoint described by *cs*, applying
+        any configured HTTP proxy.  Used when the caller supplies an EH connection
+        string (e.g. from IoT Hub's built-in endpoint in the Azure portal) so that
+        the AMQP link-redirect step can be skipped entirely.
+        """
+        parts = {}
+        for segment in cs.split(";"):
+            if "=" in segment:
+                k, _, v = segment.partition("=")
+                parts[k.strip()] = v.strip()
+
+        endpoint_raw = parts.get("Endpoint", "")
+        for prefix in ("sb://", "amqps://"):
+            if endpoint_raw.lower().startswith(prefix):
+                endpoint_raw = endpoint_raw[len(prefix):]
+                break
+        hostname = endpoint_raw.rstrip("/")
+        entity_path = parts.get("EntityPath", "")
+        sas_key_name = parts.get("SharedAccessKeyName", "")
+        sas_key = parts.get("SharedAccessKey", "")
+
+        create_kwargs = {
+            "consumer_group": "$Default",
+        }
+        proxy_settings = get_http_proxy_settings()
+        if proxy_settings:
+            create_kwargs["http_proxy"] = proxy_settings
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
+
+        client = EventHubConsumerClient.from_connection_string(cs, **create_kwargs)
+        try:
+            async with client:
+                partition_ids = await client.get_partition_ids()
+                return Target(
+                    hostname=hostname,
+                    path=entity_path,
+                    partitions=list(partition_ids),
+                    policy=sas_key_name,
+                    key=sas_key,
+                )
+        except Exception as e:
+            raise CLIInternalError(
+                f"Unable to query partitions from Event Hub endpoint '{hostname}': {e}"
             )
 
     async def _evaluate_redirect(self, target):

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -36,18 +36,18 @@ class EventTargetBuilder:
         self.eventLoop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.eventLoop)
 
-    def build_iot_hub_target(self, target):
+    def build_iot_hub_target(self, target, transport=None):
         return self.eventLoop.run_until_complete(
-            self._build_iot_hub_target_async(target)
+            self._build_iot_hub_target_async(target, transport=transport)
         )
 
-    async def _build_iot_hub_target_async(self, target):
+    async def _build_iot_hub_target_async(self, target, transport=None):
         cs = target.get("cs", "")
         # If the connection string is an Event Hub connection string (e.g. from IoT Hub's
         # built-in endpoint in the Azure portal), skip the AMQP redirect and connect
         # directly.  This also ensures proxy settings are applied correctly.
         if "EntityPath=" in cs and "servicebus.windows.net" in cs and "events" not in target:
-            return await self._build_from_eh_connection_string(cs)
+            return await self._build_from_eh_connection_string(cs, transport=transport)
 
         # If events metadata not provided, attempt to discover it via AMQP redirect
         if "events" not in target:
@@ -95,9 +95,10 @@ class EventTargetBuilder:
             "eventhub_name": path,
         }
         proxy_settings = get_http_proxy_settings()
+        if transport == "amqp_ws" or proxy_settings:
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
-            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
 
         client = EventHubConsumerClient.from_connection_string(
             connection_str,
@@ -119,7 +120,7 @@ class EventTargetBuilder:
                 f"Unable to query partitions for '{target['entity'].split('.')[0]}': {e}"
             )
 
-    async def _build_from_eh_connection_string(self, cs: str) -> Target:
+    async def _build_from_eh_connection_string(self, cs: str, transport=None) -> Target:
         """Build a Target directly from an Event Hub connection string.
 
         Parses and connects to the Event Hub endpoint described by *cs*, applying
@@ -147,9 +148,10 @@ class EventTargetBuilder:
             "consumer_group": "$Default",
         }
         proxy_settings = get_http_proxy_settings()
+        if transport == "amqp_ws" or proxy_settings:
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
-            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
 
         client = EventHubConsumerClient.from_connection_string(cs, **create_kwargs)
         try:

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -7,11 +7,13 @@
 import asyncio
 
 from azure.cli.core.azclierror import CLIInternalError
+from azure.eventhub import TransportType
 from azure.eventhub.aio import EventHubConsumerClient
 from knack.log import get_logger
 from azext_iot.common.sas_token_auth import SasTokenAuthentication
 from azext_iot.common.utility import url_encode_str
 from azext_iot.monitor.models.target import Target
+from azext_iot.monitor.utility import get_http_proxy_settings
 
 logger = get_logger(__name__)
 
@@ -81,10 +83,18 @@ class EventTargetBuilder:
             f"SharedAccessKey={key};"
             f"EntityPath={path}"
         )
+        create_kwargs = {
+            "consumer_group": "$Default",
+            "eventhub_name": path,
+        }
+        proxy_settings = get_http_proxy_settings()
+        if proxy_settings:
+            create_kwargs["http_proxy"] = proxy_settings
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
+
         client = EventHubConsumerClient.from_connection_string(
             connection_str,
-            consumer_group="$Default",
-            eventhub_name=path,
+            **create_kwargs,
         )
 
         try:

--- a/azext_iot/monitor/builders/hub_target_builder.py
+++ b/azext_iot/monitor/builders/hub_target_builder.py
@@ -46,7 +46,7 @@ class EventTargetBuilder:
         # If the connection string is an Event Hub connection string (e.g. from IoT Hub's
         # built-in endpoint in the Azure portal), skip the AMQP redirect and connect
         # directly.  This also ensures proxy settings are applied correctly.
-        if "EntityPath=" in cs and "servicebus.windows.net" in cs and "events" not in target:
+        if "EntityPath=" in cs and "servicebus.windows.net" in cs:
             return await self._build_from_eh_connection_string(cs, transport=transport)
 
         # If events metadata not provided, attempt to discover it via AMQP redirect
@@ -128,21 +128,17 @@ class EventTargetBuilder:
         string (e.g. from IoT Hub's built-in endpoint in the Azure portal) so that
         the AMQP link-redirect step can be skipped entirely.
         """
-        parts = {}
-        for segment in cs.split(";"):
-            if "=" in segment:
-                k, _, v = segment.partition("=")
-                parts[k.strip()] = v.strip()
-
-        endpoint_raw = parts.get("Endpoint", "")
+        from azext_iot.common._azure import parse_event_hub_connection_string
+        parsed = parse_event_hub_connection_string(cs)
+        endpoint_raw = parsed.get("Endpoint", "")
         for prefix in ("sb://", "amqps://"):
             if endpoint_raw.lower().startswith(prefix):
                 endpoint_raw = endpoint_raw[len(prefix):]
                 break
         hostname = endpoint_raw.rstrip("/")
-        entity_path = parts.get("EntityPath", "")
-        sas_key_name = parts.get("SharedAccessKeyName", "")
-        sas_key = parts.get("SharedAccessKey", "")
+        entity_path = parsed["EntityPath"]
+        sas_key_name = parsed["SharedAccessKeyName"]
+        sas_key = parsed["SharedAccessKey"]
 
         create_kwargs = {
             "consumer_group": "$Default",

--- a/azext_iot/monitor/models/enum.py
+++ b/azext_iot/monitor/models/enum.py
@@ -15,5 +15,5 @@ class Severity(IntEnum):
 
 
 class Transport(str, Enum):
-    amqp = "amqp"
-    amqp_ws = "amqp_ws"
+    AMQP = "amqp"
+    AMQP_WS = "amqp_ws"

--- a/azext_iot/monitor/models/enum.py
+++ b/azext_iot/monitor/models/enum.py
@@ -5,10 +5,15 @@
 # --------------------------------------------------------------------------------------------
 
 
-from enum import IntEnum
+from enum import IntEnum, Enum
 
 
 class Severity(IntEnum):
     info = 1
     warning = 2
     error = 3
+
+
+class Transport(str, Enum):
+    amqp = "amqp"
+    amqp_ws = "amqp_ws"

--- a/azext_iot/monitor/telemetry.py
+++ b/azext_iot/monitor/telemetry.py
@@ -28,6 +28,7 @@ def start_single_monitor(
     on_start_string: str,
     on_message_received,
     timeout=0,
+    transport=None,
 ):
     """
     :param on_message_received:
@@ -40,6 +41,7 @@ def start_single_monitor(
         on_start_string=on_start_string,
         on_message_received=on_message_received,
         timeout=timeout,
+        transport=transport,
     )
 
 
@@ -49,6 +51,7 @@ def start_multiple_monitors(
     enqueued_time_utc,
     on_message_received,
     timeout=0,
+    transport=None,
 ):
     """
     :param on_message_received:
@@ -61,6 +64,7 @@ def start_multiple_monitors(
             enqueued_time_utc=enqueued_time_utc,
             on_message_received=on_message_received,
             timeout=timeout,
+            transport=transport,
         )
         for target in targets
     ]
@@ -97,7 +101,7 @@ def start_multiple_monitors(
 
 
 async def _initiate_event_monitor(
-    target: Target, enqueued_time_utc, on_message_received, timeout=0
+    target: Target, enqueued_time_utc, on_message_received, timeout=0, transport=None
 ):
     if not target.partitions:
         logger.warning("No Event Hub partitions found to listen on.")
@@ -123,9 +127,10 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "eventhub_name": target.path,
         }
+        if transport == "amqp_ws" or proxy_settings:
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
-            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
 
         consumer_client = EventHubConsumerClient.from_connection_string(
             connection_str,
@@ -139,9 +144,10 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "credential": target.sas_credential,
         }
+        if transport == "amqp_ws" or proxy_settings:
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
-            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
 
         consumer_client = EventHubConsumerClient(**create_kwargs)
     else:

--- a/azext_iot/monitor/telemetry.py
+++ b/azext_iot/monitor/telemetry.py
@@ -8,6 +8,7 @@ import asyncio
 import sys
 from azure.eventhub.aio import EventHubConsumerClient
 from azure.eventhub import TransportType
+from azext_iot.monitor.models.enum import Transport
 from azure.cli.core.azclierror import CLIInternalError
 from datetime import datetime, timezone
 
@@ -127,7 +128,7 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "eventhub_name": target.path,
         }
-        if transport == "amqp_ws" or proxy_settings:
+        if transport == Transport.amqp_ws or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
@@ -144,7 +145,7 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "credential": target.sas_credential,
         }
-        if transport == "amqp_ws" or proxy_settings:
+        if transport == Transport.amqp_ws or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/telemetry.py
+++ b/azext_iot/monitor/telemetry.py
@@ -128,7 +128,7 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "eventhub_name": target.path,
         }
-        if transport == Transport.amqp_ws or proxy_settings:
+        if transport == Transport.AMQP_WS or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings
@@ -145,7 +145,7 @@ async def _initiate_event_monitor(
             "consumer_group": target.consumer_group,
             "credential": target.sas_credential,
         }
-        if transport == Transport.amqp_ws or proxy_settings:
+        if transport == Transport.AMQP_WS or proxy_settings:
             create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
         if proxy_settings:
             create_kwargs["http_proxy"] = proxy_settings

--- a/azext_iot/monitor/telemetry.py
+++ b/azext_iot/monitor/telemetry.py
@@ -7,6 +7,7 @@
 import asyncio
 import sys
 from azure.eventhub.aio import EventHubConsumerClient
+from azure.eventhub import TransportType
 from azure.cli.core.azclierror import CLIInternalError
 from datetime import datetime, timezone
 
@@ -15,7 +16,7 @@ from knack.log import get_logger
 from typing import List
 from azext_iot.constants import VERSION, USER_AGENT
 from azext_iot.monitor.models.target import Target
-from azext_iot.monitor.utility import get_loop
+from azext_iot.monitor.utility import get_http_proxy_settings, get_loop
 
 logger = get_logger(__name__)
 DEBUG = False
@@ -108,6 +109,8 @@ async def _initiate_event_monitor(
     #   - IoT Central: AzureSasCredential with pre-generated token
     # EventHubSharedKeyCredential has sync/async compatibility issues with aio client
 
+    proxy_settings = get_http_proxy_settings()
+
     if target.policy and target.key:
         # IoT Hub: Use connection string (works with async EventHubConsumerClient)
         connection_str = (
@@ -116,19 +119,31 @@ async def _initiate_event_monitor(
             f"SharedAccessKey={target.key};"
             f"EntityPath={target.path}"
         )
+        create_kwargs = {
+            "consumer_group": target.consumer_group,
+            "eventhub_name": target.path,
+        }
+        if proxy_settings:
+            create_kwargs["http_proxy"] = proxy_settings
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
+
         consumer_client = EventHubConsumerClient.from_connection_string(
             connection_str,
-            consumer_group=target.consumer_group,
-            eventhub_name=target.path,
+            **create_kwargs,
         )
     elif target.sas_credential:
         # IoT Central: Use pre-generated SAS token credential
-        consumer_client = EventHubConsumerClient(
-            fully_qualified_namespace=target.hostname,
-            eventhub_name=target.path,
-            consumer_group=target.consumer_group,
-            credential=target.sas_credential,
-        )
+        create_kwargs = {
+            "fully_qualified_namespace": target.hostname,
+            "eventhub_name": target.path,
+            "consumer_group": target.consumer_group,
+            "credential": target.sas_credential,
+        }
+        if proxy_settings:
+            create_kwargs["http_proxy"] = proxy_settings
+            create_kwargs["transport_type"] = TransportType.AmqpOverWebsocket
+
+        consumer_client = EventHubConsumerClient(**create_kwargs)
     else:
         raise CLIInternalError(
             "Target object is missing authentication credentials. "

--- a/azext_iot/monitor/utility.py
+++ b/azext_iot/monitor/utility.py
@@ -8,6 +8,10 @@ import asyncio
 import os
 from urllib.parse import unquote, urlparse
 
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
 
 def generate_on_start_string(device_id=None):
     device_filter_txt = None
@@ -93,6 +97,11 @@ def get_http_proxy_settings():
 
     parsed = urlparse(proxy_value if "://" in proxy_value else f"http://{proxy_value}")
     if not parsed.hostname or not parsed.port:
+        logger.warning(
+            "Proxy environment variable is set (%r) but could not be parsed "
+            "(hostname or port missing) — proxy will not be used for event monitoring.",
+            proxy_value,
+        )
         return None
 
     proxy_scheme = parsed.scheme or "http"

--- a/azext_iot/monitor/utility.py
+++ b/azext_iot/monitor/utility.py
@@ -96,6 +96,7 @@ def get_http_proxy_settings():
         return None
 
     proxy_scheme = parsed.scheme or "http"
+    # proxy_hostname must include the scheme (e.g. "http://host" not "host").
     settings = {
         "proxy_hostname": f"{proxy_scheme}://{parsed.hostname}",
         "proxy_port": parsed.port,

--- a/azext_iot/monitor/utility.py
+++ b/azext_iot/monitor/utility.py
@@ -5,6 +5,8 @@
 # --------------------------------------------------------------------------------------------
 
 import asyncio
+import os
+from urllib.parse import unquote, urlparse
 
 
 def generate_on_start_string(device_id=None):
@@ -75,3 +77,33 @@ def extract_message_body(message) -> bytes:
             return b''.join(chunks)
         except Exception:
             return b''
+
+
+def get_http_proxy_settings():
+    """Return EventHub-compatible proxy settings from environment variables."""
+    proxy_value = (
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+
+    if not proxy_value:
+        return None
+
+    parsed = urlparse(proxy_value if "://" in proxy_value else f"http://{proxy_value}")
+    if not parsed.hostname or not parsed.port:
+        return None
+
+    proxy_scheme = parsed.scheme or "http"
+    settings = {
+        "proxy_hostname": f"{proxy_scheme}://{parsed.hostname}",
+        "proxy_port": parsed.port,
+    }
+
+    if parsed.username:
+        settings["username"] = unquote(parsed.username)
+    if parsed.password:
+        settings["password"] = unquote(parsed.password)
+
+    return settings

--- a/azext_iot/operations/hub.py
+++ b/azext_iot/operations/hub.py
@@ -2670,6 +2670,7 @@ def iot_hub_monitor_events(
     content_type=None,
     device_query=None,
     message_count: Optional[int] = None,
+    transport=None,
 ):
     try:
         _iot_hub_monitor_events(
@@ -2689,6 +2690,7 @@ def iot_hub_monitor_events(
             content_type=content_type,
             device_query=device_query,
             message_count=message_count,
+            transport=transport,
         )
     except RuntimeError as e:
         raise CLIInternalError(e)
@@ -2757,6 +2759,7 @@ def _iot_hub_monitor_events(
     content_type=None,
     device_query=None,
     message_count: Optional[int] = None,
+    transport=None,
 ):
     (enqueued_time, properties, timeout, output, message_count) = init_monitoring(
         cmd, timeout, properties, enqueued_time, repair, yes, message_count
@@ -2788,7 +2791,7 @@ def _iot_hub_monitor_events(
         CommonHandlerArguments,
     )
 
-    target = hub_target_builder.EventTargetBuilder().build_iot_hub_target(target)
+    target = hub_target_builder.EventTargetBuilder().build_iot_hub_target(target, transport=transport)
     target.add_consumer_group(consumer_group)
 
     on_start_string = generate_on_start_string(device_id=device_id)
@@ -2814,6 +2817,7 @@ def _iot_hub_monitor_events(
         on_start_string=on_start_string,
         on_message_received=handler.parse_message,
         timeout=timeout,
+        transport=transport,
     )
 
 

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -26,7 +26,7 @@ from knack.log import get_logger
 
 logger = get_logger(__name__)
 
-LIVE_CONSUMER_GROUPS = ["test1", "test2", "test3"]
+LIVE_CONSUMER_GROUPS = ["test1", "test2", "test3", "test4"]
 MQTT_PROVIDER_SETUP_TIME = 15
 
 messaging_data_path = get_context_path(__file__, "test_messaging_data.json")
@@ -1241,10 +1241,23 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
                 device_ids,
             )
 
-        # Monitor events with --login parameter
+        # Monitor events with --login parameter (IoT Hub connection string)
         self.command_execute_assert(
             "iot hub monitor-events -t 8 -y -p all --cg {} --et {} --login {}".format(
                 LIVE_CONSUMER_GROUPS[2], enqueued_time, self.connection_string
+            ),
+            device_ids,
+        )
+
+        # Monitor events with --login using an Event Hub connection string
+        # (the built-in endpoint CS available from `az iot hub connection-string show --eh`)
+        eh_cs_output = self.cmd(
+            "iot hub connection-string show -n {} --eh -o json".format(self.entity_name)
+        ).get_output_in_json()
+        eh_cs = eh_cs_output["connectionString"]
+        self.command_execute_assert(
+            "iot hub monitor-events -t 8 -y --cg {} --et {} --login {}".format(
+                LIVE_CONSUMER_GROUPS[3], enqueued_time, eh_cs
             ),
             device_ids,
         )

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -1262,6 +1262,14 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
             device_ids,
         )
 
+        # Monitor events with explicit --transport amqp_ws (AMQP over WebSocket)
+        self.command_execute_assert(
+            "iot hub monitor-events -n {} -g {} --cg {} --et {} -t 8 -y --transport amqp_ws".format(
+                self.entity_name, self.entity_rg, LIVE_CONSUMER_GROUPS[0], enqueued_time
+            ),
+            device_ids,
+        )
+
         enqueued_time = calculate_millisec_since_unix_epoch_utc()
 
         # Send messages that have JSON payload, but do not pass $.ct property

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------------------------
 
 import pytest
-from types import SimpleNamespace
 from azext_iot.iothub.providers.discovery import IotHubDiscovery
 from azext_iot.common._azure import parse_iot_hub_connection_string
 from azext_iot.common.shared import AuthenticationTypeDataplane
@@ -99,39 +98,28 @@ class TestIoTHubDiscovery:
         assert target["secondarykey"] == AuthenticationTypeDataplane.login.value
         assert target["cmd"] == fixture_cmd
 
-    def test_get_target_by_cstring_with_include_events_hydrates_events(
-        self, fixture_cmd, get_mgmt_client, mocker
-    ):
+    def test_get_target_by_eh_connection_string(self, fixture_cmd, get_mgmt_client):
+        """An Event Hub connection string passed as --login is parsed directly without ARM."""
         discovery = IotHubDiscovery(cmd=fixture_cmd)
 
-        fake_login = (
-            "HostName=CoolIoTHub.azure-devices.net;SharedAccessKeyName=iothubowner;"
-            "SharedAccessKey=AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj="
-        )
-
-        fake_events = SimpleNamespace(
-            endpoint="sb://cooliothub.servicebus.windows.net/",
-            partition_count=4,
-            path="cooliothub",
-            partition_ids=["0", "1", "2", "3"],
-        )
-        fake_resource = SimpleNamespace(
-            properties=SimpleNamespace(event_hub_endpoints={"events": fake_events})
-        )
-
-        find_resource = mocker.patch.object(
-            discovery, "find_resource", return_value=fake_resource
+        fake_eh_cs = (
+            "Endpoint=sb://cooliothub.servicebus.windows.net/;"
+            "SharedAccessKeyName=iothubowner;"
+            "SharedAccessKey=AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj=;"
+            "EntityPath=cooliothub"
         )
 
         target = discovery.get_target(
-            resource_name="CoolIoTHub.azure-devices.net",
-            resource_group_name="myrg",
-            login=fake_login,
-            include_events=True,
+            resource_name=None, resource_group_name=None, login=fake_eh_cs
         )
 
-        find_resource.assert_called_once_with(resource_name="CoolIoTHub", rg="myrg")
+        # Ensure no ARM calls are made
+        assert get_mgmt_client.call_count == 0
+
+        assert target["cs"] == fake_eh_cs
+        assert target["entity"] == "cooliothub.servicebus.windows.net"
+        assert target["name"] == "cooliothub"
+        assert target["policy"] == "iothubowner"
+        assert target["primarykey"] == "AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj="
         assert target["events"]["endpoint"] == "cooliothub.servicebus.windows.net"
-        assert target["events"]["partition_count"] == 4
         assert target["events"]["path"] == "cooliothub"
-        assert target["events"]["partition_ids"] == ["0", "1", "2", "3"]

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
@@ -121,5 +121,5 @@ class TestIoTHubDiscovery:
         assert target["name"] == "cooliothub"
         assert target["policy"] == "iothubowner"
         assert target["primarykey"] == "AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj="
-        assert target["events"]["endpoint"] == "cooliothub.servicebus.windows.net"
-        assert target["events"]["path"] == "cooliothub"
+        # Endpoint resolution is deferred to EventTargetBuilder — no 'events' key here
+        assert "events" not in target

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------------------------
 
 import pytest
+from types import SimpleNamespace
 from azext_iot.iothub.providers.discovery import IotHubDiscovery
 from azext_iot.common._azure import parse_iot_hub_connection_string
 from azext_iot.common.shared import AuthenticationTypeDataplane
@@ -97,3 +98,40 @@ class TestIoTHubDiscovery:
         assert target["primarykey"] == AuthenticationTypeDataplane.login.value
         assert target["secondarykey"] == AuthenticationTypeDataplane.login.value
         assert target["cmd"] == fixture_cmd
+
+    def test_get_target_by_cstring_with_include_events_hydrates_events(
+        self, fixture_cmd, get_mgmt_client, mocker
+    ):
+        discovery = IotHubDiscovery(cmd=fixture_cmd)
+
+        fake_login = (
+            "HostName=CoolIoTHub.azure-devices.net;SharedAccessKeyName=iothubowner;"
+            "SharedAccessKey=AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj="
+        )
+
+        fake_events = SimpleNamespace(
+            endpoint="sb://cooliothub.servicebus.windows.net/",
+            partition_count=4,
+            path="cooliothub",
+            partition_ids=["0", "1", "2", "3"],
+        )
+        fake_resource = SimpleNamespace(
+            properties=SimpleNamespace(event_hub_endpoints={"events": fake_events})
+        )
+
+        find_resource = mocker.patch.object(
+            discovery, "find_resource", return_value=fake_resource
+        )
+
+        target = discovery.get_target(
+            resource_name="CoolIoTHub.azure-devices.net",
+            resource_group_name="myrg",
+            login=fake_login,
+            include_events=True,
+        )
+
+        find_resource.assert_called_once_with(resource_name="CoolIoTHub", rg="myrg")
+        assert target["events"]["endpoint"] == "cooliothub.servicebus.windows.net"
+        assert target["events"]["partition_count"] == 4
+        assert target["events"]["path"] == "cooliothub"
+        assert target["events"]["partition_ids"] == ["0", "1", "2", "3"]

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_unit.py
@@ -117,9 +117,9 @@ class TestIoTHubDiscovery:
         assert get_mgmt_client.call_count == 0
 
         assert target["cs"] == fake_eh_cs
-        assert target["entity"] == "cooliothub.servicebus.windows.net"
-        assert target["name"] == "cooliothub"
-        assert target["policy"] == "iothubowner"
-        assert target["primarykey"] == "AB+c/+5nm2XpDXcffhnGhnxz/TVF4m5ag7AuVIGwchj="
+        assert target["entity"] == "eventhub"
+        assert target["name"] == "eventhub"
+        assert target["policy"] == ""
+        assert target["primarykey"] == ""
         # Endpoint resolution is deferred to EventTargetBuilder — no 'events' key here
         assert "events" not in target

--- a/azext_iot/tests/utility/test_monitor_parsers_unit.py
+++ b/azext_iot/tests/utility/test_monitor_parsers_unit.py
@@ -793,3 +793,94 @@ class TestMonitorProxySupport:
         assert captured["kwargs"]["http_proxy"]["proxy_hostname"] == "http://proxy.local"
         assert captured["kwargs"]["http_proxy"]["proxy_port"] == 8888
         assert captured["kwargs"]["transport_type"] == TransportType.AmqpOverWebsocket
+
+    async def _run_initiate_with_transport(self, target, transport):
+        await telemetry._initiate_event_monitor(
+            target=target,
+            enqueued_time_utc=0,
+            on_message_received=lambda _: None,
+            timeout=10,
+            transport=transport,
+        )
+
+    def test_transport_amqp_ws_sets_websocket_without_proxy(self, mocker, monkeypatch):
+        """--transport amqp_ws forces AmqpOverWebsocket even when no proxy is set."""
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+
+        target = Target(
+            hostname="testhub1234.azure-devices.net",
+            path="messages/events",
+            partitions=["0"],
+            policy="iothubowner",
+            key="abc",
+        )
+        target.add_consumer_group("$Default")
+
+        captured = {}
+
+        def fake_from_connection_string(connection_str, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        async def fake_monitor_events(**kwargs):
+            return None
+
+        mocker.patch.object(
+            telemetry.EventHubConsumerClient,
+            "from_connection_string",
+            side_effect=fake_from_connection_string,
+        )
+        mocker.patch.object(
+            telemetry, "_monitor_events", side_effect=fake_monitor_events
+        )
+
+        import asyncio
+
+        asyncio.run(self._run_initiate_with_transport(target, "amqp_ws"))
+
+        assert captured["kwargs"].get("transport_type") == TransportType.AmqpOverWebsocket
+        assert "http_proxy" not in captured["kwargs"]
+
+    def test_transport_amqp_does_not_set_websocket(self, mocker, monkeypatch):
+        """--transport amqp (default) does not set AmqpOverWebsocket when no proxy."""
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+
+        target = Target(
+            hostname="testhub1234.azure-devices.net",
+            path="messages/events",
+            partitions=["0"],
+            policy="iothubowner",
+            key="abc",
+        )
+        target.add_consumer_group("$Default")
+
+        captured = {}
+
+        def fake_from_connection_string(connection_str, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        async def fake_monitor_events(**kwargs):
+            return None
+
+        mocker.patch.object(
+            telemetry.EventHubConsumerClient,
+            "from_connection_string",
+            side_effect=fake_from_connection_string,
+        )
+        mocker.patch.object(
+            telemetry, "_monitor_events", side_effect=fake_monitor_events
+        )
+
+        import asyncio
+
+        asyncio.run(self._run_initiate_with_transport(target, "amqp"))
+
+        assert "transport_type" not in captured["kwargs"]
+        assert "http_proxy" not in captured["kwargs"]

--- a/azext_iot/tests/utility/test_monitor_parsers_unit.py
+++ b/azext_iot/tests/utility/test_monitor_parsers_unit.py
@@ -10,16 +10,21 @@ import pytest
 
 from unittest import mock
 from azure.eventhub import EventData
+from azure.eventhub import TransportType
 from azext_iot.central.providers import (
     CentralDeviceProvider,
     CentralDeviceTemplateProvider,
 )
 from azext_iot.central.models.v2022_06_30_preview import TemplatePreview
 from azext_iot.central.models.ga_2022_07_31 import DeviceGa
+from azext_iot.monitor import telemetry
+from azext_iot.monitor.builders import _common
+from azext_iot.monitor.models.target import Target
 from azext_iot.monitor.parsers import common_parser, central_parser
 from azext_iot.monitor.parsers import strings
 from azext_iot.monitor.models.arguments import CommonParserArguments
 from azext_iot.monitor.models.enum import Severity
+from azext_iot.monitor.utility import get_http_proxy_settings
 from azext_iot.tests.helpers import load_json
 from azext_iot.tests.test_constants import FileNames
 
@@ -674,3 +679,117 @@ class TestCentralParser:
             central_template_provider=template_provider,
             common_parser_args=args,
         )
+
+
+class TestMonitorProxySupport:
+    def test_get_http_proxy_settings_prefers_https(self, monkeypatch):
+        monkeypatch.setenv("HTTP_PROXY", "http://http-proxy.local:8080")
+        monkeypatch.setenv("HTTPS_PROXY", "http://https-proxy.local:8443")
+
+        result = get_http_proxy_settings()
+
+        assert result["proxy_hostname"] == "http://https-proxy.local"
+        assert result["proxy_port"] == 8443
+
+    def test_get_http_proxy_settings_falls_back_to_http(self, monkeypatch):
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.setenv(
+            "HTTP_PROXY", "http://user%40name:p%40ss@http-proxy.local:8080"
+        )
+
+        result = get_http_proxy_settings()
+
+        assert result["proxy_hostname"] == "http://http-proxy.local"
+        assert result["proxy_port"] == 8080
+        assert result["username"] == "user@name"
+        assert result["password"] == "p@ss"
+
+    def test_get_http_proxy_settings_returns_none_for_invalid(self, monkeypatch):
+        monkeypatch.setenv("HTTPS_PROXY", "https://proxy.local")
+
+        assert get_http_proxy_settings() is None
+
+    async def _run_initiate(self, target):
+        await telemetry._initiate_event_monitor(
+            target=target,
+            enqueued_time_utc=0,
+            on_message_received=lambda _: None,
+            timeout=10,
+        )
+
+    def test_initiate_event_monitor_passes_http_proxy(self, mocker, monkeypatch):
+        target = Target(
+            hostname="testhub1234.azure-devices.net",
+            path="messages/events",
+            partitions=["0"],
+            policy="iothubowner",
+            key="abc",
+        )
+        target.add_consumer_group("$Default")
+
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:3128")
+
+        captured = {}
+
+        def fake_from_connection_string(connection_str, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        async def fake_monitor_events(**kwargs):
+            return None
+
+        mocker.patch.object(
+            telemetry.EventHubConsumerClient,
+            "from_connection_string",
+            side_effect=fake_from_connection_string,
+        )
+        mocker.patch.object(
+            telemetry, "_monitor_events", side_effect=fake_monitor_events
+        )
+
+        import asyncio
+
+        asyncio.run(self._run_initiate(target))
+
+        assert "http_proxy" in captured["kwargs"]
+        assert captured["kwargs"]["http_proxy"]["proxy_hostname"] == "http://proxy.local"
+        assert captured["kwargs"]["http_proxy"]["proxy_port"] == 3128
+        assert captured["kwargs"]["transport_type"] == TransportType.AmqpOverWebsocket
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get_partition_ids(self):
+            return ["0", "1"]
+
+    def test_query_partition_count_passes_http_proxy(self, mocker, monkeypatch):
+        monkeypatch.setenv("HTTP_PROXY", "http://proxy.local:8888")
+
+        captured = {}
+
+        def fake_eventhub_consumer_client(**kwargs):
+            captured["kwargs"] = kwargs
+            return self._FakeClient()
+
+        mocker.patch.object(
+            _common,
+            "EventHubConsumerClient",
+            side_effect=fake_eventhub_consumer_client,
+        )
+
+        import asyncio
+
+        count = asyncio.run(
+            _common._query_partition_count("host.servicebus.windows.net", "path", object())
+        )
+
+        assert count == 2
+        assert "http_proxy" in captured["kwargs"]
+        assert captured["kwargs"]["http_proxy"]["proxy_hostname"] == "http://proxy.local"
+        assert captured["kwargs"]["http_proxy"]["proxy_port"] == 8888
+        assert captured["kwargs"]["transport_type"] == TransportType.AmqpOverWebsocket

--- a/azext_iot/tests/utility/test_monitor_parsers_unit.py
+++ b/azext_iot/tests/utility/test_monitor_parsers_unit.py
@@ -708,7 +708,13 @@ class TestMonitorProxySupport:
     def test_get_http_proxy_settings_returns_none_for_invalid(self, monkeypatch):
         monkeypatch.setenv("HTTPS_PROXY", "https://proxy.local")
 
-        assert get_http_proxy_settings() is None
+        from unittest.mock import patch
+        with patch("azext_iot.monitor.utility.logger") as mock_logger:
+            result = get_http_proxy_settings()
+            assert result is None
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "proxy" in warning_msg.lower()
 
     async def _run_initiate(self, target):
         await telemetry._initiate_event_monitor(

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ DEPENDENCIES = [
     "treelib~=1.6",
     "packaging>=23.2",
     "azure-eventhub~=5.15.0",
+    # aiohttp is required by azure-eventhub for async AMQP over WebSocket transport (used when proxy is configured).
+    # azure-eventhub does not include it as an extras dependency, so it must be declared explicitly.
     "aiohttp>=3.9,<4.0",
 ]
 EXTRAS = {}

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ DEPENDENCIES = [
     "treelib~=1.6",
     "packaging>=23.2",
     "azure-eventhub~=5.15.0",
+    "aiohttp>=3.9,<4.0",
 ]
 EXTRAS = {}
 


### PR DESCRIPTION
1. Added proxy support — monitor-events now reads HTTPS_PROXY/HTTP_PROXY env vars and passes them to the EventHub consumer client, consistent with other commands in the extension.

2. Fixed AMQP WebSocket transport bug — when a proxy is configured, automatically switches to AmqpOverWebsocket and correctly formats proxy_hostname with the URL scheme (e.g. http://host), fixing the EventHubError('host:port\nhost:port') bug in pyamqp.

3. Added aiohttp dependency + login discovery fallback — aiohttp is required for async WebSocket transport; also improved --login target discovery to hydrate Event Hub metadata from ARM when the connection string path lacks it.


Testing:
Successfully ran integration test, unit tests and live commands.

<img width="1981" height="805" alt="image" src="https://github.com/user-attachments/assets/4fe6911d-fad9-4465-a8d2-522eaff0a132" />


---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to the IoT extension!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
