### PR TITLE
chore: replace deprecated datetime and codecs calls

### DIFF
--- a/azext_iot/common/certops.py
+++ b/azext_iot/common/certops.py
@@ -59,9 +59,9 @@ def create_self_signed_certificate(
         .issuer_name(subject_name)
         .public_key(key.public_key())
         .serial_number(serial)
-        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
         .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=valid_days)
         )
     )
 
@@ -221,9 +221,9 @@ def create_ca_signed_certificate(
         .issuer_name(ca_cert.subject)
         .public_key(private_key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
         .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=valid_days)
         )
         .add_extension(subject_key_id, False)
         .add_extension(authority_key_id, False)

--- a/azext_iot/common/utility.py
+++ b/azext_iot/common/utility.py
@@ -20,7 +20,7 @@ import hmac
 import hashlib
 from typing import Any, Optional, List, Dict
 from threading import Event, Thread
-from datetime import datetime
+from datetime import datetime, timezone
 from knack.log import get_logger
 from azure.cli.core.azclierror import (
     CLIInternalError,
@@ -213,12 +213,10 @@ def shell_safe_json_parse(json_or_dict_string, preserve_order=False):
 
 
 def read_file_content(file_path, allow_binary=False):
-    from codecs import open as codecs_open
-
     # Note, always put 'utf-8-sig' first, so that BOM in WinOS won't cause trouble.
     for encoding in ["utf-8-sig", "utf-8", "utf-16", "utf-16le", "utf-16be"]:
         try:
-            with codecs_open(file_path, encoding=encoding) as f:
+            with open(file_path, encoding=encoding) as f:
                 logger.debug("Attempting to read file %s as %s", file_path, encoding)
                 return f.read()
         except (UnicodeError, UnicodeDecodeError):
@@ -446,8 +444,8 @@ def dict_transform_lower_case_key(d):
 
 
 def calculate_millisec_since_unix_epoch_utc(offset_seconds: int = 0):
-    now = datetime.utcnow()
-    epoch = datetime.utcfromtimestamp(0)
+    now = datetime.now(timezone.utc)
+    epoch = datetime.fromtimestamp(0, tz=timezone.utc)
     return int(1000 * ((now - epoch).total_seconds() + offset_seconds))
 
 
@@ -673,7 +671,7 @@ def generate_storage_account_sas_token(
     list: bool = False,
     delete: bool = False,
 ):
-    from datetime import datetime, timedelta
+    from datetime import timedelta
     ensure_azure_namespace_path()
     from azure.storage.blob import ResourceTypes, AccountSasPermissions, generate_account_sas, BlobServiceClient
 
@@ -686,7 +684,7 @@ def generate_storage_account_sas_token(
         permission=AccountSasPermissions(
             read=read, write=write, create=create, update=update, add=add, list=list, delete=delete
         ),
-        expiry=datetime.utcnow() + timedelta(hours=expiry_in_hours)
+        expiry=datetime.now(timezone.utc) + timedelta(hours=expiry_in_hours)
     )
 
     return sas_token

--- a/azext_iot/deviceupdate/commands_update.py
+++ b/azext_iot/deviceupdate/commands_update.py
@@ -234,7 +234,7 @@ def manifest_init_v5(
     deployable: bool = None,
     no_validation: Optional[bool] = None,
 ):
-    from datetime import datetime
+    from datetime import datetime, timezone
     from pathlib import PurePath
     from azure.cli.core.azclierror import ArgumentUsageError
     from azext_iot.deviceupdate.common import FP_HANDLERS_REQUIRE_CRITERIA
@@ -279,7 +279,7 @@ def manifest_init_v5(
 
     payload = {}
     payload["manifestVersion"] = "5.0"
-    payload["createdDateTime"] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    payload["createdDateTime"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     payload["updateId"] = {}
     payload["updateId"]["name"] = update_name
     payload["updateId"]["provider"] = update_provider
@@ -487,7 +487,7 @@ def stage_update(
     from azure.storage.blob import ResourceTypes, AccountSasPermissions, generate_account_sas
     from azure.core.exceptions import ResourceExistsError
     from pathlib import PurePath
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     cli = EmbeddedCLI()
     # If the user is not logged in, 'account show' will fail asking the user to login
@@ -517,7 +517,7 @@ def stage_update(
                     name=f"{container_directory}{file_name}", data=data, overwrite=overwrite
                 )
 
-            target_datetime_expiry = datetime.utcnow() + timedelta(hours=3.0)
+            target_datetime_expiry = datetime.now(timezone.utc) + timedelta(hours=3.0)
             sas_token = generate_account_sas(
                 account_name=blob_service_client.credential.account_name,
                 account_key=blob_service_client.credential.account_key,

--- a/azext_iot/iothub/providers/device_messaging.py
+++ b/azext_iot/iothub/providers/device_messaging.py
@@ -377,7 +377,7 @@ class DeviceMessagingProvider(IoTHubProvider):
                 self.calls += 1
                 payload = {
                     "id": str(uuid.uuid4()),
-                    "timestamp": str(datetime.datetime.utcnow()),
+                    "timestamp": str(datetime.datetime.now(datetime.timezone.utc)),
                     "data": str(data + " #{}".format(self.calls)),
                 }
                 return json.dumps(payload) if jsonify else payload

--- a/azext_iot/tests/deviceupdate/test_adu_update_int.py
+++ b/azext_iot/tests/deviceupdate/test_adu_update_int.py
@@ -611,7 +611,7 @@ def _stage_update_assets(file_paths: List[str], storage_account_id: str, storage
             f"--connection-string '{storage_account_cstring}' -n {file_name}"
         ).success()
 
-        target_datetime_expiry = (datetime.utcnow() + timedelta(hours=3.0)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        target_datetime_expiry = (datetime.now(timezone.utc) + timedelta(hours=3.0)).strftime("%Y-%m-%dT%H:%M:%SZ")
         file_sas_uri = cli.invoke(
             f"storage blob generate-sas --connection-string '{storage_account_cstring}' --container {storage_container} "
             f"--name {file_name} --permissions r --expiry {target_datetime_expiry} "

--- a/azext_iot/tests/test_utils.py
+++ b/azext_iot/tests/test_utils.py
@@ -88,9 +88,9 @@ def _generate_root_certificate(subject: str, valid_days: int, key: rsa.RSAPrivat
         .issuer_name(subject_name)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
         .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=valid_days)
         )
         .add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False
@@ -151,9 +151,9 @@ def _generate_device_certificate(
         .issuer_name(root_cert.issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
         .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=valid_days)
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=valid_days)
         )
         .add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False


### PR DESCRIPTION
## Replace deprecated Python APIs to eliminate deprecation warnings on Python 3.12 <= version <= 3.14:

   - `datetime.utcnow()` -> `datetime.now(timezone.utc)` (deprecated since Python 3.12 https://docs.python.org/3.14/library/datetime.html#datetime.datetime.utcnow
   - codecs.open() - built-in open() (deprecated since Python 3.14)

Before:
<img width="1784" height="504" alt="image" src="https://github.com/user-attachments/assets/1456d2c1-c608-47ad-9582-808a0a9b4bf0" />

Now:
<img width="1786" height="1115" alt="image" src="https://github.com/user-attachments/assets/43176780-0ca9-4e42-9811-1cb501b89cab" />

 No behavioral change, all replacements produce identical output.