### PR TITLE
fix: Convert mgmt SDK responses to dict access

### DIFF
--- a/azext_iot/common/shared.py
+++ b/azext_iot/common/shared.py
@@ -86,6 +86,15 @@ class HostnameType(Enum):
     SERVICE = "service"
 
 
+class GatewayVersion(Enum):
+    """
+    IoT Hub gateway version.
+    """
+
+    V1 = "V1"
+    V2 = "V2"
+
+
 class AttestationType(Enum):
     """
     Type of atestation (TMP or certificate based).

--- a/azext_iot/core/command_map.py
+++ b/azext_iot/core/command_map.py
@@ -21,19 +21,19 @@ ENDPOINT_DEPRECATION_INFO = 'IoT Extension (azure-iot) message-endpoint command 
 class PolicyUpdateResultTransform(LongRunningOperation):  # pylint: disable=too-few-public-methods
     def __call__(self, poller):
         result = super().__call__(poller)
-        return result.properties.authorization_policies
+        return result["properties"]["authorizationPolicies"]
 
 
 class EndpointUpdateResultTransform(LongRunningOperation):  # pylint: disable=too-few-public-methods
     def __call__(self, poller):
         result = super().__call__(poller)
-        return result.properties.routing.endpoints
+        return result["properties"]["routing"]["endpoints"]
 
 
 class RouteUpdateResultTransform(LongRunningOperation):  # pylint: disable=too-few-public-methods
     def __call__(self, poller):
         result = super().__call__(poller)
-        return result.properties.routing.routes
+        return result["properties"]["routing"]["routes"]
 
 
 # Deleting IoT Hub is a long-running operation. Due to API implementation issue, 404 error will be thrown during

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -97,7 +97,7 @@ def iot_dps_create(
     dps_name,
     resource_group_name,
     location=None,
-    sku=IotDpsSku.S1,
+    sku=IotDpsSku.S1.value,
     unit=1,
     tags=None,
     enable_data_residency=None,
@@ -655,7 +655,7 @@ def iot_hub_create(
     hub_name,
     resource_group_name,
     location=None,
-    sku=IotHubSku.S1,
+    sku=IotHubSku.S1.value,
     unit=1,
     partition_count=4,
     retention_day=1,
@@ -913,8 +913,8 @@ def update_iot_hub_custom(instance,
     existing_sku_name = instance["sku"]["name"]
     final_sku_name = sku or existing_sku_name
 
-    is_existing_gen2 = existing_sku_name == IotHubSku.GEN2
-    is_final_gen2 = final_sku_name == IotHubSku.GEN2
+    is_existing_gen2 = existing_sku_name == IotHubSku.GEN2.value
+    is_final_gen2 = final_sku_name == IotHubSku.GEN2.value
 
     if sku and (is_existing_gen2 ^ is_final_gen2):
         raise InvalidArgumentValueError(
@@ -1751,7 +1751,7 @@ def _validate_and_set_adr_properties(
 ):
     """Validate and set Azure Device Registry properties for IoT Hub."""
 
-    if sku == IotHubSku.GEN2:
+    if sku == IotHubSku.GEN2.value:
         # Generation2 hubs require both ADR properties
         if not (adr_namespace_resource_id and adr_identity_resource_id):
             raise RequiredArgumentMissingError(

--- a/azext_iot/core/shared.py
+++ b/azext_iot/core/shared.py
@@ -91,7 +91,7 @@ class ManagedServiceIdentityType(str, Enum):
     SYSTEM_ASSIGNED_USER_ASSIGNED = "SystemAssigned,UserAssigned"
 
 
-class IotHubSku(str, Enum):
+class IotHubSku(Enum):
     """The name of the IoT Hub SKU."""
 
     F1 = "F1"
@@ -104,7 +104,7 @@ class IotHubSku(str, Enum):
     GEN2 = "GEN2"
 
 
-class IotDpsSku(str, Enum):
+class IotDpsSku(Enum):
     """DPS SKU name."""
 
     S1 = "S1"

--- a/azext_iot/iothub/providers/discovery.py
+++ b/azext_iot/iothub/providers/discovery.py
@@ -8,7 +8,7 @@ from knack.log import get_logger
 from azure.cli.core.commands.client_factory import get_subscription_id
 from azext_iot.common._azure import IOT_SERVICE_CS_TEMPLATE
 from azext_iot.common.base_discovery import BaseDiscovery
-from azext_iot.common.shared import DiscoveryResourceType, AuthenticationTypeDataplane
+from azext_iot.common.shared import DiscoveryResourceType, AuthenticationTypeDataplane, GatewayVersion
 from azext_iot.common.utility import trim_from_start
 from azext_iot.iothub.models.iothub_target import IotHubTarget
 from azext_iot._factory import iot_hub_service_factory
@@ -77,7 +77,7 @@ class IotHubDiscovery(BaseDiscovery):
         tls_device = props.get("deviceHostName")
         tls_service = props.get("serviceHostName")
         gw_version = props.get("iotHubDetails", {}).get("gatewayVersion")
-        service_hostname = tls_service if gw_version == "V2" else None
+        service_hostname = tls_service if gw_version == GatewayVersion.V2.value else None
         hostname = service_hostname or props.get("hostName")
 
         target = {}

--- a/azext_iot/iothub/providers/message_endpoint.py
+++ b/azext_iot/iothub/providers/message_endpoint.py
@@ -28,7 +28,6 @@ from azext_iot.iothub.common import (
 )
 from azext_iot.iothub.providers.base import IoTHubProvider
 from azext_iot.common._azure import parse_cosmos_db_connection_string
-from azure.mgmt.iothub.models import ManagedIdentity
 from azure.core.exceptions import HttpResponseError
 
 
@@ -45,9 +44,10 @@ class MessageEndpoint(IoTHubProvider):
         super(MessageEndpoint, self).__init__(cmd, hub_name, rg, dataplane=False)
         # Temporary flag to check for which cosmos property to look for.
         self.support_cosmos = IoTHubSDKVersion.NoCosmos.value
-        if hasattr(self.hub_resource.properties.routing.endpoints, "cosmos_db_sql_collections"):
+        endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
+        if "cosmosDBSqlCollections" in endpoints:
             self.support_cosmos = IoTHubSDKVersion.CosmosCollections.value
-        if hasattr(self.hub_resource.properties.routing.endpoints, "cosmos_db_sql_containers"):
+        if "cosmosDBSqlContainers" in endpoints:
             self.support_cosmos = IoTHubSDKVersion.CosmosContainers.value
         self.cli = EmbeddedCLI(cli_ctx=self.cmd.cli_ctx)
 
@@ -75,9 +75,9 @@ class MessageEndpoint(IoTHubProvider):
         identity: Optional[str] = None
     ):
         if not endpoint_resource_group:
-            endpoint_resource_group = self.hub_resource.additional_properties["resourcegroup"]
+            endpoint_resource_group = self.hub_resource["resourcegroup"]
         if not endpoint_subscription_id:
-            endpoint_subscription_id = self.hub_resource.additional_properties['subscriptionid']
+            endpoint_subscription_id = self.hub_resource['subscriptionid']
 
         if connection_string and identity:
             raise MutuallyExclusiveArgumentError("Please use either --connection-string or --identity, both were provided.")
@@ -87,9 +87,9 @@ class MessageEndpoint(IoTHubProvider):
         if identity:
             authentication_type = AuthenticationType.IdentityBased.value
             if identity != SYSTEM_ASSIGNED_IDENTITY:
-                endpoint_identity = ManagedIdentity(
-                    user_assigned_identity=identity
-                )
+                endpoint_identity = {
+                    "userAssignedIdentity": identity
+                }
         elif not connection_string:
             # check for args to get the connection string
             self._connection_string_retrieval_args_check(
@@ -111,7 +111,7 @@ class MessageEndpoint(IoTHubProvider):
         }
         fetch_connection_string = identity is None and not connection_string
 
-        endpoints = self.hub_resource.properties.routing.endpoints
+        endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
         if endpoint_type.lower() == EndpointType.EventHub.value:
             if fetch_connection_string:
                 new_endpoint["connectionString"] = get_eventhub_cstring(
@@ -124,7 +124,7 @@ class MessageEndpoint(IoTHubProvider):
                 )
             elif entity_path:
                 new_endpoint["entityPath"] = entity_path.replace("~", "/")
-            endpoints.event_hubs.append(new_endpoint)
+            endpoints["eventHubs"].append(new_endpoint)
         elif endpoint_type.lower() == EndpointType.ServiceBusQueue.value:
             if fetch_connection_string:
                 new_endpoint["connectionString"] = get_servicebus_queue_cstring(
@@ -137,7 +137,7 @@ class MessageEndpoint(IoTHubProvider):
                 )
             if entity_path:
                 new_endpoint["entityPath"] = entity_path
-            endpoints.service_bus_queues.append(new_endpoint)
+            endpoints["serviceBusQueues"].append(new_endpoint)
         elif endpoint_type.lower() == EndpointType.ServiceBusTopic.value:
             if fetch_connection_string:
                 new_endpoint["connectionString"] = get_servicebus_topic_cstring(
@@ -150,7 +150,7 @@ class MessageEndpoint(IoTHubProvider):
                 )
             if entity_path:
                 new_endpoint["entityPath"] = entity_path
-            endpoints.service_bus_topics.append(new_endpoint)
+            endpoints["serviceBusTopics"].append(new_endpoint)
         elif endpoint_type.lower() == EndpointType.CosmosDBContainer.value:
             if fetch_connection_string:
                 # try to get connection string - this will be used to get keys + uri
@@ -196,14 +196,14 @@ class MessageEndpoint(IoTHubProvider):
             # @vilit - None checks for when the service breaks things
             if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
                 new_endpoint["containerName"] = container_name
-                if endpoints.cosmos_db_sql_containers is None:
-                    endpoints.cosmos_db_sql_containers = []
-                endpoints.cosmos_db_sql_containers.append(new_endpoint)
+                if endpoints["cosmosDBSqlContainers"] is None:
+                    endpoints["cosmosDBSqlContainers"] = []
+                endpoints["cosmosDBSqlContainers"].append(new_endpoint)
             if self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
                 new_endpoint["collectionName"] = container_name
-                if endpoints.cosmos_db_sql_collections is None:
-                    endpoints.cosmos_db_sql_collections = []
-                endpoints.cosmos_db_sql_collections.append(new_endpoint)
+                if endpoints["cosmosDBSqlCollections"] is None:
+                    endpoints["cosmosDBSqlCollections"] = []
+                endpoints["cosmosDBSqlCollections"].append(new_endpoint)
         elif endpoint_type.lower() == EndpointType.AzureStorageContainer.value:
             if fetch_connection_string:
                 # try to get connection string
@@ -222,14 +222,14 @@ class MessageEndpoint(IoTHubProvider):
                 "batchFrequencyInSeconds": batch_frequency,
                 "maxChunkSizeInBytes": (chunk_size_window * BYTES_PER_MEGABYTE),
             })
-            endpoints.storage_containers.append(new_endpoint)
+            endpoints["storageContainers"].append(new_endpoint)
 
         try:
             return self.discovery.client.begin_create_or_update(
-                self.hub_resource.additional_properties["resourcegroup"],
-                self.hub_resource.name,
+                self.hub_resource["resourcegroup"],
+                self.hub_resource["name"],
                 self.hub_resource,
-                etag=self.hub_resource.etag
+                etag=self.hub_resource["etag"]
             )
         except HttpResponseError as e:
             handle_service_exception(e)
@@ -265,88 +265,88 @@ class MessageEndpoint(IoTHubProvider):
 
         # Properties for all endpoint types
         if endpoint_resource_group:
-            original_endpoint.resource_group = endpoint_resource_group
+            original_endpoint["resourceGroup"] = endpoint_resource_group
         if endpoint_subscription_id:
-            original_endpoint.subscription_id = endpoint_subscription_id
+            original_endpoint["subscriptionId"] = endpoint_subscription_id
         if endpoint_uri:
             # Handle this later with cosmos db connection string parsing
-            original_endpoint.endpoint_uri = endpoint_uri
+            original_endpoint["endpointUri"] = endpoint_uri
 
         # Identity/Connection String schenanigans
         # If Identity and Connection String args are provided, Identity wins
         if identity:
             if endpoint_type.lower() == EndpointType.CosmosDBContainer.value:
-                if original_endpoint.primary_key or original_endpoint.secondary_key:
+                if original_endpoint["primaryKey"] or original_endpoint["secondaryKey"]:
                     logger.warning(NULL_WARNING.format("Primary and secondary keys"))
-                original_endpoint.primary_key = None
-                original_endpoint.secondary_key = None
+                original_endpoint["primaryKey"] = None
+                original_endpoint["secondaryKey"] = None
             else:
-                if original_endpoint.connection_string:
+                if original_endpoint["connectionString"]:
                     logger.warning(NULL_WARNING.format("The connection string"))
-                original_endpoint.connection_string = None
-            original_endpoint.authentication_type = AuthenticationType.IdentityBased.value
+                original_endpoint["connectionString"] = None
+            original_endpoint["authenticationType"] = AuthenticationType.IdentityBased.value
             if identity == SYSTEM_ASSIGNED_IDENTITY:
-                original_endpoint.identity = None
+                original_endpoint["identity"] = None
             else:
-                original_endpoint.identity = ManagedIdentity(
-                    user_assigned_identity=identity
-                )
+                original_endpoint["identity"] = {
+                    "userAssignedIdentity": identity
+                }
         elif any([connection_string, primary_key, secondary_key]):
-            if original_endpoint.identity:
+            if original_endpoint["identity"]:
                 logger.warning(NULL_WARNING.format("The managed identity property"))
-            original_endpoint.identity = None
-            original_endpoint.authentication_type = AuthenticationType.KeyBased.value
+            original_endpoint["identity"] = None
+            original_endpoint["authenticationType"] = AuthenticationType.KeyBased.value
             if endpoint_type.lower() != EndpointType.CosmosDBContainer.value:
-                original_endpoint.endpoint_uri = None
-            if hasattr(original_endpoint, "entity_path"):
-                if original_endpoint.entity_path:
+                original_endpoint["endpointUri"] = None
+            if "entityPath" in original_endpoint:
+                if original_endpoint["entityPath"]:
                     logger.warning(NULL_WARNING.format("The entity path"))
-                original_endpoint.entity_path = None
+                original_endpoint["entityPath"] = None
 
             if endpoint_type.lower() != EndpointType.CosmosDBContainer.value:
-                original_endpoint.connection_string = connection_string
+                original_endpoint["connectionString"] = connection_string
             else:
                 if primary_key:
-                    original_endpoint.primary_key = primary_key
+                    original_endpoint["primaryKey"] = primary_key
                 if secondary_key:
-                    original_endpoint.secondary_key = secondary_key
+                    original_endpoint["secondaryKey"] = secondary_key
 
         # Properties by specific types
         if endpoint_type in [
             EndpointType.EventHub.value, EndpointType.ServiceBusQueue.value, EndpointType.ServiceBusTopic.value
         ] and entity_path and not connection_string:
             # only set entity_path if no connection string
-            original_endpoint.entity_path = entity_path
+            original_endpoint["entityPath"] = entity_path
 
         if endpoint_type == EndpointType.AzureStorageContainer.value:
             if file_name_format:
-                original_endpoint.file_name_format = file_name_format
+                original_endpoint["fileNameFormat"] = file_name_format
             if batch_frequency:
-                original_endpoint.batch_frequency_in_seconds = batch_frequency
+                original_endpoint["batchFrequencyInSeconds"] = batch_frequency
             if chunk_size_window:
-                original_endpoint.max_chunk_size_in_bytes = (chunk_size_window * BYTES_PER_MEGABYTE)
+                original_endpoint["maxChunkSizeInBytes"] = (chunk_size_window * BYTES_PER_MEGABYTE)
         elif endpoint_type == EndpointType.CosmosDBContainer.value:
             if connection_string:
                 # parse out key from connection string
                 parsed_cs = parse_cosmos_db_connection_string(connection_string)
                 if not primary_key and not secondary_key:
-                    original_endpoint.primary_key = parsed_cs["AccountKey"]
-                    original_endpoint.secondary_key = parsed_cs["AccountKey"]
+                    original_endpoint["primaryKey"] = parsed_cs["AccountKey"]
+                    original_endpoint["secondaryKey"] = parsed_cs["AccountKey"]
                 # parse out endpoint uri from connection string
                 if not endpoint_uri:
-                    original_endpoint.endpoint_uri = parsed_cs["AccountEndpoint"]
+                    original_endpoint["endpointUri"] = parsed_cs["AccountEndpoint"]
             if database_name:
-                original_endpoint.database_name = database_name
+                original_endpoint["databaseName"] = database_name
             if partition_key_name:
-                original_endpoint.partition_key_name = None if partition_key_name == "" else partition_key_name
+                original_endpoint["partitionKeyName"] = None if partition_key_name == "" else partition_key_name
             if partition_key_template:
-                original_endpoint.partition_key_template = None if partition_key_template == "" else partition_key_template
+                original_endpoint["partitionKeyTemplate"] = None if partition_key_template == "" else partition_key_template
 
         return self.discovery.client.begin_create_or_update(
-            self.hub_resource.additional_properties["resourcegroup"],
-            self.hub_resource.name,
+            self.hub_resource["resourcegroup"],
+            self.hub_resource["name"],
             self.hub_resource,
-            etag=self.hub_resource.etag
+            etag=self.hub_resource["etag"]
         )
 
     def _connection_string_retrieval_args_check(
@@ -374,56 +374,56 @@ class MessageEndpoint(IoTHubProvider):
             )
 
     def _show_by_type(self, endpoint_name: str, endpoint_type: Optional[str] = None):
-        endpoints = self.hub_resource.properties.routing.endpoints
+        endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
         endpoint_list = []
         if endpoint_type is None or endpoint_type.lower() == EndpointType.EventHub.value:
-            endpoint_list.extend(endpoints.event_hubs)
+            endpoint_list.extend(endpoints["eventHubs"])
         if endpoint_type is None or endpoint_type.lower() == EndpointType.ServiceBusQueue.value:
-            endpoint_list.extend(endpoints.service_bus_queues)
+            endpoint_list.extend(endpoints["serviceBusQueues"])
         if endpoint_type is None or endpoint_type.lower() == EndpointType.ServiceBusTopic.value:
-            endpoint_list.extend(endpoints.service_bus_topics)
+            endpoint_list.extend(endpoints["serviceBusTopics"])
         if endpoint_type is None or endpoint_type.lower() == EndpointType.AzureStorageContainer.value:
-            endpoint_list.extend(endpoints.storage_containers)
+            endpoint_list.extend(endpoints["storageContainers"])
         if (endpoint_type is None or endpoint_type.lower() == EndpointType.CosmosDBContainer.value):
             if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                endpoint_list.extend(endpoints.cosmos_db_sql_containers)
+                endpoint_list.extend(endpoints["cosmosDBSqlContainers"])
             elif self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                endpoint_list.extend(endpoints.cosmos_db_sql_collections)
+                endpoint_list.extend(endpoints["cosmosDBSqlCollections"])
 
         for endpoint in endpoint_list:
-            if endpoint.name.lower() == endpoint_name.lower():
+            if endpoint["name"].lower() == endpoint_name.lower():
                 return endpoint
 
         if endpoint_type:
             raise ResourceNotFoundError(
-                f"{endpoint_type} endpoint {endpoint_name} not found in IoT Hub {self.hub_resource.name}."
+                f"{endpoint_type} endpoint {endpoint_name} not found in IoT Hub {self.hub_resource['name']}."
             )
 
-        raise ResourceNotFoundError(f"Endpoint {endpoint_name} not found in IoT Hub {self.hub_resource.name}.")
+        raise ResourceNotFoundError(f"Endpoint {endpoint_name} not found in IoT Hub {self.hub_resource['name']}.")
 
     def show(self, endpoint_name: str):
         return self._show_by_type(endpoint_name=endpoint_name)
 
     def list(self, endpoint_type: Optional[str] = None):
-        endpoints = self.hub_resource.properties.routing.endpoints
+        endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
         if not endpoint_type:
             return endpoints
         endpoint_type = endpoint_type.lower()
         if EndpointType.EventHub.value == endpoint_type:
-            return endpoints.event_hubs
+            return endpoints["eventHubs"]
         elif EndpointType.ServiceBusQueue.value == endpoint_type:
-            return endpoints.service_bus_queues
+            return endpoints["serviceBusQueues"]
         elif EndpointType.ServiceBusTopic.value == endpoint_type:
-            return endpoints.service_bus_topics
+            return endpoints["serviceBusTopics"]
         elif EndpointType.CosmosDBContainer.value == endpoint_type:
             if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                return endpoints.cosmos_db_sql_containers
+                return endpoints["cosmosDBSqlContainers"]
             elif self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                return endpoints.cosmos_db_sql_collections
+                return endpoints["cosmosDBSqlCollections"]
         elif EndpointType.CosmosDBContainer.value == endpoint_type:
             raise InvalidArgumentValueError(INVALID_CLI_CORE_FOR_COSMOS)
         elif EndpointType.AzureStorageContainer.value == endpoint_type:
-            return endpoints.storage_containers
+            return endpoints["storageContainers"]
 
     def delete(
         self,
@@ -431,7 +431,7 @@ class MessageEndpoint(IoTHubProvider):
         endpoint_type: Optional[str] = None,
         force: bool = False
     ):
-        endpoints = self.hub_resource.properties.routing.endpoints
+        endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
         if endpoint_type:
             endpoint_type = endpoint_type.lower()
             if (
@@ -439,7 +439,7 @@ class MessageEndpoint(IoTHubProvider):
             ):
                 raise InvalidArgumentValueError(INVALID_CLI_CORE_FOR_COSMOS)
 
-        if self.hub_resource.properties.routing.enrichments or self.hub_resource.properties.routing.routes:
+        if self.hub_resource["properties"]["routing"]["enrichments"] or self.hub_resource["properties"]["routing"]["routes"]:
             # collect endpoints to remove
             endpoint_names = []
             if endpoint_name:
@@ -451,46 +451,46 @@ class MessageEndpoint(IoTHubProvider):
                     pass
             else:
                 if not endpoint_type or endpoint_type == EndpointType.EventHub.value:
-                    endpoint_names.extend([e.name for e in endpoints.event_hubs])
+                    endpoint_names.extend([e["name"] for e in endpoints["eventHubs"]])
                 if not endpoint_type or endpoint_type == EndpointType.ServiceBusQueue.value:
-                    endpoint_names.extend([e.name for e in endpoints.service_bus_queues])
+                    endpoint_names.extend([e["name"] for e in endpoints["serviceBusQueues"]])
                 if not endpoint_type or endpoint_type == EndpointType.ServiceBusTopic.value:
-                    endpoint_names.extend([e.name for e in endpoints.service_bus_topics])
+                    endpoint_names.extend([e["name"] for e in endpoints["serviceBusTopics"]])
                 if not endpoint_type or endpoint_type == EndpointType.CosmosDBContainer.value:
                     if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                        endpoint_names.extend([e.name for e in endpoints.cosmos_db_sql_containers])
+                        endpoint_names.extend([e["name"] for e in endpoints["cosmosDBSqlContainers"]])
                     if self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                        endpoint_names.extend([e.name for e in endpoints.cosmos_db_sql_collections])
+                        endpoint_names.extend([e["name"] for e in endpoints["cosmosDBSqlCollections"]])
                 if not endpoint_type or endpoint_type == EndpointType.AzureStorageContainer.value:
-                    endpoint_names.extend([e.name for e in endpoints.storage_containers])
+                    endpoint_names.extend([e["name"] for e in endpoints["storageContainers"]])
 
             # only do the routing and enrichment checks if there are endpoints to check.
             if force and endpoint_names:
                 # remove enrichments
-                if self.hub_resource.properties.routing.enrichments:
-                    enrichments = self.hub_resource.properties.routing.enrichments
-                    enrichments = [e for e in enrichments if not any(n for n in e.endpoint_names if n in endpoint_names)]
-                    self.hub_resource.properties.routing.enrichments = enrichments
+                if self.hub_resource["properties"]["routing"]["enrichments"]:
+                    enrichments = self.hub_resource["properties"]["routing"]["enrichments"]
+                    enrichments = [e for e in enrichments if not any(n for n in e["endpointNames"] if n in endpoint_names)]
+                    self.hub_resource["properties"]["routing"]["enrichments"] = enrichments
                 # remove routes
-                if self.hub_resource.properties.routing.routes:
-                    routes = self.hub_resource.properties.routing.routes
-                    routes = [r for r in routes if r.endpoint_names[0] not in endpoint_names]
-                    self.hub_resource.properties.routing.routes = routes
+                if self.hub_resource["properties"]["routing"]["routes"]:
+                    routes = self.hub_resource["properties"]["routing"]["routes"]
+                    routes = [r for r in routes if r["endpointNames"][0] not in endpoint_names]
+                    self.hub_resource["properties"]["routing"]["routes"] = routes
             elif endpoint_names:
                 # warn if needed:
                 conflicts = []
-                if self.hub_resource.properties.routing.enrichments:
-                    enrichments = self.hub_resource.properties.routing.enrichments
+                if self.hub_resource["properties"]["routing"]["enrichments"]:
+                    enrichments = self.hub_resource["properties"]["routing"]["enrichments"]
                     num_enrichments = len(
-                        [e for e in enrichments if any(n for n in e.endpoint_names if n in endpoint_names)]
+                        [e for e in enrichments if any(n for n in e["endpointNames"] if n in endpoint_names)]
                     )
                     if num_enrichments > 0:
                         enrichment_msg = f"{num_enrichments} message enrichment" + ("s" if num_enrichments > 1 else "")
                         conflicts.append(enrichment_msg)
 
-                if self.hub_resource.properties.routing.routes:
-                    routes = self.hub_resource.properties.routing.routes
-                    num_routes = len([r for r in routes if r.endpoint_names[0] in endpoint_names])
+                if self.hub_resource["properties"]["routing"]["routes"]:
+                    routes = self.hub_resource["properties"]["routing"]["routes"]
+                    num_routes = len([r for r in routes if r["endpointNames"][0] in endpoint_names])
                     if num_routes > 0:
                         enrichment_msg = f"{num_routes} route" + ("s" if num_routes > 1 else "")
                         conflicts.append(enrichment_msg)
@@ -502,56 +502,56 @@ class MessageEndpoint(IoTHubProvider):
             endpoint_name = endpoint_name.lower()
 
             if not endpoint_type or EndpointType.EventHub.value == endpoint_type:
-                endpoints.event_hubs = [e for e in endpoints.event_hubs if e.name.lower() != endpoint_name]
+                endpoints["eventHubs"] = [e for e in endpoints["eventHubs"] if e["name"].lower() != endpoint_name]
             if not endpoint_type or EndpointType.ServiceBusQueue.value == endpoint_type:
-                endpoints.service_bus_queues = [e for e in endpoints.service_bus_queues if e.name.lower() != endpoint_name]
+                endpoints["serviceBusQueues"] = [e for e in endpoints["serviceBusQueues"] if e["name"].lower() != endpoint_name]
             if not endpoint_type or EndpointType.ServiceBusTopic.value == endpoint_type:
-                endpoints.service_bus_topics = [e for e in endpoints.service_bus_topics if e.name.lower() != endpoint_name]
+                endpoints["serviceBusTopics"] = [e for e in endpoints["serviceBusTopics"] if e["name"].lower() != endpoint_name]
             if not endpoint_type or endpoint_type == EndpointType.CosmosDBContainer.value:
                 if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                    cosmos_db_endpoints = endpoints.cosmos_db_sql_containers if endpoints.cosmos_db_sql_containers else []
-                    endpoints.cosmos_db_sql_containers = [
-                        e for e in cosmos_db_endpoints if e.name.lower() != endpoint_name
+                    cosmos_db_endpoints = endpoints["cosmosDBSqlContainers"] or []
+                    endpoints["cosmosDBSqlContainers"] = [
+                        e for e in cosmos_db_endpoints if e["name"].lower() != endpoint_name
                     ]
                 if self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                    cosmos_db_endpoints = endpoints.cosmos_db_sql_collections if endpoints.cosmos_db_sql_collections else []
-                    endpoints.cosmos_db_sql_collections = [
-                        e for e in cosmos_db_endpoints if e.name.lower() != endpoint_name
+                    cosmos_db_endpoints = endpoints["cosmosDBSqlCollections"] or []
+                    endpoints["cosmosDBSqlCollections"] = [
+                        e for e in cosmos_db_endpoints if e["name"].lower() != endpoint_name
                     ]
             if not endpoint_type or EndpointType.AzureStorageContainer.value == endpoint_type:
-                endpoints.storage_containers = [e for e in endpoints.storage_containers if e.name.lower() != endpoint_name]
+                endpoints["storageContainers"] = [e for e in endpoints["storageContainers"] if e["name"].lower() != endpoint_name]
         elif endpoint_type:
             # Delete all endpoints in type
             if EndpointType.EventHub.value == endpoint_type:
-                endpoints.event_hubs = []
+                endpoints["eventHubs"] = []
             elif EndpointType.ServiceBusQueue.value == endpoint_type:
-                endpoints.service_bus_queues = []
+                endpoints["serviceBusQueues"] = []
             elif EndpointType.ServiceBusTopic.value == endpoint_type:
-                endpoints.service_bus_topics = []
+                endpoints["serviceBusTopics"] = []
             elif EndpointType.CosmosDBContainer.value == endpoint_type:
                 if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                    endpoints.cosmos_db_sql_containers = []
+                    endpoints["cosmosDBSqlContainers"] = []
                 elif self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                    endpoints.cosmos_db_sql_collections = []
+                    endpoints["cosmosDBSqlCollections"] = []
             elif EndpointType.AzureStorageContainer.value == endpoint_type:
-                endpoints.storage_containers = []
+                endpoints["storageContainers"] = []
         else:
             # Delete all endpoints
-            endpoints.event_hubs = []
-            endpoints.service_bus_queues = []
-            endpoints.service_bus_topics = []
+            endpoints["eventHubs"] = []
+            endpoints["serviceBusQueues"] = []
+            endpoints["serviceBusTopics"] = []
             if self.support_cosmos == IoTHubSDKVersion.CosmosContainers.value:
-                endpoints.cosmos_db_sql_containers = []
+                endpoints["cosmosDBSqlContainers"] = []
             if self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
-                endpoints.cosmos_db_sql_collections = []
-            endpoints.storage_containers = []
+                endpoints["cosmosDBSqlCollections"] = []
+            endpoints["storageContainers"] = []
 
         try:
             return self.discovery.client.begin_create_or_update(
-                self.hub_resource.additional_properties["resourcegroup"],
-                self.hub_resource.name,
+                self.hub_resource["resourcegroup"],
+                self.hub_resource["name"],
                 self.hub_resource,
-                etag=self.hub_resource.etag
+                etag=self.hub_resource["etag"]
             )
         except HttpResponseError as e:
             handle_service_exception(e)

--- a/azext_iot/iothub/providers/message_route.py
+++ b/azext_iot/iothub/providers/message_route.py
@@ -33,7 +33,7 @@ class MessageRoute(IoTHubProvider):
         enabled: bool = True,
         condition: str = "true",
     ):
-        self.hub_resource.properties.routing.routes.append(
+        self.hub_resource["properties"]["routing"]["routes"].append(
             {
                 "source": source_type,
                 "name": route_name,
@@ -45,10 +45,10 @@ class MessageRoute(IoTHubProvider):
 
         try:
             return self.discovery.client.begin_create_or_update(
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
-                resource_name=self.hub_resource.name,
+                resource_group_name=self.hub_resource["resourcegroup"],
+                resource_name=self.hub_resource["name"],
                 iot_hub_description=self.hub_resource,
-                etag=self.hub_resource.etag
+                etag=self.hub_resource["etag"]
             )
         except HttpResponseError as e:
             handle_service_exception(e)
@@ -62,49 +62,49 @@ class MessageRoute(IoTHubProvider):
         condition: Optional[str] = None,
     ):
         route = self.show(route_name=route_name)
-        route.source = route.source if source_type is None else source_type
-        route.endpoint_names = route.endpoint_names if endpoint_name is None else endpoint_name.split()
-        route.condition = route.condition if condition is None else condition
-        route.is_enabled = route.is_enabled if enabled is None else enabled
+        route["source"] = route["source"] if source_type is None else source_type
+        route["endpointNames"] = route["endpointNames"] if endpoint_name is None else endpoint_name.split()
+        route["condition"] = route["condition"] if condition is None else condition
+        route["isEnabled"] = route["isEnabled"] if enabled is None else enabled
 
         try:
             return self.discovery.client.begin_create_or_update(
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
-                resource_name=self.hub_resource.name,
+                resource_group_name=self.hub_resource["resourcegroup"],
+                resource_name=self.hub_resource["name"],
                 iot_hub_description=self.hub_resource,
-                etag=self.hub_resource.etag
+                etag=self.hub_resource["etag"]
             )
         except HttpResponseError as e:
             handle_service_exception(e)
 
     def show(self, route_name: str):
-        routes = self.hub_resource.properties.routing.routes
+        routes = self.hub_resource["properties"]["routing"]["routes"]
         for route in routes:
-            if route.name.lower() == route_name.lower():
+            if route["name"].lower() == route_name.lower():
                 return route
         raise ResourceNotFoundError("No route found.")
 
     def list(self, source_type: Optional[str] = None):
-        routes = self.hub_resource.properties.routing.routes
+        routes = self.hub_resource["properties"]["routing"]["routes"]
         if source_type:
-            return [route for route in routes if route.source.lower() == source_type.lower()]
+            return [route for route in routes if route["source"].lower() == source_type.lower()]
         return routes
 
     def delete(self, route_name: Optional[str] = None, source_type: Optional[str] = None):
-        routing = self.hub_resource.properties.routing
+        routing = self.hub_resource["properties"]["routing"]
         if not route_name and not source_type:
-            routing.routes = []
+            routing["routes"] = []
         elif route_name:
-            routing.routes = [route for route in routing.routes if route.name.lower() != route_name.lower()]
+            routing["routes"] = [route for route in routing["routes"] if route["name"].lower() != route_name.lower()]
         else:
-            routing.routes = [route for route in routing.routes if route.source.lower() != source_type.lower()]
+            routing["routes"] = [route for route in routing["routes"] if route["source"].lower() != source_type.lower()]
 
         try:
             return self.discovery.client.begin_create_or_update(
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
-                resource_name=self.hub_resource.name,
+                resource_group_name=self.hub_resource["resourcegroup"],
+                resource_name=self.hub_resource["name"],
                 iot_hub_description=self.hub_resource,
-                etag=self.hub_resource.etag
+                etag=self.hub_resource["etag"]
             )
         except HttpResponseError as e:
             handle_service_exception(e)
@@ -136,8 +136,8 @@ class MessageRoute(IoTHubProvider):
                 "route": route
             }
             return self.discovery.client.test_route(
-                iot_hub_name=self.hub_resource.name,
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
+                iot_hub_name=self.hub_resource["name"],
+                resource_group_name=self.hub_resource["resourcegroup"],
                 input=test_route_input
             )
 
@@ -148,8 +148,8 @@ class MessageRoute(IoTHubProvider):
                 "twin": None
             }
             return self.discovery.client.test_all_routes(
-                iot_hub_name=self.hub_resource.name,
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
+                iot_hub_name=self.hub_resource["name"],
+                resource_group_name=self.hub_resource["resourcegroup"],
                 input=test_all_routes_input
             )
 
@@ -163,13 +163,13 @@ class MessageRoute(IoTHubProvider):
                 "twin": None
             }
             result = self.discovery.client.test_all_routes(
-                iot_hub_name=self.hub_resource.name,
-                resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
+                iot_hub_name=self.hub_resource["name"],
+                resource_group_name=self.hub_resource["resourcegroup"],
                 input=test_all_routes_input
-            ).routes
+            )["routes"]
 
             # Fallback for if no routes pass
-            if len(result) == 1 and result[0].properties.name == "$fallback":
+            if len(result) == 1 and result[0]["properties"]["name"] == "$fallback":
                 fallback = result
             else:
                 routes.extend(result)
@@ -179,16 +179,16 @@ class MessageRoute(IoTHubProvider):
         return {"routes": routes}
 
     def show_fallback(self):
-        return self.hub_resource.properties.routing.fallback_route
+        return self.hub_resource["properties"]["routing"]["fallbackRoute"]
 
     def set_fallback(self, enabled: bool):
-        fallback_route = self.hub_resource.properties.routing.fallback_route
-        fallback_route.is_enabled = enabled
+        fallback_route = self.hub_resource["properties"]["routing"]["fallbackRoute"]
+        fallback_route["isEnabled"] = enabled
 
         self.discovery.client.begin_create_or_update(
-            resource_group_name=self.hub_resource.additional_properties['resourcegroup'],
-            resource_name=self.hub_resource.name,
+            resource_group_name=self.hub_resource["resourcegroup"],
+            resource_name=self.hub_resource["name"],
             iot_hub_description=self.hub_resource,
-            etag=self.hub_resource.etag
+            etag=self.hub_resource["etag"]
         )
         return self.show_fallback()

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -246,8 +246,8 @@ class StateProvider(IoTHubProvider):
                 control_plane_obj = self.discovery.find_resource(hub_name, hub_rg)
 
                 if not hub_rg:
-                    hub_rg = control_plane_obj.additional_properties["resourcegroup"]
-                hub_resource_id = control_plane_obj.id
+                    hub_rg = control_plane_obj["resourcegroup"]
+                hub_resource_id = control_plane_obj["id"]
                 hub_arm = cli.invoke(f"group export -n {hub_rg} --resource-ids '{hub_resource_id}' --skip-all-params").as_json()
                 if hub_arm and hub_arm["resources"]:
                     hub_state["arm"] = hub_arm
@@ -272,22 +272,22 @@ class StateProvider(IoTHubProvider):
                 # remove/overwrite attributes that cannot be changed
                 current_hub_resource = self.discovery.find_resource(self.hub_name, self.rg)
                 if not self.rg:
-                    self.rg = current_hub_resource.additional_properties["resourcegroup"]
+                    self.rg = current_hub_resource["resourcegroup"]
                 # location
-                hub_resource["location"] = current_hub_resource.location
+                hub_resource["location"] = current_hub_resource["location"]
                 # sku
-                hub_resource["sku"] = current_hub_resource.sku.serialize()
+                hub_resource["sku"] = current_hub_resource["sku"]
                 # event hub partitions
-                partition_count = current_hub_resource.properties.event_hub_endpoints["events"].partition_count
+                partition_count = current_hub_resource["properties"]["eventHubEndpoints"]["events"]["partitionCount"]
                 hub_resource["properties"]["eventHubEndpoints"]["events"]["partitionCount"] = partition_count
                 # enable data residency
                 if (
-                    hasattr(current_hub_resource.properties, "enable_data_residency")
+                    "enableDataResidency" in current_hub_resource["properties"]
                     and "enableDataResidency" in hub_resource["properties"]
                 ):
-                    hub_resource["properties"]["enableDataResidency"] = current_hub_resource.properties.enable_data_residency
+                    hub_resource["properties"]["enableDataResidency"] = current_hub_resource["properties"]["enableDataResidency"]
                 # features - hub takes care of this but we will do this just incase
-                hub_resource["properties"]["features"] = current_hub_resource.properties.features
+                hub_resource["properties"]["features"] = current_hub_resource["properties"]["features"]
                 # TODO check for other props and add them as they pop up
 
             else:

--- a/azext_iot/operations/dps.py
+++ b/azext_iot/operations/dps.py
@@ -50,10 +50,6 @@ from azext_iot.sdk.dps.service.models import (
 logger = get_logger(__name__)
 
 
-def _get_dps_resource_group(dps):
-    return getattr(dps, "resourcegroup", None) or dps.additional_properties.get("resourcegroup")
-
-
 # DPS Enrollments
 
 
@@ -775,12 +771,12 @@ def iot_dps_connection_string_show(
 
         connection_strings = []
         for dps in dps:
-            if dps.properties.state == IoTDPSStateType.Active.value:
+            if dps["properties"]["state"] == IoTDPSStateType.Active.value:
                 try:
-                    dps_resource_group = _get_dps_resource_group(dps)
+                    dps_resource_group = dps["resourcegroup"]
                     connection_strings.append(
                         {
-                            "name": dps.name,
+                            "name": dps["name"],
                             "connectionString": conn_str_getter(dps)
                             if show_all
                             else conn_str_getter(dps)[0],
@@ -788,14 +784,14 @@ def iot_dps_connection_string_show(
                     )
                 except Exception:
                     logger.warning(
-                        f"Warning: The DPS {dps.name} in resource group "
+                        f"Warning: The DPS {dps['name']} in resource group "
                         + f"{dps_resource_group} does "
                         + f"not have the target policy {policy_name}."
                     )
             else:
-                dps_resource_group = _get_dps_resource_group(dps)
+                dps_resource_group = dps["resourcegroup"]
                 logger.warning(
-                    f"Warning: The DPS {dps.name} in resource group "
+                    f"Warning: The DPS {dps['name']} in resource group "
                     + f"{dps_resource_group} is skipped "
                     + "because the DPS is not active."
                 )
@@ -813,24 +809,24 @@ def _get_dps_connection_string(
     discovery, dps, policy_name, key_type, show_all
 ):
     policies = []
-    dps_resource_group = _get_dps_resource_group(dps)
+    dps_resource_group = dps["resourcegroup"]
     if show_all:
         policies.extend(
-            discovery.get_policies(dps.name, dps_resource_group)
+            discovery.get_policies(dps["name"], dps_resource_group)
         )
     else:
         policies.append(
             discovery.find_policy(
-                dps.name, dps_resource_group, policy_name
+                dps["name"], dps_resource_group, policy_name
             )
         )
 
-    hostname = dps.properties.service_operations_host_name
+    hostname = dps["properties"]["serviceOperationsHostName"]
     return [
         IOT_SERVICE_CS_TEMPLATE.format(
             hostname,
-            p.key_name,
-            p.secondary_key if key_type == KeyType.secondary.value else p.primary_key,
+            p["keyName"],
+            p["secondaryKey"] if key_type == KeyType.secondary.value else p["primaryKey"],
         )
         for p in policies
     ]

--- a/azext_iot/tests/dps/core/test_dps_discovery_int.py
+++ b/azext_iot/tests/dps/core/test_dps_discovery_int.py
@@ -18,16 +18,16 @@ def test_dps_discovery(provisioned_iot_dps_no_hub_module):
     discovery = DPSDiscovery(cmd_shell)
 
     resource = discovery.find_resource(resource_name=dps_name)
-    assert resource.name == dps_name
+    assert resource["name"] == dps_name
 
-    auto_policy = discovery.find_policy(resource_name=dps_name, rg=dps_rg).as_dict()
+    auto_policy = discovery.find_policy(resource_name=dps_name, rg=dps_rg)
     assert auto_policy
 
     # Assumption - Test DPS includes the vanilla provisioningserviceowner policy
     desired_policy = discovery.find_policy(
         resource_name=dps_name, rg=dps_rg, policy_name=desired_policy_name
-    ).as_dict()
-    assert desired_policy["key_name"] == desired_policy_name
+    )
+    assert desired_policy["keyName"] == desired_policy_name
 
     policies = discovery.get_policies(resource_name=dps_name, rg=dps_rg)
     assert len(policies)
@@ -40,14 +40,14 @@ def test_dps_discovery(provisioned_iot_dps_no_hub_module):
     assert sub_dps
 
     filtered_sub_dps = [
-        dps for dps in sub_dps if dps.as_dict()["name"] == dps_name
+        dps for dps in sub_dps if dps["name"] == dps_name
     ]
     assert filtered_sub_dps
 
     rg_dpss = discovery.get_resources(rg=dps_rg)
     assert rg_dpss
 
-    filtered_rg_dpss = [dps for dps in rg_dpss if dps.as_dict()["name"] == dps_name]
+    filtered_rg_dpss = [dps for dps in rg_dpss if dps["name"] == dps_name]
     assert filtered_rg_dpss
 
     assert len(rg_dpss) <= len(sub_dps)

--- a/azext_iot/tests/iothub/core/test_iot_hub_adr_unit.py
+++ b/azext_iot/tests/iothub/core/test_iot_hub_adr_unit.py
@@ -34,7 +34,7 @@ hub_id = f"{rg_id}/providers/Microsoft.Devices/IotHubs/{hub}"
 
 @pytest.mark.parametrize("namespace_id", [namespace_id, None, ""])
 @pytest.mark.parametrize("identity_id", [identity_id, None, ""])
-@pytest.mark.parametrize("sku", [IotHubSku.GEN2, IotHubSku.S1])
+@pytest.mark.parametrize("sku", [IotHubSku.GEN2.value, IotHubSku.S1.value])
 @pytest.mark.parametrize(
     "existing_properties",
     [
@@ -48,7 +48,7 @@ def test_validate_and_set_adr_properties(namespace_id, identity_id, sku, existin
     instance = {"deviceRegistry": existing_properties}
 
     # Test behavior based on SKU type and parameters
-    if sku == IotHubSku.GEN2:  # Generation2 SKU
+    if sku == IotHubSku.GEN2.value:  # Generation2 SKU
         if namespace_id and identity_id:
             # Valid Gen2 configuration
             _validate_and_set_adr_properties(

--- a/azext_iot/tests/iothub/core/test_iothub_discovery_int.py
+++ b/azext_iot/tests/iothub/core/test_iothub_discovery_int.py
@@ -23,17 +23,17 @@ class TestIoTHubDiscovery(IoTLiveScenarioTest):
         discovery = IotHubDiscovery(self.cmd_shell)
 
         iothub = discovery.find_resource(resource_name=self.entity_name)
-        assert iothub.name == self.entity_name
+        assert iothub["name"] == self.entity_name
 
-        auto_policy = discovery.find_policy(resource_name=self.entity_name, rg=self.entity_rg).as_dict()
+        auto_policy = discovery.find_policy(resource_name=self.entity_name, rg=self.entity_rg)
         rights_set = set(auto_policy["rights"].split(", "))
         assert rights_set == PRIVILEDGED_ACCESS_RIGHTS_SET
 
         # Assumption - Test Iothub includes the vanilla iothubowner policy
         desired_policy = discovery.find_policy(
             resource_name=self.entity_name, rg=self.entity_rg, policy_name=self.desired_policy_name
-        ).as_dict()
-        assert desired_policy["key_name"] == self.desired_policy_name
+        )
+        assert desired_policy["keyName"] == self.desired_policy_name
 
         policies = discovery.get_policies(resource_name=self.entity_name, rg=self.entity_rg)
         assert len(policies)
@@ -46,14 +46,14 @@ class TestIoTHubDiscovery(IoTLiveScenarioTest):
         assert sub_hubs
 
         filtered_sub_hubs = [
-            hub for hub in sub_hubs if hub.as_dict()["name"] == self.entity_name
+            hub for hub in sub_hubs if hub["name"] == self.entity_name
         ]
         assert filtered_sub_hubs
 
         rg_hubs = discovery.get_resources(rg=self.entity_rg)
         assert rg_hubs
 
-        filtered_rg_hubs = [hub for hub in rg_hubs if hub.as_dict()["name"] == self.entity_name]
+        filtered_rg_hubs = [hub for hub in rg_hubs if hub["name"] == self.entity_name]
         assert filtered_rg_hubs
 
         assert len(rg_hubs) <= len(sub_hubs)

--- a/azext_iot/tests/iothub/core/test_iothub_utilities_int.py
+++ b/azext_iot/tests/iothub/core/test_iothub_utilities_int.py
@@ -68,7 +68,7 @@ class TestIoTHubUtilities(IoTLiveScenarioTest):
         )
 
     def test_iothub_connection_string_show(self):
-        conn_str_pattern = r"^HostName={0}.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=".format(
+        conn_str_pattern = r"^HostName={0}(\.\w+)?\.azure-devices\.net;SharedAccessKeyName=iothubowner;SharedAccessKey=".format(
             self.entity_name
         )
         conn_str_eventhub_pattern = (

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
@@ -357,7 +357,7 @@ class TestNestedEdgeHierarchy(IoTLiveScenarioTest):
                     # hub hostname
                     assert (
                         config["provisioning"]["iothub_hostname"]
-                        == f"{self.entity_name}.azure-devices.net"
+                        == self.host_name
                     )
                     # device_id
                     assert config["provisioning"]["device_id"] == device_id

--- a/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
+++ b/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
@@ -361,11 +361,6 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
             f"iot hub device-identity create -d {device_ids[1]} -n {self.entity_name} -g {self.entity_rg} --am x509_ca"
         )
 
-        sym_cstring_pattern = f"HostName={self.entity_name}.azure-devices.net;DeviceId={device_ids[0]};SharedAccessKey=#"
-        cer_cstring_pattern = (
-            f"HostName={self.entity_name}.azure-devices.net;DeviceId={device_ids[1]};x509=true"
-        )
-
         for auth_phase in DATAPLANE_AUTH_TYPES:
             primary_key_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -375,12 +370,11 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            target_key = symmetric_key_device["authentication"]["symmetricKey"][
-                "primaryKey"
-            ]
-            target_sym_cstring = sym_cstring_pattern.replace("#", target_key)
-
-            assert target_sym_cstring == primary_key_cstring["connectionString"]
+            cs = primary_key_cstring["connectionString"]
+            target_key = symmetric_key_device["authentication"]["symmetricKey"]["primaryKey"]
+            assert f"DeviceId={device_ids[0]}" in cs
+            assert f"SharedAccessKey={target_key}" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
             secondary_key_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -390,12 +384,11 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            target_key = symmetric_key_device["authentication"]["symmetricKey"][
-                "secondaryKey"
-            ]
-            target_sym_cstring = sym_cstring_pattern.replace("#", target_key)
-
-            assert target_sym_cstring == secondary_key_cstring["connectionString"]
+            cs = secondary_key_cstring["connectionString"]
+            target_key = symmetric_key_device["authentication"]["symmetricKey"]["secondaryKey"]
+            assert f"DeviceId={device_ids[0]}" in cs
+            assert f"SharedAccessKey={target_key}" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
             x509_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -405,7 +398,10 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            assert cer_cstring_pattern == x509_cstring["connectionString"]
+            cs = x509_cstring["connectionString"]
+            assert f"DeviceId={device_ids[1]}" in cs
+            assert "x509=true" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
     # TODO: Improve validation of tests via micro device client or other means.
     def test_iothub_device_generate_sas_token(self):

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
@@ -6,6 +6,7 @@
 
 import pytest
 import logging
+from collections import defaultdict
 import azext_iot.iothub.commands_message_endpoint as subject
 from azure.cli.core.azclierror import (
     MutuallyExclusiveArgumentError,
@@ -14,7 +15,6 @@ from azure.cli.core.azclierror import (
 from azext_iot.iothub.common import BYTES_PER_MEGABYTE, AuthenticationType
 from azext_iot.tests.generators import generate_names
 
-from azure.mgmt.iothub.models import ManagedIdentity
 
 logging.disable(logging.CRITICAL)
 
@@ -43,16 +43,27 @@ def fixture_update_endpoint_ops(mocker):
     find_resource = mocker.patch(path_find_resource, autospec=True)
 
     def create_mock_endpoint():
-        endpoint = mocker.Mock()
-        endpoint.name = endpoint_name
-        return endpoint
+        return defaultdict(lambda: None, name=endpoint_name, authenticationType="keyBased")
 
-    hub_mock = mocker.MagicMock()
-    hub_mock.properties.routing.endpoints.event_hubs = [create_mock_endpoint()]
-    hub_mock.properties.routing.endpoints.service_bus_queues = [create_mock_endpoint()]
-    hub_mock.properties.routing.endpoints.service_bus_topics = [create_mock_endpoint()]
-    hub_mock.properties.routing.endpoints.storage_containers = [create_mock_endpoint()]
-    hub_mock.properties.routing.endpoints.cosmos_db_sql_containers = [create_mock_endpoint()]
+    hub_mock = {
+        "name": "test-hub",
+        "etag": "test-etag",
+        "resourcegroup": "test-rg",
+        "subscriptionid": "test-sub",
+        "properties": {
+            "routing": {
+                "endpoints": {
+                    "eventHubs": [create_mock_endpoint()],
+                    "serviceBusQueues": [create_mock_endpoint()],
+                    "serviceBusTopics": [create_mock_endpoint()],
+                    "storageContainers": [create_mock_endpoint()],
+                    "cosmosDBSqlContainers": [create_mock_endpoint()],
+                },
+                "routes": [],
+                "enrichments": [],
+            }
+        }
+    }
 
     def initialize_mock_client(self, *args):
         self.client = mocker.MagicMock()
@@ -76,13 +87,27 @@ def fixture_update_endpoint_backwards_comp_ops(mocker):
     find_resource = mocker.patch(path_find_resource, autospec=True)
 
     def create_mock_endpoint():
-        endpoint = mocker.Mock()
-        endpoint.name = endpoint_name
-        return endpoint
+        return defaultdict(lambda: None, name=endpoint_name, authenticationType="keyBased")
 
-    hub_mock = mocker.MagicMock()
-    del hub_mock.properties.routing.endpoints.cosmos_db_sql_containers
-    hub_mock.properties.routing.endpoints.cosmos_db_sql_collections = [create_mock_endpoint()]
+    hub_mock = {
+        "name": "test-hub",
+        "etag": "test-etag",
+        "resourcegroup": "test-rg",
+        "subscriptionid": "test-sub",
+        "properties": {
+            "routing": {
+                "endpoints": {
+                    "eventHubs": [create_mock_endpoint()],
+                    "serviceBusQueues": [create_mock_endpoint()],
+                    "serviceBusTopics": [create_mock_endpoint()],
+                    "storageContainers": [create_mock_endpoint()],
+                    "cosmosDBSqlCollections": [create_mock_endpoint()],
+                },
+                "routes": [],
+                "enrichments": [],
+            }
+        }
+    }
 
     def initialize_mock_client(self, *args):
         self.client = mocker.MagicMock()
@@ -159,54 +184,53 @@ class TestMessageEndpointUpdate:
         resource_group = fixture_find_resource.call_args[0][2]
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
-        endpoints = hub_resource.properties.routing.endpoints.event_hubs
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["eventHubs"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.connection_string is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["connectionString"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif req.get("connection_string"):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
-            assert endpoint.connection_string == req.get("connection_string")
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
+            assert endpoint["connectionString"] == req.get("connection_string")
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"
 
         # props that are conditional
         if not req.get("connection_string"):
             if req.get("entity_path"):
-                assert endpoint.entity_path == req.get("entity_path")
+                assert endpoint["entityPath"] == req.get("entity_path")
             else:
-                assert isinstance(endpoint.entity_path, mock)
+                assert endpoint["entityPath"] is None
 
             if req.get("endpoint_uri"):
-                assert endpoint.endpoint_uri == req.get("endpoint_uri")
+                assert endpoint["endpointUri"] == req.get("endpoint_uri")
             else:
-                assert isinstance(endpoint.endpoint_uri, mock)
+                assert endpoint["endpointUri"] is None
 
     def test_message_endpoint_update_event_hub_error(self, fixture_cmd, fixture_update_endpoint_ops):
         # Cannot do both types of Authentication
@@ -295,54 +319,53 @@ class TestMessageEndpointUpdate:
         resource_group = fixture_find_resource.call_args[0][2]
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
-        endpoints = hub_resource.properties.routing.endpoints.service_bus_queues
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["serviceBusQueues"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.connection_string is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["connectionString"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif req.get("connection_string"):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
-            assert endpoint.connection_string == req.get("connection_string")
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
+            assert endpoint["connectionString"] == req.get("connection_string")
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"
 
         # props that are conditional
         if not req.get("connection_string"):
             if req.get("entity_path"):
-                assert endpoint.entity_path == req.get("entity_path")
+                assert endpoint["entityPath"] == req.get("entity_path")
             else:
-                assert isinstance(endpoint.entity_path, mock)
+                assert endpoint["entityPath"] is None
 
             if req.get("endpoint_uri"):
-                assert endpoint.endpoint_uri == req.get("endpoint_uri")
+                assert endpoint["endpointUri"] == req.get("endpoint_uri")
             else:
-                assert isinstance(endpoint.endpoint_uri, mock)
+                assert endpoint["endpointUri"] is None
 
     def test_message_endpoint_update_service_bus_queue_error(self, fixture_cmd, fixture_update_endpoint_ops):
         # Cannot do both types of Authentication
@@ -431,54 +454,53 @@ class TestMessageEndpointUpdate:
         resource_group = fixture_find_resource.call_args[0][2]
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
-        endpoints = hub_resource.properties.routing.endpoints.service_bus_topics
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["serviceBusTopics"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.connection_string is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["connectionString"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif req.get("connection_string"):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
-            assert endpoint.connection_string == req.get("connection_string")
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
+            assert endpoint["connectionString"] == req.get("connection_string")
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"
 
         # props that are conditional
         if not req.get("connection_string"):
             if req.get("entity_path"):
-                assert endpoint.entity_path == req.get("entity_path")
+                assert endpoint["entityPath"] == req.get("entity_path")
             else:
-                assert isinstance(endpoint.entity_path, mock)
+                assert endpoint["entityPath"] is None
 
             if req.get("endpoint_uri"):
-                assert endpoint.endpoint_uri == req.get("endpoint_uri")
+                assert endpoint["endpointUri"] == req.get("endpoint_uri")
             else:
-                assert isinstance(endpoint.endpoint_uri, mock)
+                assert endpoint["endpointUri"] is None
 
     def test_message_endpoint_update_service_bus_topic_error(self, fixture_cmd, fixture_update_endpoint_ops):
         # Cannot do both types of Authentication
@@ -566,69 +588,68 @@ class TestMessageEndpointUpdate:
         resource_group = fixture_find_resource.call_args[0][2]
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
-        endpoints = hub_resource.properties.routing.endpoints.storage_containers
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["storageContainers"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set if present
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         if req.get("file_name_format"):
-            assert endpoint.file_name_format == req.get("file_name_format")
+            assert endpoint["fileNameFormat"] == req.get("file_name_format")
         else:
-            assert isinstance(endpoint.file_name_format, mock)
+            assert endpoint["fileNameFormat"] is None
 
         if req.get("batch_frequency"):
-            assert endpoint.batch_frequency_in_seconds == req.get("batch_frequency")
+            assert endpoint["batchFrequencyInSeconds"] == req.get("batch_frequency")
         else:
-            assert isinstance(endpoint.batch_frequency_in_seconds, mock)
+            assert endpoint["batchFrequencyInSeconds"] is None
 
         if req.get("chunk_size_window"):
-            assert endpoint.max_chunk_size_in_bytes == (req.get("chunk_size_window") * BYTES_PER_MEGABYTE)
+            assert endpoint["maxChunkSizeInBytes"] == (req.get("chunk_size_window") * BYTES_PER_MEGABYTE)
         else:
-            assert isinstance(endpoint.max_chunk_size_in_bytes, mock)
+            assert endpoint["maxChunkSizeInBytes"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.connection_string is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["connectionString"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif req.get("connection_string"):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
-            assert endpoint.connection_string == req.get("connection_string")
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
+            assert endpoint["connectionString"] == req.get("connection_string")
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"
 
         # props that are conditional
         if not req.get("connection_string"):
             if req.get("entity_path"):
-                assert endpoint.entity_path == req.get("entity_path")
+                assert endpoint["entityPath"] == req.get("entity_path")
             else:
-                assert isinstance(endpoint.entity_path, mock)
+                assert endpoint["entityPath"] is None
 
             if req.get("endpoint_uri"):
-                assert endpoint.endpoint_uri == req.get("endpoint_uri")
+                assert endpoint["endpointUri"] == req.get("endpoint_uri")
             else:
-                assert isinstance(endpoint.endpoint_uri, mock)
+                assert endpoint["endpointUri"] is None
 
     def test_message_endpoint_update_storage_container_error(self, fixture_cmd, fixture_update_endpoint_ops):
         # Cannot do both types of Authentication
@@ -751,84 +772,83 @@ class TestMessageEndpointUpdate:
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
         # TODO: @vilit fix once service fixes their naming
-        endpoints = hub_resource.properties.routing.endpoints.cosmos_db_sql_containers
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["cosmosDBSqlContainers"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set if present
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         if req.get("database_name"):
-            assert endpoint.database_name == req.get("database_name").lower()
+            assert endpoint["databaseName"] == req.get("database_name").lower()
         else:
-            assert isinstance(endpoint.database_name, mock)
+            assert endpoint["databaseName"] is None
 
         if req.get("partition_key_name"):
             partition_key_name = req.get("partition_key_name")
             if partition_key_name == "":
-                assert endpoint.partition_key_name is None
+                assert endpoint["partitionKeyName"] is None
             else:
-                endpoint.partition_key_name == partition_key_name
+                endpoint["partitionKeyName"] == partition_key_name
         else:
-            assert isinstance(endpoint.partition_key_name, mock)
+            assert endpoint["partitionKeyName"] is None
 
         if req.get("partition_key_template"):
             partition_key_template = req.get("partition_key_template")
             if partition_key_template == "":
-                assert endpoint.partition_key_template is None
+                assert endpoint["partitionKeyTemplate"] is None
             else:
-                endpoint.partition_key_template == partition_key_template
+                endpoint["partitionKeyTemplate"] == partition_key_template
         else:
-            assert isinstance(endpoint.partition_key_template, mock)
+            assert endpoint["partitionKeyTemplate"] is None
 
         # Connection strings dont exist
-        assert isinstance(endpoint.connection_string, mock)
+        assert endpoint["connectionString"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.primary_key is None
-            assert endpoint.secondary_key is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["primaryKey"] is None
+            assert endpoint["secondaryKey"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif any([req.get("connection_string"), req.get("primary_key"), req.get("secondary_key")]):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
             connection_string = req.get("connection_string")
             primary_key = req.get("primary_key")
             secondary_key = req.get("secondary_key")
             endpoint_uri = req.get("endpoint_uri")
 
             if primary_key:
-                assert endpoint.primary_key == primary_key
+                assert endpoint["primaryKey"] == primary_key
             if secondary_key:
-                assert endpoint.secondary_key == secondary_key
+                assert endpoint["secondaryKey"] == secondary_key
             if not primary_key and not secondary_key and connection_string:
-                assert endpoint.primary_key == endpoint.secondary_key == "get_cosmos_db_account_key"
+                assert endpoint["primaryKey"] == endpoint["secondaryKey"] == "get_cosmos_db_account_key"
 
             if endpoint_uri:
-                assert endpoint.endpoint_uri == endpoint_uri
+                assert endpoint["endpointUri"] == endpoint_uri
             elif connection_string:
-                assert endpoint.endpoint_uri == "get_cosmos_db_account_endpoint"
+                assert endpoint["endpointUri"] == "get_cosmos_db_account_endpoint"
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"
 
     def test_message_endpoint_update_cosmos_db_sql_container_error(self, fixture_cmd, fixture_update_endpoint_ops):
         # Cannot do both types of Authentication
@@ -979,81 +999,80 @@ class TestMessageEndpointUpdate:
         assert req.get("resource_group_name") == resource_group
         hub_resource = fixture_find_resource.call_args[0][0].client.begin_create_or_update.call_args[0][2]
         # TODO: @vilit fix once service fixes their naming
-        endpoints = hub_resource.properties.routing.endpoints.cosmos_db_sql_collections
+        endpoints = hub_resource["properties"]["routing"]["endpoints"]["cosmosDBSqlCollections"]
         assert len(endpoints) == 1
         endpoint = endpoints[0]
 
-        assert endpoint.name == endpoint_name
-        mock = mocker.Mock
+        assert endpoint["name"] == endpoint_name
 
         # if a prop is not set, it will be a Mock object
         # Props that will always be set if present
         if req.get("endpoint_resource_group"):
-            assert endpoint.resource_group == req.get("endpoint_resource_group")
+            assert endpoint["resourceGroup"] == req.get("endpoint_resource_group")
         else:
-            assert isinstance(endpoint.resource_group, mock)
+            assert endpoint["resourceGroup"] is None
 
         if req.get("endpoint_subscription_id"):
-            assert endpoint.subscription_id == req.get("endpoint_subscription_id")
+            assert endpoint["subscriptionId"] == req.get("endpoint_subscription_id")
         else:
-            assert isinstance(endpoint.subscription_id, mock)
+            assert endpoint["subscriptionId"] is None
 
         if req.get("database_name"):
-            assert endpoint.database_name == req.get("database_name").lower()
+            assert endpoint["databaseName"] == req.get("database_name").lower()
         else:
-            assert isinstance(endpoint.database_name, mock)
+            assert endpoint["databaseName"] is None
 
         if req.get("partition_key_name"):
             partition_key_name = req.get("partition_key_name")
             if partition_key_name == "":
-                assert endpoint.partition_key_name is None
+                assert endpoint["partitionKeyName"] is None
             else:
-                endpoint.partition_key_name == partition_key_name
+                endpoint["partitionKeyName"] == partition_key_name
         else:
-            assert isinstance(endpoint.partition_key_name, mock)
+            assert endpoint["partitionKeyName"] is None
 
         if req.get("partition_key_template"):
             partition_key_template = req.get("partition_key_template")
             if partition_key_template == "":
-                assert endpoint.partition_key_template is None
+                assert endpoint["partitionKeyTemplate"] is None
             else:
-                endpoint.partition_key_template == partition_key_template
+                endpoint["partitionKeyTemplate"] == partition_key_template
         else:
-            assert isinstance(endpoint.partition_key_template, mock)
+            assert endpoint["partitionKeyTemplate"] is None
 
         # Connection strings dont exist
-        assert isinstance(endpoint.connection_string, mock)
+        assert endpoint["connectionString"] is None
 
         # Authentication props
         if req.get("identity"):
-            assert endpoint.authentication_type == AuthenticationType.IdentityBased.value
-            assert endpoint.primary_key is None
-            assert endpoint.secondary_key is None
+            assert endpoint["authenticationType"] == AuthenticationType.IdentityBased.value
+            assert endpoint["primaryKey"] is None
+            assert endpoint["secondaryKey"] is None
             identity = req.get("identity")
             if identity == "[system]":
-                assert endpoint.identity is None
+                assert endpoint["identity"] is None
             else:
-                assert isinstance(endpoint.identity, ManagedIdentity)
-                assert endpoint.identity.user_assigned_identity == identity
+                assert isinstance(endpoint["identity"], dict)
+                assert endpoint["identity"]["userAssignedIdentity"] == identity
         elif any([req.get("connection_string"), req.get("primary_key"), req.get("secondary_key")]):
-            assert endpoint.authentication_type == AuthenticationType.KeyBased.value
-            assert endpoint.identity is None
-            assert endpoint.entity_path is None
+            assert endpoint["authenticationType"] == AuthenticationType.KeyBased.value
+            assert endpoint["identity"] is None
+            assert endpoint["entityPath"] is None
             connection_string = req.get("connection_string")
             primary_key = req.get("primary_key")
             secondary_key = req.get("secondary_key")
             endpoint_uri = req.get("endpoint_uri")
 
             if primary_key:
-                assert endpoint.primary_key == primary_key
+                assert endpoint["primaryKey"] == primary_key
             if secondary_key:
-                assert endpoint.secondary_key == secondary_key
+                assert endpoint["secondaryKey"] == secondary_key
             if not primary_key and not secondary_key and connection_string:
-                assert endpoint.primary_key == endpoint.secondary_key == "get_cosmos_db_account_key"
+                assert endpoint["primaryKey"] == endpoint["secondaryKey"] == "get_cosmos_db_account_key"
 
             if endpoint_uri:
-                assert endpoint.endpoint_uri == endpoint_uri
+                assert endpoint["endpointUri"] == endpoint_uri
             elif connection_string:
-                assert endpoint.endpoint_uri == "get_cosmos_db_account_endpoint"
+                assert endpoint["endpointUri"] == "get_cosmos_db_account_endpoint"
         else:
-            assert isinstance(endpoint.authentication_type, mock)
+            assert endpoint["authenticationType"] == "keyBased"

--- a/azext_iot/tests/iothub/modules/test_iothub_modules_int.py
+++ b/azext_iot/tests/iothub/modules/test_iothub_modules_int.py
@@ -326,15 +326,6 @@ class TestIoTHubModules(IoTLiveScenarioTest):
             f"-m {module_ids[1]} -d {device_ids[0]} -n {self.entity_name} -g {self.entity_rg} --am x509_ca"
         )
 
-        sym_cstring_pattern = (
-            f"HostName={self.entity_name}.azure-devices.net;DeviceId={device_ids[0]};"
-            f"ModuleId={module_ids[0]};SharedAccessKey=#"
-        )
-        cer_cstring_pattern = (
-            f"HostName={self.entity_name}.azure-devices.net;"
-            f"DeviceId={device_ids[0]};ModuleId={module_ids[1]};x509=true"
-        )
-
         for auth_phase in DATAPLANE_AUTH_TYPES:
             primary_key_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -344,12 +335,12 @@ class TestIoTHubModules(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            target_key = symmetric_key_module["authentication"]["symmetricKey"][
-                "primaryKey"
-            ]
-            target_sym_cstring = sym_cstring_pattern.replace("#", target_key)
-
-            assert target_sym_cstring == primary_key_cstring["connectionString"]
+            cs = primary_key_cstring["connectionString"]
+            target_key = symmetric_key_module["authentication"]["symmetricKey"]["primaryKey"]
+            assert f"DeviceId={device_ids[0]}" in cs
+            assert f"ModuleId={module_ids[0]}" in cs
+            assert f"SharedAccessKey={target_key}" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
             secondary_key_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -359,12 +350,12 @@ class TestIoTHubModules(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            target_key = symmetric_key_module["authentication"]["symmetricKey"][
-                "secondaryKey"
-            ]
-            target_sym_cstring = sym_cstring_pattern.replace("#", target_key)
-
-            assert target_sym_cstring == secondary_key_cstring["connectionString"]
+            cs = secondary_key_cstring["connectionString"]
+            target_key = symmetric_key_module["authentication"]["symmetricKey"]["secondaryKey"]
+            assert f"DeviceId={device_ids[0]}" in cs
+            assert f"ModuleId={module_ids[0]}" in cs
+            assert f"SharedAccessKey={target_key}" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
             x509_cstring = self.cmd(
                 self.set_cmd_auth_type(
@@ -374,7 +365,11 @@ class TestIoTHubModules(IoTLiveScenarioTest):
                 )
             ).get_output_in_json()
 
-            assert cer_cstring_pattern == x509_cstring["connectionString"]
+            cs = x509_cstring["connectionString"]
+            assert f"DeviceId={device_ids[0]}" in cs
+            assert f"ModuleId={module_ids[1]}" in cs
+            assert "x509=true" in cs
+            assert cs.startswith(f"HostName={self.entity_name}")
 
     def test_iothub_module_generate_sas_token(self):
         device_count = 1


### PR DESCRIPTION
﻿ Adapts all IoT Hub and DPS management SDK consumers to use dict access (resource["key"]) instead of model attribute access (resource.property) after the modelless SDK regeneration. Also fixes enum serialization for IotHubSku/IotDpsSku and updates integration tests for 1.2.1 hostname resolution.

﻿ Verification

   - ✅ 1749 unit tests pass (0 regressions)
   - ✅ Flake8 lint clean
   - ✅ 29 commands manually verified on live resources (hub/DPS CRUD, connection strings, device
  identity, twin, enrollment, linked-hub, message-route, message-endpoint)
   - ✅ 28 integration tests pass; 
   
﻿Note: Some integration tests cannot run yet because 2026-03-01-preview is only deployed on canary
(eastus2euap) and limited to specific subscriptions. The canary test environment lacks full RBAC
permissions and test infrastructure (storage, EventHub, etc.). All failures have been verified to
also fail on the dev branch with the same hub. Once 2026-03-01-preview is deployed globally and we
can use the standard CI environment, all integration tests are expected to pass.