### PR TITLE
feat: add --hostname-type param for DPS

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -1158,6 +1158,16 @@ def load_arguments(self, _):
             help="ADR Namespace Credential Policy Name.",
             arg_group="ADR Credential Policy"
         )
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(["auto", "classic", "device"]),
+            default=HostnameType.AUTO.value,
+            help="Type of IoT Hub hostname to show in enrollment results. "
+            "'auto' uses the TLS 1.3 device hostname (default). "
+            "'classic' uses the default hostname. "
+            "'device' uses the TLS 1.3 device hostname.",
+        )
 
     with self.argument_context("iot dps enrollment create") as context:
         context.argument(
@@ -1211,6 +1221,16 @@ def load_arguments(self, _):
             "registration_id",
             options_list=["--enrollment-id", "--eid"],
             help="Individual device enrollment ID."
+        )
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(["auto", "classic", "device"]),
+            default=HostnameType.AUTO.value,
+            help="Type of IoT Hub hostname to show in registration results. "
+            "'auto' uses the TLS 1.3 device hostname (default). "
+            "'classic' uses the default hostname. "
+            "'device' uses the TLS 1.3 device hostname.",
         )
 
     with self.argument_context("iot dps enrollment-group") as context:
@@ -1270,6 +1290,16 @@ def load_arguments(self, _):
             help="ADR Namespace Credential Policy Name.",
             arg_group="ADR Credential Policy"
         )
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(["auto", "classic", "device"]),
+            default=HostnameType.AUTO.value,
+            help="Type of IoT Hub hostname to show in enrollment group results. "
+            "'auto' uses the TLS 1.3 device hostname (default). "
+            "'classic' uses the default hostname. "
+            "'device' uses the TLS 1.3 device hostname.",
+        )
 
     with self.argument_context("iot dps enrollment-group show") as context:
         context.argument(
@@ -1291,6 +1321,18 @@ def load_arguments(self, _):
 
     with self.argument_context("iot dps registration") as context:
         context.argument("registration_id", help="ID of device registration.")
+
+    with self.argument_context("iot dps enrollment-group registration") as context:
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(["auto", "classic", "device"]),
+            default=HostnameType.AUTO.value,
+            help="Type of IoT Hub hostname to show in registration results. "
+            "'auto' uses the TLS 1.3 device hostname (default). "
+            "'classic' uses the default hostname. "
+            "'device' uses the TLS 1.3 device hostname.",
+        )
 
     with self.argument_context("iot dps registration list") as context:
         context.argument(

--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -1321,6 +1321,16 @@ def load_arguments(self, _):
 
     with self.argument_context("iot dps registration") as context:
         context.argument("registration_id", help="ID of device registration.")
+        context.argument(
+            "hostname_type",
+            options_list=["--hostname-type", "--ht"],
+            arg_type=get_enum_type(["auto", "classic", "device"]),
+            default=HostnameType.AUTO.value,
+            help="Type of IoT Hub hostname to show in registration results. "
+            "'auto' uses the TLS 1.3 device hostname (default). "
+            "'classic' uses the default hostname. "
+            "'device' uses the TLS 1.3 device hostname.",
+        )
 
     with self.argument_context("iot dps enrollment-group registration") as context:
         context.argument(

--- a/azext_iot/common/shared.py
+++ b/azext_iot/common/shared.py
@@ -86,6 +86,15 @@ class HostnameType(Enum):
     SERVICE = "service"
 
 
+class GatewayVersion(Enum):
+    """
+    IoT Hub gateway version.
+    """
+
+    V1 = "V1"
+    V2 = "V2"
+
+
 class AttestationType(Enum):
     """
     Type of atestation (TMP or certificate based).

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -99,12 +99,7 @@ def _enum_to_str(value):
     if isinstance(value, Enum):
         return value.value
     s = str(value)
-    return s.split(".")[-1] if "." in s else s
-
-
-def _strip_none(d):
-    """Remove None values from a dict for modelless SDK serialization."""
-    return {k: v for k, v in d.items() if v is not None}
+    return s.rsplit(".", maxsplit=1)[-1] if "." in s else s
 
 
 def iot_dps_create(
@@ -129,9 +124,9 @@ def iot_dps_create(
     cli_ctx = cmd.cli_ctx
     _check_dps_name_availability(client.iot_dps_resource, dps_name)
     location = _ensure_location(cli_ctx, resource_group_name, location)
-    dps_property = {}
-    if enable_data_residency is not None:
-        dps_property["enableDataResidency"] = enable_data_residency
+    dps_property = {
+        "enableDataResidency": enable_data_residency,
+    }
 
     # TODO - CMS Preview - DPS ADR properties
     if adr_ns_id:
@@ -149,11 +144,10 @@ def iot_dps_create(
     sku_name = _enum_to_str(sku)
     dps_description = {
         "location": location,
-        "properties": _strip_none(dps_property),
+        "properties": dps_property,
         "sku": {"name": sku_name, "capacity": unit},
+        "tags": tags,
     }
-    if tags:
-        dps_description["tags"] = tags
 
     if mi_system_assigned is not None or mi_user_assigned:
         dps_description["identity"] = _construct_identity_info(mi_system_assigned, mi_user_assigned)
@@ -749,15 +743,15 @@ def iot_hub_create(
                                                 "ttlAsIso8601": timedelta(hours=fileupload_notification_ttl),
                                                 "lockDurationAsIso8601": timedelta(seconds=fileupload_notification_lock_duration)}
     storage_endpoint_dic = {}
-    storage_endpoint_dic['$default'] = _strip_none({
+    storage_endpoint_dic['$default'] = {
         "sasTtlAsIso8601": timedelta(hours=fileupload_sas_ttl),
         "connectionString": fileupload_storage_connectionstring or '',
         "containerName": fileupload_storage_container_name or '',
         "authenticationType": _enum_to_str(fileupload_storage_authentication_type) if fileupload_storage_authentication_type else None,
         "identity": {"userAssignedIdentity": fileupload_storage_identity} if fileupload_storage_identity else None,
-    })
+    }
 
-    properties = _strip_none({
+    properties = {
         "eventHubEndpoints": event_hub_dic,
         "messagingEndpoints": msg_endpoint_dic,
         "storageEndpoints": storage_endpoint_dic,
@@ -767,7 +761,7 @@ def iot_hub_create(
         "disableLocalAuth": disable_local_auth,
         "disableDeviceSAS": disable_device_sas,
         "disableModuleSAS": disable_module_sas,
-    })
+    }
     properties["enableFileUploadNotifications"] = enable_fileupload_notifications
 
     # TODO - CMS Preview - Hub Create ADR property validation
@@ -778,12 +772,12 @@ def iot_hub_create(
         adr_identity_resource_id=adr_ns_identity_id
     )
 
-    hub_description = _strip_none({
+    hub_description = {
         "location": location,
         "sku": sku,
         "properties": properties,
         "tags": tags,
-    })
+    }
     if (system_identity or user_identities):
         hub_description["identity"] = _build_identity(system=bool(system_identity), identities=user_identities)
     if bool(identity_role) ^ bool(identity_scopes):

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -124,9 +124,7 @@ def iot_dps_create(
     cli_ctx = cmd.cli_ctx
     _check_dps_name_availability(client.iot_dps_resource, dps_name)
     location = _ensure_location(cli_ctx, resource_group_name, location)
-    dps_property = {
-        "enableDataResidency": enable_data_residency,
-    }
+    dps_property = {"enableDataResidency": enable_data_residency}
 
     # TODO - CMS Preview - DPS ADR properties
     if adr_ns_id:
@@ -141,11 +139,10 @@ def iot_dps_create(
             "Device Registry namespace id (--ns-resource-id) is required when specifying namespace user identity."
         )
 
-    sku_name = _enum_to_str(sku)
     dps_description = {
         "location": location,
         "properties": dps_property,
-        "sku": {"name": sku_name, "capacity": unit},
+        "sku": {"name": _enum_to_str(sku), "capacity": unit},
         "tags": tags,
     }
 

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -91,24 +91,13 @@ def iot_dps_get(client, dps_name, resource_group_name=None):
     return client.iot_dps_resource.get(provisioning_service_name=dps_name, resource_group_name=resource_group_name)
 
 
-def _enum_to_str(value):
-    """Extract enum value for modelless SDK serialization.
-
-    CLI argparser may pass enum as 'ClassName.VALUE' string or as Enum instance.
-    """
-    if isinstance(value, Enum):
-        return value.value
-    s = str(value)
-    return s.rsplit(".", maxsplit=1)[-1] if "." in s else s
-
-
 def iot_dps_create(
     cmd,
     client,
     dps_name,
     resource_group_name,
     location=None,
-    sku=IotDpsSku.S1,
+    sku=IotDpsSku.S1.value,
     unit=1,
     tags=None,
     enable_data_residency=None,
@@ -142,7 +131,7 @@ def iot_dps_create(
     dps_description = {
         "location": location,
         "properties": dps_property,
-        "sku": {"name": _enum_to_str(sku), "capacity": unit},
+        "sku": {"name": sku, "capacity": unit},
         "tags": tags,
     }
 
@@ -666,7 +655,7 @@ def iot_hub_create(
     hub_name,
     resource_group_name,
     location=None,
-    sku=IotHubSku.S1,
+    sku=IotHubSku.S1.value,
     unit=1,
     partition_count=4,
     retention_day=1,
@@ -724,7 +713,7 @@ def iot_hub_create(
             "to enable it. Check command help (-h) for more information on this property's usage and implications."
         )
 
-    sku = {"name": _enum_to_str(sku), "capacity": unit}
+    sku = {"name": sku, "capacity": unit}
 
     event_hub_dic = {}
     event_hub_dic['events'] = {"retentionTimeInDays": retention_day,
@@ -744,7 +733,7 @@ def iot_hub_create(
         "sasTtlAsIso8601": timedelta(hours=fileupload_sas_ttl),
         "connectionString": fileupload_storage_connectionstring or '',
         "containerName": fileupload_storage_container_name or '',
-        "authenticationType": _enum_to_str(fileupload_storage_authentication_type) if fileupload_storage_authentication_type else None,
+        "authenticationType": fileupload_storage_authentication_type if fileupload_storage_authentication_type else None,
         "identity": {"userAssignedIdentity": fileupload_storage_identity} if fileupload_storage_identity else None,
     }
 
@@ -929,8 +918,8 @@ def update_iot_hub_custom(instance,
     existing_sku_name = instance["sku"]["name"]
     final_sku_name = sku or existing_sku_name
 
-    is_existing_gen2 = existing_sku_name == IotHubSku.GEN2
-    is_final_gen2 = final_sku_name == IotHubSku.GEN2
+    is_existing_gen2 = existing_sku_name == IotHubSku.GEN2.value
+    is_final_gen2 = final_sku_name == IotHubSku.GEN2.value
 
     if sku and (is_existing_gen2 ^ is_final_gen2):
         raise InvalidArgumentValueError(
@@ -1767,7 +1756,7 @@ def _validate_and_set_adr_properties(
 ):
     """Validate and set Azure Device Registry properties for IoT Hub."""
 
-    if sku == IotHubSku.GEN2:
+    if sku == IotHubSku.GEN2.value:
         # Generation2 hubs require both ADR properties
         if not (adr_namespace_resource_id and adr_identity_resource_id):
             raise RequiredArgumentMissingError(

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -91,6 +91,22 @@ def iot_dps_get(client, dps_name, resource_group_name=None):
     return client.iot_dps_resource.get(provisioning_service_name=dps_name, resource_group_name=resource_group_name)
 
 
+def _enum_to_str(value):
+    """Extract enum value for modelless SDK serialization.
+
+    CLI argparser may pass enum as 'ClassName.VALUE' string or as Enum instance.
+    """
+    if isinstance(value, Enum):
+        return value.value
+    s = str(value)
+    return s.split(".")[-1] if "." in s else s
+
+
+def _strip_none(d):
+    """Remove None values from a dict for modelless SDK serialization."""
+    return {k: v for k, v in d.items() if v is not None}
+
+
 def iot_dps_create(
     cmd,
     client,
@@ -113,7 +129,9 @@ def iot_dps_create(
     cli_ctx = cmd.cli_ctx
     _check_dps_name_availability(client.iot_dps_resource, dps_name)
     location = _ensure_location(cli_ctx, resource_group_name, location)
-    dps_property = {"enableDataResidency": enable_data_residency}
+    dps_property = {}
+    if enable_data_residency is not None:
+        dps_property["enableDataResidency"] = enable_data_residency
 
     # TODO - CMS Preview - DPS ADR properties
     if adr_ns_id:
@@ -128,12 +146,14 @@ def iot_dps_create(
             "Device Registry namespace id (--ns-resource-id) is required when specifying namespace user identity."
         )
 
+    sku_name = _enum_to_str(sku)
     dps_description = {
         "location": location,
-        "properties": dps_property,
-        "sku": {"name": sku, "capacity": unit},
-        "tags": tags,
+        "properties": _strip_none(dps_property),
+        "sku": {"name": sku_name, "capacity": unit},
     }
+    if tags:
+        dps_description["tags"] = tags
 
     if mi_system_assigned is not None or mi_user_assigned:
         dps_description["identity"] = _construct_identity_info(mi_system_assigned, mi_user_assigned)
@@ -713,7 +733,7 @@ def iot_hub_create(
             "to enable it. Check command help (-h) for more information on this property's usage and implications."
         )
 
-    sku = {"name": sku, "capacity": unit}
+    sku = {"name": _enum_to_str(sku), "capacity": unit}
 
     event_hub_dic = {}
     event_hub_dic['events'] = {"retentionTimeInDays": retention_day,
@@ -729,22 +749,25 @@ def iot_hub_create(
                                                 "ttlAsIso8601": timedelta(hours=fileupload_notification_ttl),
                                                 "lockDurationAsIso8601": timedelta(seconds=fileupload_notification_lock_duration)}
     storage_endpoint_dic = {}
-    storage_endpoint_dic['$default'] = {
+    storage_endpoint_dic['$default'] = _strip_none({
         "sasTtlAsIso8601": timedelta(hours=fileupload_sas_ttl),
-        "connectionString": fileupload_storage_connectionstring if fileupload_storage_connectionstring else '',
-        "containerName": fileupload_storage_container_name if fileupload_storage_container_name else '',
-        "authenticationType": fileupload_storage_authentication_type if fileupload_storage_authentication_type else None,
-        "identity": {"userAssignedIdentity": fileupload_storage_identity} if fileupload_storage_identity else None}
+        "connectionString": fileupload_storage_connectionstring or '',
+        "containerName": fileupload_storage_container_name or '',
+        "authenticationType": _enum_to_str(fileupload_storage_authentication_type) if fileupload_storage_authentication_type else None,
+        "identity": {"userAssignedIdentity": fileupload_storage_identity} if fileupload_storage_identity else None,
+    })
 
-    properties = {"eventHubEndpoints": event_hub_dic,
-                    "messagingEndpoints": msg_endpoint_dic,
-                    "storageEndpoints": storage_endpoint_dic,
-                    "cloudToDevice": cloud_to_device_properties,
-                    "minTlsVersion": min_tls_version,
-                    "enableDataResidency": enable_data_residency,
-                    "disableLocalAuth": disable_local_auth,
-                    "disableDeviceSAS": disable_device_sas,
-                    "disableModuleSAS": disable_module_sas}
+    properties = _strip_none({
+        "eventHubEndpoints": event_hub_dic,
+        "messagingEndpoints": msg_endpoint_dic,
+        "storageEndpoints": storage_endpoint_dic,
+        "cloudToDevice": cloud_to_device_properties,
+        "minTlsVersion": min_tls_version,
+        "enableDataResidency": enable_data_residency,
+        "disableLocalAuth": disable_local_auth,
+        "disableDeviceSAS": disable_device_sas,
+        "disableModuleSAS": disable_module_sas,
+    })
     properties["enableFileUploadNotifications"] = enable_fileupload_notifications
 
     # TODO - CMS Preview - Hub Create ADR property validation
@@ -755,10 +778,12 @@ def iot_hub_create(
         adr_identity_resource_id=adr_ns_identity_id
     )
 
-    hub_description = {"location": location,
-                       "sku": sku,
-                       "properties": properties,
-                       "tags": tags}
+    hub_description = _strip_none({
+        "location": location,
+        "sku": sku,
+        "properties": properties,
+        "tags": tags,
+    })
     if (system_identity or user_identities):
         hub_description["identity"] = _build_identity(system=bool(system_identity), identities=user_identities)
     if bool(identity_role) ^ bool(identity_scopes):

--- a/azext_iot/core/shared.py
+++ b/azext_iot/core/shared.py
@@ -91,7 +91,7 @@ class ManagedServiceIdentityType(str, Enum):
     SYSTEM_ASSIGNED_USER_ASSIGNED = "SystemAssigned,UserAssigned"
 
 
-class IotHubSku(str, Enum):
+class IotHubSku(Enum):
     """The name of the IoT Hub SKU."""
 
     F1 = "F1"
@@ -104,7 +104,7 @@ class IotHubSku(str, Enum):
     GEN2 = "GEN2"
 
 
-class IotDpsSku(str, Enum):
+class IotDpsSku(Enum):
     """DPS SKU name."""
 
     S1 = "S1"

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -8,7 +8,7 @@ from knack.log import get_logger
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azext_iot.common._azure import IOT_SERVICE_CS_TEMPLATE
 from azext_iot.common.base_discovery import BaseDiscovery
-from azext_iot.common.shared import DiscoveryResourceType, AuthenticationTypeDataplane
+from azext_iot.common.shared import DiscoveryResourceType, AuthenticationTypeDataplane, GatewayVersion
 from azext_iot.common.utility import trim_from_start
 from azext_iot.iothub.models.iothub_target import IotHubTarget
 from azext_iot._factory import iot_hub_service_factory
@@ -77,7 +77,7 @@ class IotHubDiscovery(BaseDiscovery):
         tls_device = props.get("deviceHostName")
         tls_service = props.get("serviceHostName")
         gw_version = props.get("iotHubDetails", {}).get("gatewayVersion")
-        service_hostname = tls_service if gw_version == "V2" else None
+        service_hostname = tls_service if gw_version == GatewayVersion.V2.value else None
         hostname = service_hostname or props.get("hostName")
 
         target = {}

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -21,12 +21,14 @@ from azext_iot.common.shared import (
     ReprovisionType,
     AllocationType,
     KeyType,
-    IoTDPSStateType
+    IoTDPSStateType,
+    HostnameType,
 )
 from azext_iot.common.utility import compute_device_key, handle_service_exception, shell_safe_json_parse
 from azext_iot.common.certops import open_certificate
 from azext_iot.dps.providers.discovery import DPSDiscovery
 from azext_iot.operations.generic import _execute_query
+from azext_iot.operations.hub import _transform_hostname
 from azext_iot._factory import SdkResolver
 from azext_iot.sdk.dps.service.models import (
     IndividualEnrollment,
@@ -54,6 +56,53 @@ def _get_dps_resource_group(dps):
     return getattr(dps, "resourcegroup", None) or dps.additional_properties.get("resourcegroup")
 
 
+def _transform_enrollment_hub_hostnames(result, hostname_type=HostnameType.AUTO.value):
+    """
+    Transform IoT Hub hostnames in enrollment result to the requested type.
+    """
+    if not result:
+        return result
+
+    if hostname_type == HostnameType.AUTO.value:
+        hostname_type = HostnameType.DEVICE.value
+
+    if isinstance(result, list):
+        return [_transform_enrollment_hub_hostnames(item, hostname_type) for item in result]
+
+    if isinstance(result, dict):
+        if result.get("iotHubs"):
+            result["iotHubs"] = [
+                _transform_hostname(h, hostname_type) for h in result["iotHubs"]
+            ]
+    else:
+        if getattr(result, "iot_hubs", None):
+            result.iot_hubs = [
+                _transform_hostname(h, hostname_type) for h in result.iot_hubs
+            ]
+
+    return result
+
+
+def _transform_registration_hub_hostname(result, hostname_type=HostnameType.AUTO.value):
+    """
+    Transform assignedHub hostname in registration state result to the requested type.
+    """
+    if not result:
+        return result
+
+    if hostname_type == HostnameType.AUTO.value:
+        hostname_type = HostnameType.DEVICE.value
+
+    if isinstance(result, list):
+        return [_transform_registration_hub_hostname(item, hostname_type) for item in result]
+
+    if isinstance(result, dict):
+        if result.get("assignedHub"):
+            result["assignedHub"] = _transform_hostname(result["assignedHub"], hostname_type)
+
+    return result
+
+
 # DPS Enrollments
 
 
@@ -62,6 +111,7 @@ def iot_dps_device_enrollment_list(
     dps_name=None,
     resource_group_name=None,
     top=None,
+    hostname_type=None,
     login=None,
     auth_type_dataplane=None,
 ):
@@ -81,7 +131,8 @@ def iot_dps_device_enrollment_list(
 
         query_command = "SELECT *"
         query = [QuerySpecification(query=query_command)]
-        return _execute_query(query, sdk.individual_enrollment.query, top)
+        result = _execute_query(query, sdk.individual_enrollment.query, top)
+        return _transform_enrollment_hub_hostnames(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -92,6 +143,7 @@ def iot_dps_device_enrollment_get(
     dps_name=None,
     resource_group_name=None,
     show_keys=None,
+    hostname_type=None,
     login=None,
     auth_type_dataplane=None,
 ):
@@ -123,7 +175,7 @@ def iot_dps_device_enrollment_get(
                         enrollment_type
                     )
                 )
-        return enrollment
+        return _transform_enrollment_hub_hostnames(enrollment, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -151,6 +203,7 @@ def iot_dps_device_enrollment_create(
     webhook_url=None,
     device_information=None,
     credential_policy_name=None,
+    hostname_type=None,
     api_version=None,
     login=None,
     auth_type_dataplane=None,
@@ -215,7 +268,8 @@ def iot_dps_device_enrollment_create(
             optional_device_information=_get_twin_collection(device_information),
             credential_policy_name=credential_policy_name
         )
-        return sdk.individual_enrollment.create_or_update(enrollment_id, enrollment)
+        result = sdk.individual_enrollment.create_or_update(enrollment_id, enrollment)
+        return _transform_enrollment_hub_hostnames(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -245,6 +299,7 @@ def iot_dps_device_enrollment_update(
     webhook_url=None,
     device_information=None,
     credential_policy_name=None,
+    hostname_type=None,
     api_version=None,
     login=None,
     auth_type_dataplane=None,
@@ -341,8 +396,11 @@ def iot_dps_device_enrollment_update(
         if credential_policy_name is not None:
             enrollment_record.credential_policy_name = credential_policy_name
 
-        return sdk.individual_enrollment.create_or_update(
-            enrollment_id, enrollment_record, if_match=(etag if etag else "*")
+        return _transform_enrollment_hub_hostnames(
+            sdk.individual_enrollment.create_or_update(
+                enrollment_id, enrollment_record, if_match=(etag if etag else "*")
+            ),
+            hostname_type,
         )
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
@@ -377,7 +435,8 @@ def iot_dps_device_enrollment_delete(
 
 
 def iot_dps_device_enrollment_group_list(
-    cmd, dps_name=None, resource_group_name=None, top=None, login=None, auth_type_dataplane=None,
+    cmd, dps_name=None, resource_group_name=None, top=None, hostname_type=None,
+    login=None, auth_type_dataplane=None,
 ):
     from azext_iot.sdk.dps.service.models import QuerySpecification
 
@@ -394,7 +453,8 @@ def iot_dps_device_enrollment_group_list(
 
         query_command = "SELECT *"
         query1 = [QuerySpecification(query=query_command)]
-        return _execute_query(query1, sdk.enrollment_group.query, top)
+        result = _execute_query(query1, sdk.enrollment_group.query, top)
+        return _transform_enrollment_hub_hostnames(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -405,6 +465,7 @@ def iot_dps_device_enrollment_group_get(
     dps_name=None,
     resource_group_name=None,
     show_keys=None,
+    hostname_type=None,
     login=None,
     auth_type_dataplane=None,
 ):
@@ -436,7 +497,7 @@ def iot_dps_device_enrollment_group_get(
                         enrollment_type
                     )
                 )
-        return enrollment_group
+        return _transform_enrollment_hub_hostnames(enrollment_group, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -462,6 +523,7 @@ def iot_dps_device_enrollment_group_create(
     edge_enabled=False,
     webhook_url=None,
     credential_policy_name=None,
+    hostname_type=None,
     api_version=None,
     login=None,
     auth_type_dataplane=None,
@@ -531,7 +593,8 @@ def iot_dps_device_enrollment_group_create(
             custom_allocation_definition=custom_allocation_definition,
             credential_policy_name=credential_policy_name
         )
-        return sdk.enrollment_group.create_or_update(enrollment_id, group_enrollment)
+        result = sdk.enrollment_group.create_or_update(enrollment_id, group_enrollment)
+        return _transform_enrollment_hub_hostnames(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
@@ -560,6 +623,7 @@ def iot_dps_device_enrollment_group_update(
     edge_enabled=None,
     webhook_url=None,
     credential_policy_name=None,
+    hostname_type=None,
     api_version=None,
     login=None,
     auth_type_dataplane=None,
@@ -671,8 +735,11 @@ def iot_dps_device_enrollment_group_update(
             enrollment_record.capabilities = DeviceCapabilities(iot_edge=edge_enabled)
         if credential_policy_name is not None:
             enrollment_record.credential_policy_name = credential_policy_name
-        return sdk.enrollment_group.create_or_update(
-            enrollment_id, enrollment_record, if_match=(etag if etag else "*")
+        return _transform_enrollment_hub_hostnames(
+            sdk.enrollment_group.create_or_update(
+                enrollment_id, enrollment_record, if_match=(etag if etag else "*")
+            ),
+            hostname_type,
         )
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
@@ -843,6 +910,7 @@ def iot_dps_registration_list(
     dps_name=None,
     resource_group_name=None,
     top=None,
+    hostname_type=None,
     login=None,
     auth_type_dataplane=None,
 ):
@@ -856,13 +924,15 @@ def iot_dps_registration_list(
     try:
         resolver = SdkResolver(target=target)
         sdk = resolver.get_sdk(SdkType.dps_sdk)
-        return _execute_query([enrollment_id], sdk.device_registration_state.query, top)
+        result = _execute_query([enrollment_id], sdk.device_registration_state.query, top)
+        return _transform_registration_hub_hostname(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 
 
 def iot_dps_registration_get(
-    cmd, registration_id, dps_name=None, resource_group_name=None, login=None, auth_type_dataplane=None,
+    cmd, registration_id, dps_name=None, resource_group_name=None,
+    hostname_type=None, login=None, auth_type_dataplane=None,
 ):
     discovery = DPSDiscovery(cmd)
     target = discovery.get_target(
@@ -875,9 +945,10 @@ def iot_dps_registration_get(
         resolver = SdkResolver(target=target)
         sdk = resolver.get_sdk(SdkType.dps_sdk)
 
-        return sdk.device_registration_state.get(
+        result = sdk.device_registration_state.get(
             registration_id, raw=True
         ).response.json()
+        return _transform_registration_hub_hostname(result, hostname_type)
     except ProvisioningServiceErrorDetailsException as e:
         handle_service_exception(e)
 

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_unit.py
@@ -652,7 +652,7 @@ class TestEnrollmentDelete():
 
 
 def generate_registration_state_show():
-    payload = {'registrationId': enrollment_id, 'status': 'assigned', 'etag': etag, 'assignedHub': 'myHub',
+    payload = {'registrationId': enrollment_id, 'status': 'assigned', 'etag': etag, 'assignedHub': 'myHub.azure-devices.net',
                'deviceId': 'myDevice'}
     return payload
 

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_unit.py
@@ -673,7 +673,7 @@ class TestEnrollmentGroupDelete():
 
 
 def generate_registration_state_show():
-    payload = {'registrationId': registration_id, 'status': 'assigned', 'etag': etag, 'assignedHub': 'myHub',
+    payload = {'registrationId': registration_id, 'status': 'assigned', 'etag': etag, 'assignedHub': 'myHub.azure-devices.net',
                'deviceId': 'myDevice'}
     return payload
 

--- a/azext_iot/tests/dps/tls13/__init__.py
+++ b/azext_iot/tests/dps/tls13/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------

--- a/azext_iot/tests/dps/tls13/test_dps_tls13_unit.py
+++ b/azext_iot/tests/dps/tls13/test_dps_tls13_unit.py
@@ -1,0 +1,181 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import MagicMock
+from azext_iot.common.shared import HostnameType
+from azext_iot.operations.dps import _transform_enrollment_hub_hostnames, _transform_registration_hub_hostname
+
+
+class TestTransformEnrollmentHubHostnames:
+    """Tests for _transform_enrollment_hub_hostnames — post-processing DPS enrollment results."""
+
+    def test_dict_classic_noop(self):
+        result = {"iotHubs": ["hub1.azure-devices.net"]}
+        transformed = _transform_enrollment_hub_hostnames(result, HostnameType.CLASSIC.value)
+        assert result["iotHubs"] == ["hub1.azure-devices.net"]
+        assert transformed is result
+
+    def test_dict_classic_strips_device_prefix(self):
+        result = {"iotHubs": ["hub1.device.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.CLASSIC.value)
+        assert result["iotHubs"] == ["hub1.azure-devices.net"]
+
+    def test_dict_classic_strips_service_prefix(self):
+        result = {"iotHubs": ["hub1.service.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.CLASSIC.value)
+        assert result["iotHubs"] == ["hub1.azure-devices.net"]
+
+    def test_dict_to_device(self):
+        result = {"iotHubs": ["hub1.azure-devices.net", "hub2.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.DEVICE.value)
+        assert result["iotHubs"] == [
+            "hub1.device.azure-devices.net",
+            "hub2.device.azure-devices.net",
+        ]
+
+    def test_dict_to_service(self):
+        result = {"iotHubs": ["hub1.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.SERVICE.value)
+        assert result["iotHubs"] == ["hub1.service.azure-devices.net"]
+
+    def test_dict_no_iot_hubs_key(self):
+        result = {"registrationId": "test1"}
+        _transform_enrollment_hub_hostnames(result, HostnameType.DEVICE.value)
+        assert "iotHubs" not in result
+
+    def test_dict_empty_iot_hubs(self):
+        result = {"iotHubs": []}
+        _transform_enrollment_hub_hostnames(result, HostnameType.DEVICE.value)
+        assert not result["iotHubs"]
+
+    def test_dict_gov_cloud(self):
+        result = {"iotHubs": ["hub1.azure-devices.us"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.DEVICE.value)
+        assert result["iotHubs"] == ["hub1.device.azure-devices.us"]
+
+    # --- Model object results (from create/update) ---
+
+    def test_model_to_device(self):
+        model = MagicMock()
+        model.iot_hubs = ["hub1.azure-devices.net", "hub2.azure-devices.net"]
+        _transform_enrollment_hub_hostnames(model, HostnameType.DEVICE.value)
+        assert model.iot_hubs == [
+            "hub1.device.azure-devices.net",
+            "hub2.device.azure-devices.net",
+        ]
+
+    def test_model_to_service(self):
+        model = MagicMock()
+        model.iot_hubs = ["hub1.azure-devices.net"]
+        _transform_enrollment_hub_hostnames(model, HostnameType.SERVICE.value)
+        assert model.iot_hubs == ["hub1.service.azure-devices.net"]
+
+    def test_model_none_iot_hubs(self):
+        model = MagicMock()
+        model.iot_hubs = None
+        _transform_enrollment_hub_hostnames(model, HostnameType.DEVICE.value)
+        assert model.iot_hubs is None
+
+    def test_model_classic_noop(self):
+        model = MagicMock()
+        model.iot_hubs = ["hub1.azure-devices.net"]
+        _transform_enrollment_hub_hostnames(model, HostnameType.CLASSIC.value)
+        assert model.iot_hubs == ["hub1.azure-devices.net"]
+
+    # --- List results (from list commands) ---
+
+    def test_list_of_dicts(self):
+        results = [
+            {"iotHubs": ["hub1.azure-devices.net"]},
+            {"iotHubs": ["hub2.azure-devices.net"]},
+        ]
+        transformed = _transform_enrollment_hub_hostnames(results, HostnameType.DEVICE.value)
+        assert transformed[0]["iotHubs"] == ["hub1.device.azure-devices.net"]
+        assert transformed[1]["iotHubs"] == ["hub2.device.azure-devices.net"]
+
+    def test_list_classic_noop(self):
+        results = [{"iotHubs": ["hub1.azure-devices.net"]}]
+        transformed = _transform_enrollment_hub_hostnames(results, HostnameType.CLASSIC.value)
+        assert transformed[0]["iotHubs"] == ["hub1.azure-devices.net"]
+
+    def test_empty_list(self):
+        assert not _transform_enrollment_hub_hostnames([], HostnameType.DEVICE.value)
+
+    # --- Edge cases ---
+
+    def test_none_result(self):
+        assert _transform_enrollment_hub_hostnames(None, HostnameType.DEVICE.value) is None
+
+    def test_default_resolves_to_device(self):
+        result = {"iotHubs": ["hub1.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result)
+        assert result["iotHubs"] == ["hub1.device.azure-devices.net"]
+
+    def test_auto_resolves_to_device(self):
+        result = {"iotHubs": ["hub1.azure-devices.net"]}
+        _transform_enrollment_hub_hostnames(result, HostnameType.AUTO.value)
+        assert result["iotHubs"] == ["hub1.device.azure-devices.net"]
+
+    def test_multiple_hubs_mixed_domains(self):
+        result = {
+            "iotHubs": [
+                "hub1.azure-devices.net",
+                "hub2.azure-devices.us",
+                "hub3.azure-devices.cn",
+            ],
+        }
+        _transform_enrollment_hub_hostnames(result, HostnameType.SERVICE.value)
+        assert result["iotHubs"] == [
+            "hub1.service.azure-devices.net",
+            "hub2.service.azure-devices.us",
+            "hub3.service.azure-devices.cn",
+        ]
+
+
+class TestTransformRegistrationHubHostname:
+    """Tests for _transform_registration_hub_hostname — transforms assignedHub in registration results."""
+
+    def test_auto_resolves_to_device(self):
+        result = {"assignedHub": "hub1.azure-devices.net", "registrationId": "dev1"}
+        _transform_registration_hub_hostname(result, HostnameType.AUTO.value)
+        assert result["assignedHub"] == "hub1.device.azure-devices.net"
+
+    def test_classic(self):
+        result = {"assignedHub": "hub1.azure-devices.net"}
+        _transform_registration_hub_hostname(result, HostnameType.CLASSIC.value)
+        assert result["assignedHub"] == "hub1.azure-devices.net"
+
+    def test_device(self):
+        result = {"assignedHub": "hub1.azure-devices.net"}
+        _transform_registration_hub_hostname(result, HostnameType.DEVICE.value)
+        assert result["assignedHub"] == "hub1.device.azure-devices.net"
+
+    def test_no_assigned_hub(self):
+        result = {"registrationId": "dev1", "status": "unassigned"}
+        _transform_registration_hub_hostname(result, HostnameType.DEVICE.value)
+        assert "assignedHub" not in result
+
+    def test_none_assigned_hub(self):
+        result = {"assignedHub": None}
+        _transform_registration_hub_hostname(result, HostnameType.DEVICE.value)
+        assert result["assignedHub"] is None
+
+    def test_list_of_registrations(self):
+        results = [
+            {"assignedHub": "hub1.azure-devices.net"},
+            {"assignedHub": "hub2.azure-devices.net"},
+        ]
+        transformed = _transform_registration_hub_hostname(results, HostnameType.DEVICE.value)
+        assert transformed[0]["assignedHub"] == "hub1.device.azure-devices.net"
+        assert transformed[1]["assignedHub"] == "hub2.device.azure-devices.net"
+
+    def test_none_result(self):
+        assert _transform_registration_hub_hostname(None, HostnameType.DEVICE.value) is None
+
+    def test_default_is_auto(self):
+        result = {"assignedHub": "hub1.azure-devices.net"}
+        _transform_registration_hub_hostname(result)
+        assert result["assignedHub"] == "hub1.device.azure-devices.net"

--- a/azext_iot/tests/iothub/core/test_iot_hub_adr_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_adr_unit.py
@@ -34,7 +34,7 @@ hub_id = f"{rg_id}/providers/Microsoft.Devices/IotHubs/{hub}"
 
 @pytest.mark.parametrize("namespace_id", [namespace_id, None, ""])
 @pytest.mark.parametrize("identity_id", [identity_id, None, ""])
-@pytest.mark.parametrize("sku", [IotHubSku.GEN2, IotHubSku.S1])
+@pytest.mark.parametrize("sku", [IotHubSku.GEN2.value, IotHubSku.S1.value])
 @pytest.mark.parametrize(
     "existing_properties",
     [
@@ -48,7 +48,7 @@ def test_validate_and_set_adr_properties(namespace_id, identity_id, sku, existin
     instance = {"deviceRegistry": existing_properties}
 
     # Test behavior based on SKU type and parameters
-    if sku == IotHubSku.GEN2:  # Generation2 SKU
+    if sku == IotHubSku.GEN2.value:  # Generation2 SKU
         if namespace_id and identity_id:
             # Valid Gen2 configuration
             _validate_and_set_adr_properties(

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -320,3 +320,13 @@ iot adr ns policy update:
     certificate_validity_days:
       rule_exclusions:
         - no_parameter_defaults_for_update_commands
+iot dps enrollment update:
+  parameters:
+    hostname_type:
+      rule_exclusions:
+        - no_parameter_defaults_for_update_commands
+iot dps enrollment-group update:
+  parameters:
+    hostname_type:
+      rule_exclusions:
+        - no_parameter_defaults_for_update_commands

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -32,9 +32,15 @@ iot dps enrollment update:
     auth_type_dataplane:
       rule_exclusions:
         - no_parameter_defaults_for_update_commands
+    hostname_type:
+      rule_exclusions:
+        - no_parameter_defaults_for_update_commands
 iot dps enrollment-group update:
   parameters:
     auth_type_dataplane:
+      rule_exclusions:
+        - no_parameter_defaults_for_update_commands
+    hostname_type:
       rule_exclusions:
         - no_parameter_defaults_for_update_commands
 iot hub configuration update:
@@ -318,15 +324,5 @@ iot adr ns policy update:
       rule_exclusions:
         - no_parameter_defaults_for_update_commands
     certificate_validity_days:
-      rule_exclusions:
-        - no_parameter_defaults_for_update_commands
-iot dps enrollment update:
-  parameters:
-    hostname_type:
-      rule_exclusions:
-        - no_parameter_defaults_for_update_commands
-iot dps enrollment-group update:
-  parameters:
-    hostname_type:
       rule_exclusions:
         - no_parameter_defaults_for_update_commands


### PR DESCRIPTION
﻿Add --hostname-type (auto/classic/device) to DPS enrollment and enrollment-group commands (show/list/create/update) and registration commands (show/list). Transforms IoT Hub hostnames in output to the requested TLS 1.3 endpoint type.

 - Default is `auto`, which resolves to `device` for DPS (device provisioning)
 - `classic` actively transforms to the default hostname
 - `device` transforms to the TLS 1.3 device hostname
 - String transformation via _transform_hostname 
 - Fix IotDpsSku and IotHubSku - They used to act as a string instead of the actual value when creating hub/dps

### - Why adding rule_exclusions on hostname_type
﻿`--hostname-type` is defined at the parent `iot dps enrollment` scope with default=auto , which applies to all sub-commands including update. 
The CLI linter rule says "no defaults on update commands." But removing the default would make update output different from show/list/create for the same enrollment, hence the exclusion

﻿### - Why auto resolves to device for DPS?
 DPS enrollments are for device provisioning. Design doc says "device for device provisioning commands."
 
### - Why string transform instead of reading from API? 
DPS dataplane API doesn't return deviceHostName/serviceHostName on enrollments. Design doc confirms: "no SDK changes required for TLS 1.3

### ﻿- Why no service option for DPS? 
 DPS enrollments are device provisioning. Service hostname is for service-side operations, not applicable to DPS.

