### PR TITLE
chore: remove hardcoded canary ARM endpoint

### DIFF
--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -57,9 +57,7 @@ def _get_credential_scopes(cli_ctx):
 
 
 def _get_arm_endpoint(cli_ctx):
-    """TODO: Revert to cli_ctx.cloud.endpoints.resource_manager once 2026-03-01-preview
-    is registered globally in ARM for all regions."""
-    return "https://eastus2euap.management.azure.com"
+    return cli_ctx.cloud.endpoints.resource_manager
 
 
 def iot_hub_service_factory(cli_ctx, *_):

--- a/azext_iot/tests/test_factory_unit.py
+++ b/azext_iot/tests/test_factory_unit.py
@@ -48,8 +48,7 @@ class TestFactoryCredentialScopes:
         mock_client_cls.assert_called_once()
         call_kwargs = mock_client_cls.call_args.kwargs
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
-        # TODO: Revert to cloud_config["resource_manager"] once 2026-03-01-preview is global
-        assert call_kwargs["endpoint"] == "https://eastus2euap.management.azure.com"
+        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
 
     def test_dps_factory(self, mocker, cloud_config):
         mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
@@ -64,8 +63,7 @@ class TestFactoryCredentialScopes:
         mock_client_cls.assert_called_once()
         call_kwargs = mock_client_cls.call_args.kwargs
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
-        # TODO: Revert to cloud_config["resource_manager"] once 2026-03-01-preview is global
-        assert call_kwargs["endpoint"] == "https://eastus2euap.management.azure.com"
+        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
 
     def test_adr_factory(self, mocker, cloud_config):
         mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")


### PR DESCRIPTION
The IoT Hub and DPS `2026-03-01-preview` ARM API was initially only available in canary (`eastus2euap`), so I hardcoded the ARM endpoint to `https://eastus2euap.management.azure.com`. The API is now registered globally and returns TLS 1.3 properties (deviceHostName, serviceHostName) from `management.azure.com` in all regions.

### Verification
 - Confirmed both IoT Hub and DPS `2026-03-01-preview` return 200 on global ARM
 - E2E CLI commands tested live (hub CRUD, device/module/twin, DPS, linked-hub, etc.) - zero failures
 - all unit tests passed, 6 factory tests updated and passing
