### PR TITLE
feat: ADR Ignite commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,32 @@
 Release History
 ===============
 
+0.33.0b1 (Preview)
++++++++++++++++
+
+**General updates**
+
+* Preview release introducing ADR Ignite command surface against the Microsoft.DeviceRegistry ``2026-11-02-preview`` API version.
+* DeviceRegistry management SDK regenerated to expose new ``Groups``, ``Jobs``, ``JobRuns`` operation groups and the extended ``Namespaces`` messaging/provisioning endpoint shape.
+* To install preview extensions, you will need to add the ``--allow-preview`` argument to ``az extension add/update`` commands.
+
+**ADR namespace updates**
+
+* New ``az iot adr ns group`` command group for managing device groups within an ADR namespace:
+
+  - ``create`` - create a Device-type group with a membership query.
+  - ``show`` / ``list`` / ``delete`` - inspect and remove groups.
+
+* New ``az iot adr ns job`` command group for managing namespace-scoped jobs:
+
+  - ``create`` - create an Update job targeting a group, parameterized by ``--update-provider``/``--update-name``/``--update-version``.
+  - ``show`` / ``list`` / ``delete`` - inspect and remove jobs.
+
+* New ``az iot adr ns link hub`` and ``az iot adr ns link dps`` command groups for managing namespace messaging/provisioning endpoint links to IoT Hub and DPS resources:
+
+  - ``add`` - attach an IoT Hub or DPS resource by ARM resource ID with either system- or user-assigned managed-identity authentication.
+  - ``show`` / ``list`` / ``remove`` - inspect and detach endpoint links.
+
 0.31.0b1 (Preview)
 +++++++++++++++
 

--- a/azext_iot/adr/_help.py
+++ b/azext_iot/adr/_help.py
@@ -429,12 +429,12 @@ def load_adr_help():
     - name: Add an IoT Hub link using the namespace's system-assigned identity
       text: |
         az iot adr ns link hub add -n hub1 --ns myNamespace -g myResourceGroup \\
-          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
+          --hub-resource-id "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
           --mi-system-assigned
     - name: Add an IoT Hub link using a user-assigned identity
       text: |
         az iot adr ns link hub add -n hub1 --ns myNamespace -g myResourceGroup \\
-          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
+          --hub-resource-id "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
           --mi-user-assigned "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami>"
   """
 
@@ -490,7 +490,7 @@ def load_adr_help():
     - name: Add a DPS link using the namespace's system-assigned identity
       text: |
         az iot adr ns link dps add -n dps1 --ns myNamespace -g myResourceGroup \\
-          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/ProvisioningServices/<dps>" \\
+          --dps-resource-id "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/ProvisioningServices/<dps>" \\
           --mi-system-assigned
   """
 

--- a/azext_iot/adr/_help.py
+++ b/azext_iot/adr/_help.py
@@ -292,3 +292,234 @@ def load_adr_help():
     - name: Revoke credentials and disable the device
       text: az iot adr ns device revoke -n myDevice --ns myNamespace -g myResourceGroup --disable
   """
+
+    # -------- Groups --------
+    helps[
+        "iot adr ns group"
+    ] = """
+  type: group
+  short-summary: Manage Device Registry groups (dynamic device memberships).
+  """
+
+    helps[
+        "iot adr ns group create"
+    ] = """
+  type: command
+  short-summary: Create a Device Registry group.
+  long-summary: |
+    Groups define a dynamic device membership using a query expression.
+    Today only "Device" groups are supported.
+  examples:
+    - name: Create a group with a membership query
+      text: |
+        az iot adr ns group create -n myGroup --ns myNamespace -g myResourceGroup \\
+          --qs "attributes.location == 'building-A'" --display-name "Building A devices"
+  """
+
+    helps[
+        "iot adr ns group show"
+    ] = """
+  type: command
+  short-summary: Show details of a Device Registry group.
+  examples:
+    - name: Show a group
+      text: az iot adr ns group show -n myGroup --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns group list"
+    ] = """
+  type: command
+  short-summary: List Device Registry groups in a namespace.
+  examples:
+    - name: List groups
+      text: az iot adr ns group list --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns group delete"
+    ] = """
+  type: command
+  short-summary: Delete a Device Registry group.
+  examples:
+    - name: Delete a group
+      text: az iot adr ns group delete -n myGroup --ns myNamespace -g myResourceGroup
+  """
+
+    # -------- Jobs --------
+    helps[
+        "iot adr ns job"
+    ] = """
+  type: group
+  short-summary: Manage Device Registry jobs (Update jobs targeting groups).
+  """
+
+    helps[
+        "iot adr ns job create"
+    ] = """
+  type: command
+  short-summary: Create an Update job in a Device Registry namespace.
+  long-summary: |
+    Creates a continuous Update job targeting a Device Registry group. The
+    update is identified by its Device Update updateId (provider/name/version).
+  examples:
+    - name: Create an Update job targeting a group
+      text: |
+        az iot adr ns job create -n myJob --ns myNamespace -g myResourceGroup \\
+          --tgid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DeviceRegistry/namespaces/<ns>/groups/<g>" \\
+          --up Contoso --un Toaster --uv 1.0.0
+  """
+
+    helps[
+        "iot adr ns job show"
+    ] = """
+  type: command
+  short-summary: Show details of a Device Registry job.
+  examples:
+    - name: Show a job
+      text: az iot adr ns job show -n myJob --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns job list"
+    ] = """
+  type: command
+  short-summary: List Device Registry jobs in a namespace.
+  examples:
+    - name: List jobs
+      text: az iot adr ns job list --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns job delete"
+    ] = """
+  type: command
+  short-summary: Delete a Device Registry job.
+  examples:
+    - name: Delete a job
+      text: az iot adr ns job delete -n myJob --ns myNamespace -g myResourceGroup
+  """
+
+    # -------- Links (hub) --------
+    helps[
+        "iot adr ns link"
+    ] = """
+  type: group
+  short-summary: Manage inbound endpoint links (IoT Hub / DPS) on a Device Registry namespace.
+  """
+
+    helps[
+        "iot adr ns link hub"
+    ] = """
+  type: group
+  short-summary: Manage IoT Hub messaging links on a Device Registry namespace.
+  """
+
+    helps[
+        "iot adr ns link hub add"
+    ] = """
+  type: command
+  short-summary: Add (or replace) an IoT Hub messaging link on the namespace.
+  long-summary: |
+    Attach an IoT Hub to the namespace as an inbound messaging endpoint. The
+    namespace identity used by inbound calls must be either system-assigned
+    (--mi-system-assigned) or a user-assigned identity already attached to the
+    namespace (--mi-user-assigned <resourceId>).
+  examples:
+    - name: Add an IoT Hub link using the namespace's system-assigned identity
+      text: |
+        az iot adr ns link hub add -n hub1 --ns myNamespace -g myResourceGroup \\
+          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
+          --mi-system-assigned
+    - name: Add an IoT Hub link using a user-assigned identity
+      text: |
+        az iot adr ns link hub add -n hub1 --ns myNamespace -g myResourceGroup \\
+          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/IotHubs/<hub>" \\
+          --mi-user-assigned "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uami>"
+  """
+
+    helps[
+        "iot adr ns link hub show"
+    ] = """
+  type: command
+  short-summary: Show details of an IoT Hub messaging link.
+  examples:
+    - name: Show a hub link
+      text: az iot adr ns link hub show -n hub1 --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns link hub list"
+    ] = """
+  type: command
+  short-summary: List IoT Hub messaging links on a namespace.
+  examples:
+    - name: List hub links
+      text: az iot adr ns link hub list --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns link hub remove"
+    ] = """
+  type: command
+  short-summary: Remove an IoT Hub messaging link from a namespace.
+  examples:
+    - name: Remove a hub link
+      text: az iot adr ns link hub remove -n hub1 --ns myNamespace -g myResourceGroup
+  """
+
+    # -------- Links (dps) --------
+    helps[
+        "iot adr ns link dps"
+    ] = """
+  type: group
+  short-summary: Manage Device Provisioning Service (DPS) links on a Device Registry namespace.
+  """
+
+    helps[
+        "iot adr ns link dps add"
+    ] = """
+  type: command
+  short-summary: Add (or replace) a DPS provisioning link on the namespace.
+  long-summary: |
+    Attach a Device Provisioning Service to the namespace as an inbound
+    provisioning endpoint. The namespace identity used for inbound calls must
+    be either system-assigned (--mi-system-assigned) or a user-assigned
+    identity already attached to the namespace (--mi-user-assigned).
+  examples:
+    - name: Add a DPS link using the namespace's system-assigned identity
+      text: |
+        az iot adr ns link dps add -n dps1 --ns myNamespace -g myResourceGroup \\
+          --rid "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Devices/ProvisioningServices/<dps>" \\
+          --mi-system-assigned
+  """
+
+    helps[
+        "iot adr ns link dps show"
+    ] = """
+  type: command
+  short-summary: Show details of a DPS provisioning link.
+  examples:
+    - name: Show a DPS link
+      text: az iot adr ns link dps show -n dps1 --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns link dps list"
+    ] = """
+  type: command
+  short-summary: List DPS provisioning links on a namespace.
+  examples:
+    - name: List DPS links
+      text: az iot adr ns link dps list --ns myNamespace -g myResourceGroup
+  """
+
+    helps[
+        "iot adr ns link dps remove"
+    ] = """
+  type: command
+  short-summary: Remove a DPS provisioning link from a namespace.
+  examples:
+    - name: Remove a DPS link
+      text: az iot adr ns link dps remove -n dps1 --ns myNamespace -g myResourceGroup
+  """

--- a/azext_iot/adr/_help.py
+++ b/azext_iot/adr/_help.py
@@ -424,7 +424,7 @@ def load_adr_help():
     Attach an IoT Hub to the namespace as an inbound messaging endpoint. The
     namespace identity used by inbound calls must be either system-assigned
     (--mi-system-assigned) or a user-assigned identity already attached to the
-    namespace (--mi-user-assigned <resourceId>).
+    namespace (--mi-user-assigned `<resourceId>`).
   examples:
     - name: Add an IoT Hub link using the namespace's system-assigned identity
       text: |

--- a/azext_iot/adr/command_map.py
+++ b/azext_iot/adr/command_map.py
@@ -28,6 +28,21 @@ adr_device_ops = CliCommandType(
     client_factory=adr_service_factory,
 )
 
+adr_group_ops = CliCommandType(
+    operations_tmpl="azext_iot.adr.commands_group#{}",
+    client_factory=adr_service_factory,
+)
+
+adr_job_ops = CliCommandType(
+    operations_tmpl="azext_iot.adr.commands_job#{}",
+    client_factory=adr_service_factory,
+)
+
+adr_link_ops = CliCommandType(
+    operations_tmpl="azext_iot.adr.commands_link#{}",
+    client_factory=adr_service_factory,
+)
+
 
 def load_adr_commands(self, _):
     # Namespace commands
@@ -61,3 +76,31 @@ def load_adr_commands(self, _):
         cmd_group.command("list", "adr_device_list")
         cmd_group.command("update", "adr_device_update")
         cmd_group.command("revoke", "adr_device_revoke", confirmation=True)
+
+    # Group commands
+    with self.command_group("iot adr ns group", command_type=adr_group_ops) as cmd_group:
+        cmd_group.command("create", "adr_group_create")
+        cmd_group.show_command("show", "adr_group_show")
+        cmd_group.command("list", "adr_group_list")
+        cmd_group.command("delete", "adr_group_delete", confirmation=True)
+
+    # Job commands
+    with self.command_group("iot adr ns job", command_type=adr_job_ops) as cmd_group:
+        cmd_group.command("create", "adr_job_create")
+        cmd_group.show_command("show", "adr_job_show")
+        cmd_group.command("list", "adr_job_list")
+        cmd_group.command("delete", "adr_job_delete", confirmation=True)
+
+    # Link commands (IoT Hub)
+    with self.command_group("iot adr ns link hub", command_type=adr_link_ops) as cmd_group:
+        cmd_group.command("add", "adr_link_hub_add")
+        cmd_group.show_command("show", "adr_link_hub_show")
+        cmd_group.command("list", "adr_link_hub_list")
+        cmd_group.command("remove", "adr_link_hub_remove", confirmation=True)
+
+    # Link commands (DPS)
+    with self.command_group("iot adr ns link dps", command_type=adr_link_ops) as cmd_group:
+        cmd_group.command("add", "adr_link_dps_add")
+        cmd_group.show_command("show", "adr_link_dps_show")
+        cmd_group.command("list", "adr_link_dps_list")
+        cmd_group.command("remove", "adr_link_dps_remove", confirmation=True)

--- a/azext_iot/adr/commands_group.py
+++ b/azext_iot/adr/commands_group.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+
+from azext_iot.adr.providers.group import GroupProvider
+
+
+def adr_group_create(
+    cmd,
+    group_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    query: str,
+    group_type: str = "Device",
+    display_name: Optional[str] = None,
+    description: Optional[str] = None,
+    location: Optional[str] = None,
+    tags: Optional[Dict[str, str]] = None,
+):
+    provider = GroupProvider(cmd)
+    return provider.create(
+        group_name=group_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        query=query,
+        group_type=group_type,
+        display_name=display_name,
+        description=description,
+        location=location,
+        tags=tags,
+    )
+
+
+def adr_group_show(cmd, group_name: str, namespace_name: str, resource_group_name: str):
+    provider = GroupProvider(cmd)
+    return provider.show(
+        group_name=group_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_group_list(cmd, namespace_name: str, resource_group_name: str):
+    provider = GroupProvider(cmd)
+    return provider.list(
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_group_delete(cmd, group_name: str, namespace_name: str, resource_group_name: str):
+    provider = GroupProvider(cmd)
+    return provider.delete(
+        group_name=group_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )

--- a/azext_iot/adr/commands_job.py
+++ b/azext_iot/adr/commands_job.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+
+from azext_iot.adr.providers.job import JobProvider
+
+
+def adr_job_create(
+    cmd,
+    job_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    target_group_id: str,
+    update_provider: str,
+    update_name: str,
+    update_version: str,
+    location: Optional[str] = None,
+    tags: Optional[Dict[str, str]] = None,
+):
+    provider = JobProvider(cmd)
+    return provider.create(
+        job_name=job_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        target_group_id=target_group_id,
+        update_provider=update_provider,
+        update_name=update_name,
+        update_version=update_version,
+        location=location,
+        tags=tags,
+    )
+
+
+def adr_job_show(cmd, job_name: str, namespace_name: str, resource_group_name: str):
+    provider = JobProvider(cmd)
+    return provider.show(
+        job_name=job_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_job_list(cmd, namespace_name: str, resource_group_name: str):
+    provider = JobProvider(cmd)
+    return provider.list(
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_job_delete(cmd, job_name: str, namespace_name: str, resource_group_name: str):
+    provider = JobProvider(cmd)
+    return provider.delete(
+        job_name=job_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )

--- a/azext_iot/adr/commands_link.py
+++ b/azext_iot/adr/commands_link.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Optional
+
+from azext_iot.adr.providers.linking import (
+    LINK_KIND_DPS,
+    LINK_KIND_HUB,
+    LinkProvider,
+)
+
+
+# ---- IoT Hub link commands ----
+
+def adr_link_hub_add(
+    cmd,
+    link_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    resource_id: str,
+    mi_system_assigned: bool = False,
+    mi_user_assigned: Optional[str] = None,
+    endpoint_type: Optional[str] = None,
+):
+    provider = LinkProvider(cmd)
+    return provider.add(
+        kind=LINK_KIND_HUB,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        resource_id=resource_id,
+        mi_system_assigned=mi_system_assigned,
+        mi_user_assigned=mi_user_assigned,
+        endpoint_type=endpoint_type,
+    )
+
+
+def adr_link_hub_show(cmd, link_name: str, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.show(
+        kind=LINK_KIND_HUB,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_link_hub_list(cmd, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.list(
+        kind=LINK_KIND_HUB,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_link_hub_remove(cmd, link_name: str, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.remove(
+        kind=LINK_KIND_HUB,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+# ---- DPS link commands ----
+
+def adr_link_dps_add(
+    cmd,
+    link_name: str,
+    namespace_name: str,
+    resource_group_name: str,
+    resource_id: str,
+    mi_system_assigned: bool = False,
+    mi_user_assigned: Optional[str] = None,
+    endpoint_type: Optional[str] = None,
+):
+    provider = LinkProvider(cmd)
+    return provider.add(
+        kind=LINK_KIND_DPS,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+        resource_id=resource_id,
+        mi_system_assigned=mi_system_assigned,
+        mi_user_assigned=mi_user_assigned,
+        endpoint_type=endpoint_type,
+    )
+
+
+def adr_link_dps_show(cmd, link_name: str, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.show(
+        kind=LINK_KIND_DPS,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_link_dps_list(cmd, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.list(
+        kind=LINK_KIND_DPS,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )
+
+
+def adr_link_dps_remove(cmd, link_name: str, namespace_name: str, resource_group_name: str):
+    provider = LinkProvider(cmd)
+    return provider.remove(
+        kind=LINK_KIND_DPS,
+        link_name=link_name,
+        namespace_name=namespace_name,
+        resource_group_name=resource_group_name,
+    )

--- a/azext_iot/adr/params_adr_management.py
+++ b/azext_iot/adr/params_adr_management.py
@@ -278,13 +278,9 @@ def load_adr_management_arguments(self, _):
                 help="Name of the link (key on the namespace endpoints dictionary).",
             )
 
+    # Shared identity + endpoint-type args for both link-add variants.
     for cmd in ["iot adr ns link hub add", "iot adr ns link dps add"]:
         with self.argument_context(cmd) as context:
-            context.argument(
-                "resource_id",
-                options_list=["--resource-id", "--rid"],
-                help="ARM resource ID of the IoT Hub or DPS to link.",
-            )
             context.argument(
                 "mi_system_assigned",
                 options_list=["--mi-system-assigned"],
@@ -308,3 +304,18 @@ def load_adr_management_arguments(self, _):
                      "'Microsoft.Devices/IotHubs' for hub links and "
                      "'Microsoft.Devices/ProvisioningServices' for DPS links.",
             )
+
+    # Per-subgroup spelling for the linked resource's ARM ID, mirroring
+    # the --policy-resource-id convention used elsewhere in this file.
+    with self.argument_context("iot adr ns link hub add") as context:
+        context.argument(
+            "resource_id",
+            options_list=["--hub-resource-id"],
+            help="ARM resource ID of the IoT Hub to link.",
+        )
+    with self.argument_context("iot adr ns link dps add") as context:
+        context.argument(
+            "resource_id",
+            options_list=["--dps-resource-id"],
+            help="ARM resource ID of the Device Provisioning Service to link.",
+        )

--- a/azext_iot/adr/params_adr_management.py
+++ b/azext_iot/adr/params_adr_management.py
@@ -176,3 +176,135 @@ def load_adr_management_arguments(self, _):
             help="Disable the device after revoking credentials. "
                  "Prevents new credentials from being issued.",
         )
+
+    # ----- Group commands -----
+    with self.argument_context("iot adr ns group") as context:
+        context.argument(
+            "namespace_name",
+            options_list=["--namespace", "--ns"],
+            help="Name of the Device Registry namespace.",
+        )
+        context.argument(
+            "group_name",
+            options_list=["--group-name", "--name", "-n"],
+            help="Name of the group.",
+        )
+
+    with self.argument_context("iot adr ns group create") as context:
+        context.argument("tags", arg_type=tags_type)
+        context.argument(
+            "location",
+            arg_type=get_location_type(self.cli_ctx),
+            validator=get_default_location_from_resource_group,
+        )
+        context.argument(
+            "query",
+            options_list=["--query-string", "--qs"],
+            help="Membership query for the group (Kusto-style query over device "
+                 "attributes). Use --query-string to avoid clashing with the "
+                 "global --query JMESPath argument.",
+        )
+        context.argument(
+            "group_type",
+            options_list=["--group-type"],
+            help="Type of group. Currently only 'Device' is supported.",
+        )
+        context.argument(
+            "display_name",
+            options_list=["--display-name", "--dn"],
+            help="Friendly display name for the group.",
+        )
+        context.argument(
+            "description",
+            options_list=["--description"],
+            help="Description of the group.",
+        )
+
+    # ----- Job commands -----
+    with self.argument_context("iot adr ns job") as context:
+        context.argument(
+            "namespace_name",
+            options_list=["--namespace", "--ns"],
+            help="Name of the Device Registry namespace.",
+        )
+        context.argument(
+            "job_name",
+            options_list=["--job-name", "--name", "-n"],
+            help="Name of the job.",
+        )
+
+    with self.argument_context("iot adr ns job create") as context:
+        context.argument("tags", arg_type=tags_type)
+        context.argument(
+            "location",
+            arg_type=get_location_type(self.cli_ctx),
+            validator=get_default_location_from_resource_group,
+        )
+        context.argument(
+            "target_group_id",
+            options_list=["--target-group-id", "--tgid"],
+            help="ARM resource ID of the Device Registry group this job targets.",
+        )
+        context.argument(
+            "update_provider",
+            options_list=["--update-provider", "--up"],
+            arg_group="Update",
+            help="Device Update 'provider' segment of the update ID.",
+        )
+        context.argument(
+            "update_name",
+            options_list=["--update-name", "--un"],
+            arg_group="Update",
+            help="Device Update 'name' segment of the update ID.",
+        )
+        context.argument(
+            "update_version",
+            options_list=["--update-version", "--uv"],
+            arg_group="Update",
+            help="Device Update 'version' segment of the update ID.",
+        )
+
+    # ----- Link commands (hub + dps share the same parameter shape) -----
+    for cmd in ["iot adr ns link hub", "iot adr ns link dps"]:
+        with self.argument_context(cmd) as context:
+            context.argument(
+                "namespace_name",
+                options_list=["--namespace", "--ns"],
+                help="Name of the Device Registry namespace.",
+            )
+            context.argument(
+                "link_name",
+                options_list=["--link-name", "--name", "-n"],
+                help="Name of the link (key on the namespace endpoints dictionary).",
+            )
+
+    for cmd in ["iot adr ns link hub add", "iot adr ns link dps add"]:
+        with self.argument_context(cmd) as context:
+            context.argument(
+                "resource_id",
+                options_list=["--resource-id", "--rid"],
+                help="ARM resource ID of the IoT Hub or DPS to link.",
+            )
+            context.argument(
+                "mi_system_assigned",
+                options_list=["--mi-system-assigned"],
+                arg_type=get_three_state_flag(),
+                arg_group="Identity",
+                help="Use the namespace's system-assigned managed identity for "
+                     "inbound calls. Mutually exclusive with --mi-user-assigned.",
+            )
+            context.argument(
+                "mi_user_assigned",
+                options_list=["--mi-user-assigned"],
+                arg_group="Identity",
+                help="Resource ID of a user-assigned managed identity already "
+                     "attached to the namespace. Mutually exclusive with "
+                     "--mi-system-assigned.",
+            )
+            context.argument(
+                "endpoint_type",
+                options_list=["--endpoint-type"],
+                help="Override the endpoint type discriminator. Defaults to "
+                     "'Microsoft.Devices/IotHubs' for hub links and "
+                     "'Microsoft.Devices/ProvisioningServices' for DPS links.",
+            )

--- a/azext_iot/adr/providers/group.py
+++ b/azext_iot/adr/providers/group.py
@@ -1,0 +1,102 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+
+from knack.log import get_logger
+from rich.console import Console
+
+from azext_iot.adr.providers.base import ADRProvider
+from azext_iot.common.utility import wait_for_terminal_state
+
+console = Console()
+logger = get_logger(__name__)
+
+
+# Device Registry group resource ("Group") provider. Groups define a dynamic
+# membership of devices by query, and are the targets of update jobs.
+class GroupProvider(ADRProvider):
+    def __init__(self, cmd):
+        super(GroupProvider, self).__init__(cmd)
+
+    def show(self, group_name: str, namespace_name: str, resource_group_name: str):
+        return self.client.groups.get(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+        )
+
+    def list(self, namespace_name: str, resource_group_name: str):
+        return list(
+            self.client.groups.list_by_namespace(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+            )
+        )
+
+    def create(
+        self,
+        group_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        query: str,
+        group_type: str = "Device",
+        display_name: Optional[str] = None,
+        description: Optional[str] = None,
+        location: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        """Create or replace a group in the namespace."""
+        # Inherit the namespace location when the caller doesn't provide one.
+        location = location or self._ensure_location(
+            self.cmd.cli_ctx, resource_group_name=resource_group_name
+        )
+
+        inner_props = {
+            "groupType": group_type,
+            "query": query,
+        }
+        if display_name is not None:
+            inner_props["displayName"] = display_name
+        if description is not None:
+            inner_props["description"] = description
+
+        resource = {
+            "location": location,
+            "properties": inner_props,
+        }
+        if tags is not None:
+            resource["tags"] = tags
+
+        with console.status(
+            f"Creating group '{group_name}' in namespace {namespace_name}..."
+        ):
+            poller = self.client.groups.begin_create_or_replace(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                group_name=group_name,
+                resource=resource,
+            )
+            return wait_for_terminal_state(poller, **kwargs)
+
+    def delete(
+        self,
+        group_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        **kwargs,
+    ):
+        """Delete a group from the namespace."""
+        with console.status(
+            f"Deleting group '{group_name}' from namespace {namespace_name}..."
+        ):
+            poller = self.client.groups.begin_delete(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                group_name=group_name,
+            )
+            return wait_for_terminal_state(poller, **kwargs)

--- a/azext_iot/adr/providers/job.py
+++ b/azext_iot/adr/providers/job.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Dict, Optional
+
+from knack.log import get_logger
+from rich.console import Console
+
+from azext_iot.adr.providers.base import ADRProvider
+from azext_iot.common.utility import wait_for_terminal_state
+
+console = Console()
+logger = get_logger(__name__)
+
+
+# Device Registry job provider. Jobs target groups and apply an action (today,
+# only "Update" jobs are supported by the service).
+class JobProvider(ADRProvider):
+    def __init__(self, cmd):
+        super(JobProvider, self).__init__(cmd)
+
+    def show(self, job_name: str, namespace_name: str, resource_group_name: str):
+        return self.client.jobs.get(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+        )
+
+    def list(self, namespace_name: str, resource_group_name: str):
+        return list(
+            self.client.jobs.list_by_namespace(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+            )
+        )
+
+    def create(
+        self,
+        job_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        target_group_id: str,
+        update_provider: str,
+        update_name: str,
+        update_version: str,
+        scheduling_type: str = "continuous",
+        job_type: str = "Update",
+        location: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        """Create or replace an Update job targeting the given group."""
+        location = location or self._ensure_location(
+            self.cmd.cli_ctx, resource_group_name=resource_group_name
+        )
+
+        # Job body mirrors the Microsoft.DeviceRegistry Job schema. For PoC we
+        # only support the "Update" discriminator.
+        inner_props = {
+            "jobType": job_type,
+            "target": {"targetResourceId": target_group_id},
+            "definition": {
+                "schedulingType": scheduling_type,
+                "update": {
+                    "updateId": {
+                        "provider": update_provider,
+                        "name": update_name,
+                        "version": update_version,
+                    }
+                },
+            },
+        }
+
+        resource = {
+            "location": location,
+            "properties": inner_props,
+        }
+        if tags is not None:
+            resource["tags"] = tags
+
+        with console.status(
+            f"Creating job '{job_name}' in namespace {namespace_name}..."
+        ):
+            poller = self.client.jobs.begin_create_or_replace(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                job_name=job_name,
+                resource=resource,
+            )
+            return wait_for_terminal_state(poller, **kwargs)
+
+    def delete(
+        self,
+        job_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        **kwargs,
+    ):
+        """Delete a job from the namespace."""
+        with console.status(
+            f"Deleting job '{job_name}' from namespace {namespace_name}..."
+        ):
+            poller = self.client.jobs.begin_delete(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                job_name=job_name,
+            )
+            return wait_for_terminal_state(poller, **kwargs)

--- a/azext_iot/adr/providers/linking.py
+++ b/azext_iot/adr/providers/linking.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from typing import Optional
+
+from azure.cli.core.azclierror import (
+    MutuallyExclusiveArgumentError,
+    RequiredArgumentMissingError,
+    ResourceNotFoundError,
+)
+from knack.log import get_logger
+from rich.console import Console
+
+from azext_iot.adr.providers.base import ADRProvider
+from azext_iot.common.utility import wait_for_terminal_state
+
+console = Console()
+logger = get_logger(__name__)
+
+
+# Default endpoint type discriminator strings used when the caller doesn't
+# override them. These match the ARM resource type segments for IoT Hub and
+# Device Provisioning Service.
+DEFAULT_HUB_ENDPOINT_TYPE = "Microsoft.Devices/IotHubs"
+DEFAULT_DPS_ENDPOINT_TYPE = "Microsoft.Devices/ProvisioningServices"
+
+LINK_KIND_HUB = "hub"
+LINK_KIND_DPS = "dps"
+
+
+def _build_identity(mi_system_assigned: bool, mi_user_assigned: Optional[str]) -> dict:
+    """Build the inboundCallerIdentity body for a linked endpoint.
+
+    Exactly one of system-assigned or user-assigned must be provided.
+    """
+    if mi_system_assigned and mi_user_assigned:
+        raise MutuallyExclusiveArgumentError(
+            "--mi-system-assigned and --mi-user-assigned cannot be used together."
+        )
+    if not mi_system_assigned and not mi_user_assigned:
+        raise RequiredArgumentMissingError(
+            "An identity is required: pass either --mi-system-assigned or "
+            "--mi-user-assigned <userAssignedIdentityResourceId>."
+        )
+    if mi_user_assigned:
+        return {"type": "UserAssigned", "userAssignedIdentity": mi_user_assigned}
+    return {"type": "SystemAssigned"}
+
+
+def _endpoint_section_path(kind: str) -> tuple:
+    """Return (top_key, sub_key) pair for the endpoint dictionary on the
+    namespace ``properties`` payload. Hub links live under
+    ``messaging.endpoints``; DPS links live under ``provisioning.endpoints``.
+    """
+    if kind == LINK_KIND_HUB:
+        return "messaging", "endpoints"
+    if kind == LINK_KIND_DPS:
+        return "provisioning", "endpoints"
+    raise ValueError(f"Unknown link kind: {kind}")
+
+
+def _read_endpoint_dict(namespace_resource: dict, kind: str) -> dict:
+    """Pluck the endpoint dictionary from a namespace resource (as returned
+    by GET). Returns an empty dict if the section is missing."""
+    top_key, sub_key = _endpoint_section_path(kind)
+    props = (namespace_resource or {}).get("properties", {}) or {}
+    section = props.get(top_key, {}) or {}
+    return section.get(sub_key, {}) or {}
+
+
+def _build_endpoint_patch(kind: str, name: str, endpoint_body) -> dict:
+    """Wrap an endpoint body in the namespace patch envelope.
+
+    ``endpoint_body`` set to ``None`` removes the endpoint key from the
+    additionalProperties dictionary.
+    """
+    top_key, sub_key = _endpoint_section_path(kind)
+    return {
+        "properties": {
+            top_key: {
+                sub_key: {name: endpoint_body},
+            }
+        }
+    }
+
+
+class LinkProvider(ADRProvider):
+    """Provider for managing inbound endpoint links (IoT Hub & DPS) attached
+    to a Device Registry namespace."""
+
+    def __init__(self, cmd):
+        super(LinkProvider, self).__init__(cmd)
+
+    # --------- read helpers (operate on the namespace GET response) ---------
+
+    def _get_namespace(self, namespace_name: str, resource_group_name: str) -> dict:
+        return self.client.namespaces.get(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+        )
+
+    def show(self, kind: str, link_name: str, namespace_name: str, resource_group_name: str):
+        namespace = self._get_namespace(namespace_name, resource_group_name)
+        endpoints = _read_endpoint_dict(namespace, kind)
+        if link_name not in endpoints:
+            raise ResourceNotFoundError(
+                f"No {kind} link named '{link_name}' was found on namespace "
+                f"'{namespace_name}' in resource group '{resource_group_name}'."
+            )
+        return endpoints[link_name]
+
+    def list(self, kind: str, namespace_name: str, resource_group_name: str) -> list:
+        namespace = self._get_namespace(namespace_name, resource_group_name)
+        endpoints = _read_endpoint_dict(namespace, kind)
+        # Normalize the additionalProperties dict into a list of {name, ...}
+        # entries, matching how Azure CLI lists nested children elsewhere.
+        result = []
+        for name, body in endpoints.items():
+            entry = {"name": name}
+            if isinstance(body, dict):
+                entry.update(body)
+            result.append(entry)
+        return result
+
+    # --------- write helpers (PATCH the namespace) ---------
+
+    def add(
+        self,
+        kind: str,
+        link_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        resource_id: str,
+        mi_system_assigned: bool = False,
+        mi_user_assigned: Optional[str] = None,
+        endpoint_type: Optional[str] = None,
+        **kwargs,
+    ):
+        """Add (or replace) a single endpoint link on the namespace."""
+        identity = _build_identity(mi_system_assigned, mi_user_assigned)
+
+        endpoint_body = {
+            "resourceId": resource_id,
+            "inboundCallerIdentity": identity,
+        }
+        # DPS endpoint requires endpointType per swagger. For hub it is optional
+        # but harmless. Set a sensible default when one isn't provided.
+        if endpoint_type is None:
+            endpoint_type = (
+                DEFAULT_DPS_ENDPOINT_TYPE if kind == LINK_KIND_DPS else DEFAULT_HUB_ENDPOINT_TYPE
+            )
+        endpoint_body["endpointType"] = endpoint_type
+
+        properties = _build_endpoint_patch(kind, link_name, endpoint_body)
+
+        with console.status(
+            f"Adding {kind} link '{link_name}' to namespace {namespace_name}..."
+        ):
+            poller = self.client.namespaces.begin_update(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                properties=properties,
+            )
+            return wait_for_terminal_state(poller, **kwargs)
+
+    def remove(
+        self,
+        kind: str,
+        link_name: str,
+        namespace_name: str,
+        resource_group_name: str,
+        **kwargs,
+    ):
+        """Remove an endpoint link from the namespace. Done via PATCH with
+        the endpoint key set to ``null`` (ARM additionalProperties tombstone)."""
+        properties = _build_endpoint_patch(kind, link_name, None)
+
+        with console.status(
+            f"Removing {kind} link '{link_name}' from namespace {namespace_name}..."
+        ):
+            poller = self.client.namespaces.begin_update(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                properties=properties,
+            )
+            return wait_for_terminal_state(poller, **kwargs)

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.31.0b1"
+VERSION = "0.33.0b1"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/sdk/deviceregistry/_client.py
+++ b/azext_iot/sdk/deviceregistry/_client.py
@@ -17,30 +17,44 @@ from azure.mgmt.core.policies import ARMAutoResourceProviderRegistrationPolicy
 
 from ._configuration import MicrosoftDeviceRegistryManagementServiceConfiguration
 from ._serialization import Deserializer, Serializer
-from .operations import CredentialsOperations, NamespaceDevicesOperations, NamespacesOperations, PoliciesOperations
+from .operations import (
+    CredentialsOperations,
+    GroupsOperations,
+    JobRunsOperations,
+    JobsOperations,
+    NamespaceDevicesOperations,
+    NamespacesOperations,
+    PoliciesOperations,
+)
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
 
 
-class MicrosoftDeviceRegistryManagementService:
+class MicrosoftDeviceRegistryManagementService:  # pylint: disable=too-many-instance-attributes
     """Microsoft.DeviceRegistry Resource Provider management API.
 
     :ivar namespaces: NamespacesOperations operations
-    :vartype namespaces: deviceregistry.mgmt.operations.NamespacesOperations
+    :vartype namespaces: azext_iot.sdk.deviceregistry.operations.NamespacesOperations
     :ivar credentials: CredentialsOperations operations
-    :vartype credentials: deviceregistry.mgmt.operations.CredentialsOperations
+    :vartype credentials: azext_iot.sdk.deviceregistry.operations.CredentialsOperations
     :ivar policies: PoliciesOperations operations
-    :vartype policies: deviceregistry.mgmt.operations.PoliciesOperations
+    :vartype policies: azext_iot.sdk.deviceregistry.operations.PoliciesOperations
     :ivar namespace_devices: NamespaceDevicesOperations operations
-    :vartype namespace_devices: deviceregistry.mgmt.operations.NamespaceDevicesOperations
+    :vartype namespace_devices: azext_iot.sdk.deviceregistry.operations.NamespaceDevicesOperations
+    :ivar groups: GroupsOperations operations
+    :vartype groups: azext_iot.sdk.deviceregistry.operations.GroupsOperations
+    :ivar jobs: JobsOperations operations
+    :vartype jobs: azext_iot.sdk.deviceregistry.operations.JobsOperations
+    :ivar job_runs: JobRunsOperations operations
+    :vartype job_runs: azext_iot.sdk.deviceregistry.operations.JobRunsOperations
     :param credential: Credential needed for the client to connect to Azure. Required.
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
     :param endpoint: Service URL. Default value is "https://management.azure.com".
     :type endpoint: str
-    :keyword api_version: Api Version. Default value is "2026-03-01-preview". Note that overriding
+    :keyword api_version: Api Version. Default value is "2026-11-02-preview". Note that overriding
      this default value may result in unsupported behavior.
     :paramtype api_version: str
     :keyword int polling_interval: Default waiting time between two polls for LRO operations if no
@@ -86,6 +100,9 @@ class MicrosoftDeviceRegistryManagementService:
         self.namespace_devices = NamespaceDevicesOperations(
             self._client, self._config, self._serialize, self._deserialize
         )
+        self.groups = GroupsOperations(self._client, self._config, self._serialize, self._deserialize)
+        self.jobs = JobsOperations(self._client, self._config, self._serialize, self._deserialize)
+        self.job_runs = JobRunsOperations(self._client, self._config, self._serialize, self._deserialize)
 
     def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs the network request through the client's chained policies.

--- a/azext_iot/sdk/deviceregistry/_configuration.py
+++ b/azext_iot/sdk/deviceregistry/_configuration.py
@@ -28,13 +28,13 @@ class MicrosoftDeviceRegistryManagementServiceConfiguration:  # pylint: disable=
     :type credential: ~azure.core.credentials.TokenCredential
     :param subscription_id: The ID of the target subscription. The value must be an UUID. Required.
     :type subscription_id: str
-    :keyword api_version: Api Version. Default value is "2026-03-01-preview". Note that overriding
+    :keyword api_version: Api Version. Default value is "2026-11-02-preview". Note that overriding
      this default value may result in unsupported behavior.
     :paramtype api_version: str
     """
 
     def __init__(self, credential: "TokenCredential", subscription_id: str, **kwargs: Any) -> None:
-        api_version: str = kwargs.pop("api_version", "2026-03-01-preview")
+        api_version: str = kwargs.pop("api_version", "2026-11-02-preview")
 
         if credential is None:
             raise ValueError("Parameter 'credential' must not be None.")
@@ -45,7 +45,7 @@ class MicrosoftDeviceRegistryManagementServiceConfiguration:  # pylint: disable=
         self.subscription_id = subscription_id
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://management.azure.com/.default"])
-        kwargs.setdefault("sdk_moniker", "deviceregistry/{}".format(VERSION))
+        kwargs.setdefault("sdk_moniker", "mgmt-deviceregistry/{}".format(VERSION))
         self.polling_interval = kwargs.get("polling_interval", 30)
         self._configure(**kwargs)
 

--- a/azext_iot/sdk/deviceregistry/_version.py
+++ b/azext_iot/sdk/deviceregistry/_version.py
@@ -6,4 +6,4 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-VERSION = "0.1.0"
+VERSION = "0.2.0"

--- a/azext_iot/sdk/deviceregistry/operations/__init__.py
+++ b/azext_iot/sdk/deviceregistry/operations/__init__.py
@@ -16,6 +16,9 @@ from ._operations import NamespacesOperations  # type: ignore
 from ._operations import CredentialsOperations  # type: ignore
 from ._operations import PoliciesOperations  # type: ignore
 from ._operations import NamespaceDevicesOperations  # type: ignore
+from ._operations import GroupsOperations  # type: ignore
+from ._operations import JobsOperations  # type: ignore
+from ._operations import JobRunsOperations  # type: ignore
 
 from ._patch import __all__ as _patch_all
 from ._patch import *
@@ -26,6 +29,9 @@ __all__ = [
     "CredentialsOperations",
     "PoliciesOperations",
     "NamespaceDevicesOperations",
+    "GroupsOperations",
+    "JobsOperations",
+    "JobRunsOperations",
 ]
 __all__.extend([p for p in _patch_all if p not in __all__])  # pyright: ignore
 _patch_sdk()

--- a/azext_iot/sdk/deviceregistry/operations/_operations.py
+++ b/azext_iot/sdk/deviceregistry/operations/_operations.py
@@ -1248,7 +1248,7 @@ def build_groups_get_current_member_count_request(  # pylint: disable=name-too-l
     return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_groups_get_sample_of_members_request(  # pylint: disable=name-too-long
+def build_groups_preview_members_request(
     resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -1258,7 +1258,7 @@ def build_groups_get_sample_of_members_request(  # pylint: disable=name-too-long
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}/getSampleOfMembers"
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}/previewMembers"
     path_format_arguments = {
         "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
         "resourceGroupName": _SERIALIZER.url(
@@ -1737,7 +1737,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -1770,6 +1776,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -1887,7 +1897,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -1920,6 +1936,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2040,7 +2060,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2073,6 +2099,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2251,7 +2281,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2284,6 +2320,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2322,7 +2362,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2355,6 +2401,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2423,7 +2473,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2456,6 +2512,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2516,7 +2576,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2549,6 +2615,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2587,7 +2657,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2620,6 +2696,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2798,11 +2878,16 @@ class NamespacesOperations:
                 properties = {
                     "id": "str",
                     "identity": {
-                        "type": "str"
+                        "type": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
-                        "dataEndpoint": "str",
                         "management": {
                             "endpoints": {
                                 "str": {
@@ -2832,6 +2917,10 @@ class NamespacesOperations:
                                 }
                             }
                         },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
+                        },
                         "provisioning": {
                             "endpoints": {
                                 "str": {
@@ -2844,9 +2933,7 @@ class NamespacesOperations:
                                     "linkingState": "str"
                                 }
                             }
-                        },
-                        "provisioningState": "str",
-                        "uuid": "str"
+                        }
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2869,7 +2956,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -2902,6 +2995,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -2970,7 +3067,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -3003,6 +3106,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -3060,11 +3167,16 @@ class NamespacesOperations:
                 properties = {
                     "id": "str",
                     "identity": {
-                        "type": "str"
+                        "type": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
-                        "dataEndpoint": "str",
                         "management": {
                             "endpoints": {
                                 "str": {
@@ -3094,6 +3206,10 @@ class NamespacesOperations:
                                 }
                             }
                         },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
+                        },
                         "provisioning": {
                             "endpoints": {
                                 "str": {
@@ -3106,9 +3222,7 @@ class NamespacesOperations:
                                     "linkingState": "str"
                                 }
                             }
-                        },
-                        "provisioningState": "str",
-                        "uuid": "str"
+                        }
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3131,7 +3245,13 @@ class NamespacesOperations:
                     "identity": {
                         "type": "str",
                         "principalId": "str",
-                        "tenantId": "str"
+                        "tenantId": "str",
+                        "userAssignedIdentities": {
+                            "str": {
+                                "clientId": "str",
+                                "principalId": "str"
+                            }
+                        }
                     },
                     "name": "str",
                     "properties": {
@@ -3164,6 +3284,10 @@ class NamespacesOperations:
                                     "resourceId": "str"
                                 }
                             }
+                        },
+                        "outboundIdentity": {
+                            "type": "str",
+                            "userAssignedIdentity": "str"
                         },
                         "provisioning": {
                             "endpoints": {
@@ -9269,10 +9393,8 @@ class GroupsOperations:
         return cast(JSON, deserialized)  # type: ignore
 
     @distributed_trace
-    def get_sample_of_members(
-        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
-    ) -> JSON:
-        """Gets a stored sample of members that was determined during the last refresh.
+    def preview_members(self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any) -> JSON:
+        """Gets a stored preview of members that was determined during the last refresh.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
@@ -9308,7 +9430,7 @@ class GroupsOperations:
 
         cls: ClsType[JSON] = kwargs.pop("cls", None)
 
-        _request = build_groups_get_sample_of_members_request(
+        _request = build_groups_preview_members_request(
             resource_group_name=resource_group_name,
             namespace_name=namespace_name,
             group_name=group_name,

--- a/azext_iot/sdk/deviceregistry/operations/_operations.py
+++ b/azext_iot/sdk/deviceregistry/operations/_operations.py
@@ -48,7 +48,7 @@ def build_namespaces_list_by_subscription_request(  # pylint: disable=name-too-l
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -74,7 +74,7 @@ def build_namespaces_list_by_resource_group_request(  # pylint: disable=name-too
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -103,7 +103,7 @@ def build_namespaces_get_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -141,7 +141,7 @@ def build_namespaces_create_or_replace_request(  # pylint: disable=name-too-long
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -181,7 +181,7 @@ def build_namespaces_update_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -220,7 +220,7 @@ def build_namespaces_delete_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -251,6 +251,86 @@ def build_namespaces_delete_request(
     return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
 
 
+def build_namespaces_bulk_export_request(
+    resource_group_name: str, namespace_name: str, subscription_id: str, *, json: JSON, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/bulkExport"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, json=json, **kwargs)
+
+
+def build_namespaces_bulk_import_request(
+    resource_group_name: str, namespace_name: str, subscription_id: str, *, json: JSON, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/bulkImport"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, json=json, **kwargs)
+
+
 def build_namespaces_migrate_request(
     resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
@@ -258,7 +338,7 @@ def build_namespaces_migrate_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -291,13 +371,13 @@ def build_namespaces_migrate_request(
     return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_credentials_list_by_resource_group_request(  # pylint: disable=name-too-long
+def build_credentials_list_by_namespace_request(  # pylint: disable=name-too-long
     resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -334,7 +414,7 @@ def build_credentials_get_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -372,7 +452,7 @@ def build_credentials_create_or_update_request(  # pylint: disable=name-too-long
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -412,7 +492,7 @@ def build_credentials_update_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -451,7 +531,7 @@ def build_credentials_delete_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -488,7 +568,7 @@ def build_credentials_synchronize_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -519,13 +599,13 @@ def build_credentials_synchronize_request(
     return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_policies_list_by_resource_group_request(  # pylint: disable=name-too-long
+def build_policies_list_by_credential_request(  # pylint: disable=name-too-long
     resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -562,7 +642,7 @@ def build_policies_get_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -603,7 +683,7 @@ def build_policies_create_or_update_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -646,7 +726,7 @@ def build_policies_update_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -688,7 +768,7 @@ def build_policies_delete_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -722,96 +802,13 @@ def build_policies_delete_request(
     return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_policies_activate_bring_your_own_root_request(  # pylint: disable=name-too-long
-    resource_group_name: str, namespace_name: str, policy_name: str, subscription_id: str, **kwargs: Any
-) -> HttpRequest:
-    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
-    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
-
-    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
-    accept = _headers.pop("Accept", "application/json")
-
-    # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/credentials/default/policies/{policyName}/activateBringYourOwnRoot"
-    path_format_arguments = {
-        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
-        "resourceGroupName": _SERIALIZER.url(
-            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
-        ),
-        "namespaceName": _SERIALIZER.url(
-            "namespace_name",
-            namespace_name,
-            "str",
-            max_length=64,
-            min_length=3,
-            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
-        ),
-        "policyName": _SERIALIZER.url(
-            "policy_name", policy_name, "str", max_length=63, min_length=3, pattern=r"^[0-9a-zA-Z][a-zA-Z0-9-]*$"
-        ),
-    }
-
-    _url: str = _url.format(**path_format_arguments)  # type: ignore
-
-    # Construct parameters
-    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
-
-    # Construct headers
-    if content_type is not None:
-        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
-    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
-
-    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
-
-
-def build_policies_revoke_issuer_request(
-    resource_group_name: str, namespace_name: str, policy_name: str, subscription_id: str, **kwargs: Any
-) -> HttpRequest:
-    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
-    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
-
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
-    accept = _headers.pop("Accept", "application/json")
-
-    # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/credentials/default/policies/{policyName}/revokeIssuer"
-    path_format_arguments = {
-        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
-        "resourceGroupName": _SERIALIZER.url(
-            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
-        ),
-        "namespaceName": _SERIALIZER.url(
-            "namespace_name",
-            namespace_name,
-            "str",
-            max_length=64,
-            min_length=3,
-            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
-        ),
-        "policyName": _SERIALIZER.url(
-            "policy_name", policy_name, "str", max_length=63, min_length=3, pattern=r"^[0-9a-zA-Z][a-zA-Z0-9-]*$"
-        ),
-    }
-
-    _url: str = _url.format(**path_format_arguments)  # type: ignore
-
-    # Construct parameters
-    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
-
-    # Construct headers
-    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
-
-    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
-
-
 def build_namespace_devices_list_by_resource_group_request(  # pylint: disable=name-too-long
     resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -848,7 +845,7 @@ def build_namespace_devices_get_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -889,7 +886,7 @@ def build_namespace_devices_create_or_replace_request(  # pylint: disable=name-t
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -932,7 +929,7 @@ def build_namespace_devices_update_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -974,7 +971,7 @@ def build_namespace_devices_delete_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -1008,18 +1005,17 @@ def build_namespace_devices_delete_request(
     return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
 
 
-def build_namespace_devices_revoke_request(
-    resource_group_name: str, namespace_name: str, device_name: str, subscription_id: str, **kwargs: Any
+def build_groups_list_by_namespace_request(
+    resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-03-01-preview"))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
-    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/devices/{deviceName}/revoke"
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups"
     path_format_arguments = {
         "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
         "resourceGroupName": _SERIALIZER.url(
@@ -1033,8 +1029,535 @@ def build_namespace_devices_revoke_request(
             min_length=3,
             pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
         ),
-        "deviceName": _SERIALIZER.url(
-            "device_name", device_name, "str", max_length=63, min_length=3, pattern=r"^[0-9a-zA-Z][a-zA-Z0-9-]*$"
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_get_request(
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_create_or_replace_request(
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_update_request(
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="PATCH", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_delete_request(
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_get_current_member_count_request(  # pylint: disable=name-too-long
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}/getCurrentMemberCount"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_get_sample_of_members_request(  # pylint: disable=name-too-long
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}/getSampleOfMembers"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_groups_refresh_members_request(
+    resource_group_name: str, namespace_name: str, group_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/groups/{groupName}/refreshMembers"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "groupName": _SERIALIZER.url(
+            "group_name", group_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_list_by_namespace_request(
+    resource_group_name: str, namespace_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_get_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_create_or_replace_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_update_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    if content_type is not None:
+        _headers["Content-Type"] = _SERIALIZER.header("content_type", content_type, "str")
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="PATCH", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_delete_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="DELETE", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_jobs_schedule_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}/schedule"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
         ),
     }
 
@@ -1051,13 +1574,139 @@ def build_namespace_devices_revoke_request(
     return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
 
 
+def build_job_runs_list_by_job_request(
+    resource_group_name: str, namespace_name: str, job_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}/runs"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_job_runs_get_request(
+    resource_group_name: str, namespace_name: str, job_name: str, run_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}/runs/{runName}"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+        "runName": _SERIALIZER.url(
+            "run_name", run_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="GET", url=_url, params=_params, headers=_headers, **kwargs)
+
+
+def build_job_runs_results_request(
+    resource_group_name: str, namespace_name: str, job_name: str, run_name: str, subscription_id: str, **kwargs: Any
+) -> HttpRequest:
+    _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+    _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
+
+    api_version: str = kwargs.pop("api_version", _params.pop("api-version", "2026-11-02-preview"))
+    accept = _headers.pop("Accept", "application/json")
+
+    # Construct URL
+    _url = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DeviceRegistry/namespaces/{namespaceName}/jobs/{jobName}/runs/{runName}/results"
+    path_format_arguments = {
+        "subscriptionId": _SERIALIZER.url("subscription_id", subscription_id, "str"),
+        "resourceGroupName": _SERIALIZER.url(
+            "resource_group_name", resource_group_name, "str", max_length=90, min_length=1
+        ),
+        "namespaceName": _SERIALIZER.url(
+            "namespace_name",
+            namespace_name,
+            "str",
+            max_length=64,
+            min_length=3,
+            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+        ),
+        "jobName": _SERIALIZER.url(
+            "job_name", job_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+        "runName": _SERIALIZER.url(
+            "run_name", run_name, "str", max_length=64, min_length=3, pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        ),
+    }
+
+    _url: str = _url.format(**path_format_arguments)  # type: ignore
+
+    # Construct parameters
+    _params["api-version"] = _SERIALIZER.query("api_version", api_version, "str")
+
+    # Construct headers
+    _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
+
+    return HttpRequest(method="POST", url=_url, params=_params, headers=_headers, **kwargs)
+
+
 class NamespacesOperations:
     """
     .. warning::
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~deviceregistry.mgmt.MicrosoftDeviceRegistryManagementService`'s
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
         :attr:`namespaces` attribute.
     """
 
@@ -1092,12 +1741,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1208,12 +1891,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1327,12 +2044,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1504,12 +2255,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1541,12 +2326,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1608,12 +2427,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1667,12 +2520,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1704,12 +2591,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1875,25 +2796,70 @@ class NamespacesOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 properties = {
+                    "id": "str",
                     "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str"
+                        "type": "str"
                     },
+                    "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
                                 }
                             }
-                        }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
+                                }
+                            }
+                        },
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
                     },
                     "tags": {
                         "str": "str"
-                    }
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
@@ -1907,12 +2873,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -1974,12 +2974,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -2024,25 +3058,70 @@ class NamespacesOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 properties = {
+                    "id": "str",
                     "identity": {
-                        "type": "str",
-                        "principalId": "str",
-                        "tenantId": "str"
+                        "type": "str"
                     },
+                    "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
                                 }
                             }
-                        }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
+                                }
+                            }
+                        },
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
                     },
                     "tags": {
                         "str": "str"
-                    }
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
@@ -2056,12 +3135,46 @@ class NamespacesOperations:
                     },
                     "name": "str",
                     "properties": {
-                        "messaging": {
+                        "dataEndpoint": "str",
+                        "management": {
                             "endpoints": {
                                 "str": {
                                     "address": "str",
                                     "endpointType": "str",
+                                    "resourceId": "str",
+                                    "scopeId": "str"
+                                }
+                            }
+                        },
+                        "messaging": {
+                            "endpoints": {
+                                "str": {
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "address": "str",
+                                    "deviceAddress": "str",
+                                    "endpointType": "str",
+                                    "linkingState": "str",
+                                    "provisioning": {
+                                        "allocationWeight": 0,
+                                        "availability": "str"
+                                    },
                                     "resourceId": "str"
+                                }
+                            }
+                        },
+                        "provisioning": {
+                            "endpoints": {
+                                "str": {
+                                    "endpointType": "str",
+                                    "inboundCallerIdentity": {
+                                        "type": "str",
+                                        "userAssignedIdentity": "str"
+                                    },
+                                    "resourceId": "str",
+                                    "linkingState": "str"
                                 }
                             }
                         },
@@ -2206,6 +3319,248 @@ class NamespacesOperations:
             raw_result = self._delete_initial(
                 resource_group_name=resource_group_name,
                 namespace_name=namespace_name,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    def _bulk_export_initial(
+        self, resource_group_name: str, namespace_name: str, body: JSON, **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: str = kwargs.pop("content_type", _headers.pop("Content-Type", "application/json"))
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        _json = body
+
+        _request = build_namespaces_bulk_export_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200, 202]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 202:
+            response_headers["Azure-AsyncOperation"] = self._deserialize(
+                "str", response.headers.get("Azure-AsyncOperation")
+            )
+            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @distributed_trace
+    def begin_bulk_export(
+        self, resource_group_name: str, namespace_name: str, body: JSON, **kwargs: Any
+    ) -> LROPoller[None]:
+        """Bulk export device metadata from the namespace into a storage account.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param body: The content of the action request. Required.
+        :type body: JSON
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: str = kwargs.pop("content_type", _headers.pop("Content-Type", "application/json"))
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._bulk_export_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                body=body,
+                content_type=content_type,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    def _bulk_import_initial(
+        self, resource_group_name: str, namespace_name: str, body: JSON, **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: str = kwargs.pop("content_type", _headers.pop("Content-Type", "application/json"))
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        _json = body
+
+        _request = build_namespaces_bulk_import_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200, 202]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 202:
+            response_headers["Azure-AsyncOperation"] = self._deserialize(
+                "str", response.headers.get("Azure-AsyncOperation")
+            )
+            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @distributed_trace
+    def begin_bulk_import(
+        self, resource_group_name: str, namespace_name: str, body: JSON, **kwargs: Any
+    ) -> LROPoller[None]:
+        """Bulk import devices into the namespace from a provided storage account.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param body: The content of the action request. Required.
+        :type body: JSON
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: str = kwargs.pop("content_type", _headers.pop("Content-Type", "application/json"))
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._bulk_import_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                body=body,
+                content_type=content_type,
                 cls=lambda x, y, z: x,
                 headers=_headers,
                 params=_params,
@@ -2522,7 +3877,7 @@ class CredentialsOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~deviceregistry.mgmt.MicrosoftDeviceRegistryManagementService`'s
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
         :attr:`credentials` attribute.
     """
 
@@ -2536,7 +3891,7 @@ class CredentialsOperations:
         self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
 
     @distributed_trace
-    def list_by_resource_group(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
+    def list_by_namespace(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
         """List Credential resources by Namespace.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
@@ -2557,7 +3912,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2589,7 +3945,7 @@ class CredentialsOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                _request = build_credentials_list_by_resource_group_request(
+                _request = build_credentials_list_by_namespace_request(
                     resource_group_name=resource_group_name,
                     namespace_name=namespace_name,
                     subscription_id=self._config.subscription_id,
@@ -2662,7 +4018,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2824,7 +4181,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2846,7 +4204,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2898,7 +4257,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2942,7 +4302,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -2964,7 +4325,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3125,9 +4487,24 @@ class CredentialsOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 properties = {
+                    "id": "str",
+                    "name": "str",
+                    "properties": {
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
                     "tags": {
                         "str": "str"
-                    }
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
@@ -3136,7 +4513,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3188,7 +4566,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3228,9 +4607,24 @@ class CredentialsOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 properties = {
+                    "id": "str",
+                    "name": "str",
+                    "properties": {
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
                     "tags": {
                         "str": "str"
-                    }
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
@@ -3239,7 +4633,8 @@ class CredentialsOperations:
                     "id": "str",
                     "name": "str",
                     "properties": {
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3518,7 +4913,7 @@ class PoliciesOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~deviceregistry.mgmt.MicrosoftDeviceRegistryManagementService`'s
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
         :attr:`policies` attribute.
     """
 
@@ -3532,7 +4927,7 @@ class PoliciesOperations:
         self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
 
     @distributed_trace
-    def list_by_resource_group(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
+    def list_by_credential(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
         """List Policy resources by Credential.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
@@ -3549,18 +4944,13 @@ class PoliciesOperations:
 
                 # response body for status code(s): 200
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -3569,7 +4959,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3578,6 +4969,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -3598,7 +4992,7 @@ class PoliciesOperations:
         def prepare_request(next_link=None):
             if not next_link:
 
-                _request = build_policies_list_by_resource_group_request(
+                _request = build_policies_list_by_credential_request(
                     resource_group_name=resource_group_name,
                     namespace_name=namespace_name,
                     subscription_id=self._config.subscription_id,
@@ -3658,7 +5052,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :return: JSON object
         :rtype: JSON
@@ -3669,18 +5063,13 @@ class PoliciesOperations:
 
                 # response body for status code(s): 200
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -3689,7 +5078,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3698,6 +5088,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -3838,7 +5231,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param resource: Resource create parameters. Required.
         :type resource: JSON
@@ -3854,18 +5247,13 @@ class PoliciesOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 resource = {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -3874,7 +5262,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3883,24 +5272,22 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
 
                 # response body for status code(s): 200, 201
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -3909,7 +5296,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3918,6 +5306,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -3941,7 +5332,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param resource: Resource create parameters. Required.
         :type resource: IO[bytes]
@@ -3957,18 +5348,13 @@ class PoliciesOperations:
 
                 # response body for status code(s): 200, 201
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -3977,7 +5363,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -3986,6 +5373,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -4007,7 +5397,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param resource: Resource create parameters. Is either a JSON type or a IO[bytes] type.
          Required.
@@ -4021,18 +5411,13 @@ class PoliciesOperations:
 
                 # JSON input template you can fill out and use as your body input.
                 resource = {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -4041,7 +5426,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -4050,24 +5436,22 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
 
                 # response body for status code(s): 200, 201
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -4076,7 +5460,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -4085,6 +5470,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -4228,7 +5616,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param properties: The resource properties to be updated. Required.
         :type properties: JSON
@@ -4246,30 +5634,25 @@ class PoliciesOperations:
                 properties = {
                     "properties": {
                         "certificate": {
-                            "certificateAuthorityConfiguration": {
-                                "bringYourOwnRoot": {}
-                            },
                             "leafCertificateConfiguration": {
                                 "validityPeriodInDays": 0
                             }
                         }
+                    },
+                    "tags": {
+                        "str": "str"
                     }
                 }
 
                 # response body for status code(s): 200
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -4278,7 +5661,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -4287,6 +5671,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -4310,7 +5697,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param properties: The resource properties to be updated. Required.
         :type properties: IO[bytes]
@@ -4326,18 +5713,13 @@ class PoliciesOperations:
 
                 # response body for status code(s): 200
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -4346,7 +5728,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -4355,6 +5738,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -4376,7 +5762,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :param properties: The resource properties to be updated. Is either a JSON type or a IO[bytes]
          type. Required.
@@ -4392,30 +5778,25 @@ class PoliciesOperations:
                 properties = {
                     "properties": {
                         "certificate": {
-                            "certificateAuthorityConfiguration": {
-                                "bringYourOwnRoot": {}
-                            },
                             "leafCertificateConfiguration": {
                                 "validityPeriodInDays": 0
                             }
                         }
+                    },
+                    "tags": {
+                        "str": "str"
                     }
                 }
 
                 # response body for status code(s): 200
                 response == {
+                    "location": "str",
                     "id": "str",
                     "name": "str",
                     "properties": {
                         "certificate": {
                             "certificateAuthorityConfiguration": {
                                 "keyType": "str",
-                                "bringYourOwnRoot": {
-                                    "enabled": bool,
-                                    "certificateSigningRequest": "str",
-                                    "issuingCertificateThumbprint": "str",
-                                    "status": "str"
-                                },
                                 "subject": "str",
                                 "validityNotAfter": "2020-02-20 00:00:00",
                                 "validityNotBefore": "2020-02-20 00:00:00"
@@ -4424,7 +5805,8 @@ class PoliciesOperations:
                                 "validityPeriodInDays": 0
                             }
                         },
-                        "provisioningState": "str"
+                        "provisioningState": "str",
+                        "uuid": "str"
                     },
                     "systemData": {
                         "createdAt": "2020-02-20 00:00:00",
@@ -4433,6 +5815,9 @@ class PoliciesOperations:
                         "lastModifiedAt": "2020-02-20 00:00:00",
                         "lastModifiedBy": "str",
                         "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
                     },
                     "type": "str"
                 }
@@ -4552,7 +5937,7 @@ class PoliciesOperations:
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
+        :param policy_name: The name of the Policy tracked resource. Required.
         :type policy_name: str
         :return: An instance of LROPoller that returns None
         :rtype: ~azure.core.polling.LROPoller[None]
@@ -4599,337 +5984,6 @@ class PoliciesOperations:
             )
         return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
 
-    def _activate_bring_your_own_root_initial(
-        self,
-        resource_group_name: str,
-        namespace_name: str,
-        policy_name: str,
-        body: Union[JSON, IO[bytes]],
-        **kwargs: Any
-    ) -> Iterator[bytes]:
-        error_map: MutableMapping = {
-            401: ClientAuthenticationError,
-            404: ResourceNotFoundError,
-            409: ResourceExistsError,
-            304: ResourceNotModifiedError,
-        }
-        error_map.update(kwargs.pop("error_map", {}) or {})
-
-        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
-        _params = kwargs.pop("params", {}) or {}
-
-        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
-
-        content_type = content_type or "application/json"
-        _json = None
-        _content = None
-        if isinstance(body, (IOBase, bytes)):
-            _content = body
-        else:
-            _json = body
-
-        _request = build_policies_activate_bring_your_own_root_request(
-            resource_group_name=resource_group_name,
-            namespace_name=namespace_name,
-            policy_name=policy_name,
-            subscription_id=self._config.subscription_id,
-            content_type=content_type,
-            api_version=self._config.api_version,
-            json=_json,
-            content=_content,
-            headers=_headers,
-            params=_params,
-        )
-        _request.url = self._client.format_url(_request.url)
-
-        _stream = True
-        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
-            _request, stream=_stream, **kwargs
-        )
-
-        response = pipeline_response.http_response
-
-        if response.status_code not in [202, 204]:
-            try:
-                response.read()  # Load the body in memory and close the socket
-            except (StreamConsumedError, StreamClosedError):
-                pass
-            map_error(status_code=response.status_code, response=response, error_map=error_map)
-            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
-
-        response_headers = {}
-        if response.status_code == 202:
-            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
-            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
-
-        deserialized = response.iter_bytes()
-
-        if cls:
-            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
-
-        return cast(Iterator[bytes], deserialized)  # type: ignore
-
-    @overload
-    def begin_activate_bring_your_own_root(
-        self,
-        resource_group_name: str,
-        namespace_name: str,
-        policy_name: str,
-        body: JSON,
-        *,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> LROPoller[None]:
-        """Activates or renews a Bring Your Own Root policy by accepting a customer-provided signed
-        certificate. This is a long-running operation that returns no content upon completion.
-
-        :param resource_group_name: The name of the resource group. The name is case insensitive.
-         Required.
-        :type resource_group_name: str
-        :param namespace_name: The name of the namespace. Required.
-        :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
-        :type policy_name: str
-        :param body: The content of the action request. Required.
-        :type body: JSON
-        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
-         Default value is "application/json".
-        :paramtype content_type: str
-        :return: An instance of LROPoller that returns None
-        :rtype: ~azure.core.polling.LROPoller[None]
-        :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "certificateChain": "str"
-                }
-        """
-
-    @overload
-    def begin_activate_bring_your_own_root(
-        self,
-        resource_group_name: str,
-        namespace_name: str,
-        policy_name: str,
-        body: IO[bytes],
-        *,
-        content_type: str = "application/json",
-        **kwargs: Any
-    ) -> LROPoller[None]:
-        """Activates or renews a Bring Your Own Root policy by accepting a customer-provided signed
-        certificate. This is a long-running operation that returns no content upon completion.
-
-        :param resource_group_name: The name of the resource group. The name is case insensitive.
-         Required.
-        :type resource_group_name: str
-        :param namespace_name: The name of the namespace. Required.
-        :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
-        :type policy_name: str
-        :param body: The content of the action request. Required.
-        :type body: IO[bytes]
-        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
-         Default value is "application/json".
-        :paramtype content_type: str
-        :return: An instance of LROPoller that returns None
-        :rtype: ~azure.core.polling.LROPoller[None]
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-
-    @distributed_trace
-    def begin_activate_bring_your_own_root(
-        self,
-        resource_group_name: str,
-        namespace_name: str,
-        policy_name: str,
-        body: Union[JSON, IO[bytes]],
-        **kwargs: Any
-    ) -> LROPoller[None]:
-        """Activates or renews a Bring Your Own Root policy by accepting a customer-provided signed
-        certificate. This is a long-running operation that returns no content upon completion.
-
-        :param resource_group_name: The name of the resource group. The name is case insensitive.
-         Required.
-        :type resource_group_name: str
-        :param namespace_name: The name of the namespace. Required.
-        :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
-        :type policy_name: str
-        :param body: The content of the action request. Is either a JSON type or a IO[bytes] type.
-         Required.
-        :type body: JSON or IO[bytes]
-        :return: An instance of LROPoller that returns None
-        :rtype: ~azure.core.polling.LROPoller[None]
-        :raises ~azure.core.exceptions.HttpResponseError:
-
-        Example:
-            .. code-block:: python
-
-                # JSON input template you can fill out and use as your body input.
-                body = {
-                    "certificateChain": "str"
-                }
-        """
-        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
-        _params = kwargs.pop("params", {}) or {}
-
-        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-        cls: ClsType[None] = kwargs.pop("cls", None)
-        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
-        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
-        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
-        if cont_token is None:
-            raw_result = self._activate_bring_your_own_root_initial(
-                resource_group_name=resource_group_name,
-                namespace_name=namespace_name,
-                policy_name=policy_name,
-                body=body,
-                content_type=content_type,
-                cls=lambda x, y, z: x,
-                headers=_headers,
-                params=_params,
-                **kwargs
-            )
-            raw_result.http_response.read()  # type: ignore
-        kwargs.pop("error_map", None)
-
-        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
-            if cls:
-                return cls(pipeline_response, None, {})  # type: ignore
-
-        if polling is True:
-            polling_method: PollingMethod = cast(
-                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
-            )
-        elif polling is False:
-            polling_method = cast(PollingMethod, NoPolling())
-        else:
-            polling_method = polling
-        if cont_token:
-            return LROPoller[None].from_continuation_token(
-                polling_method=polling_method,
-                continuation_token=cont_token,
-                client=self._client,
-                deserialization_callback=get_long_running_output,
-            )
-        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
-
-    def _revoke_issuer_initial(
-        self, resource_group_name: str, namespace_name: str, policy_name: str, **kwargs: Any
-    ) -> Iterator[bytes]:
-        error_map: MutableMapping = {
-            401: ClientAuthenticationError,
-            404: ResourceNotFoundError,
-            409: ResourceExistsError,
-            304: ResourceNotModifiedError,
-        }
-        error_map.update(kwargs.pop("error_map", {}) or {})
-
-        _headers = kwargs.pop("headers", {}) or {}
-        _params = kwargs.pop("params", {}) or {}
-
-        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
-
-        _request = build_policies_revoke_issuer_request(
-            resource_group_name=resource_group_name,
-            namespace_name=namespace_name,
-            policy_name=policy_name,
-            subscription_id=self._config.subscription_id,
-            api_version=self._config.api_version,
-            headers=_headers,
-            params=_params,
-        )
-        _request.url = self._client.format_url(_request.url)
-
-        _stream = True
-        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
-            _request, stream=_stream, **kwargs
-        )
-
-        response = pipeline_response.http_response
-
-        if response.status_code not in [202, 204]:
-            try:
-                response.read()  # Load the body in memory and close the socket
-            except (StreamConsumedError, StreamClosedError):
-                pass
-            map_error(status_code=response.status_code, response=response, error_map=error_map)
-            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
-
-        response_headers = {}
-        if response.status_code == 202:
-            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
-            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
-
-        deserialized = response.iter_bytes()
-
-        if cls:
-            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
-
-        return cast(Iterator[bytes], deserialized)  # type: ignore
-
-    @distributed_trace
-    def begin_revoke_issuer(
-        self, resource_group_name: str, namespace_name: str, policy_name: str, **kwargs: Any
-    ) -> LROPoller[None]:
-        """A long-running resource action.
-
-        :param resource_group_name: The name of the resource group. The name is case insensitive.
-         Required.
-        :type resource_group_name: str
-        :param namespace_name: The name of the namespace. Required.
-        :type namespace_name: str
-        :param policy_name: The name of the Policy proxy resource. Required.
-        :type policy_name: str
-        :return: An instance of LROPoller that returns None
-        :rtype: ~azure.core.polling.LROPoller[None]
-        :raises ~azure.core.exceptions.HttpResponseError:
-        """
-        _headers = kwargs.pop("headers", {}) or {}
-        _params = kwargs.pop("params", {}) or {}
-
-        cls: ClsType[None] = kwargs.pop("cls", None)
-        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
-        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
-        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
-        if cont_token is None:
-            raw_result = self._revoke_issuer_initial(
-                resource_group_name=resource_group_name,
-                namespace_name=namespace_name,
-                policy_name=policy_name,
-                cls=lambda x, y, z: x,
-                headers=_headers,
-                params=_params,
-                **kwargs
-            )
-            raw_result.http_response.read()  # type: ignore
-        kwargs.pop("error_map", None)
-
-        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
-            if cls:
-                return cls(pipeline_response, None, {})  # type: ignore
-
-        if polling is True:
-            polling_method: PollingMethod = cast(
-                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
-            )
-        elif polling is False:
-            polling_method = cast(PollingMethod, NoPolling())
-        else:
-            polling_method = polling
-        if cont_token:
-            return LROPoller[None].from_continuation_token(
-                polling_method=polling_method,
-                continuation_token=cont_token,
-                client=self._client,
-                deserialization_callback=get_long_running_output,
-            )
-        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
-
 
 class NamespaceDevicesOperations:
     """
@@ -4937,7 +5991,7 @@ class NamespaceDevicesOperations:
         **DO NOT** instantiate this class directly.
 
         Instead, you should access the following operations through
-        :class:`~deviceregistry.mgmt.MicrosoftDeviceRegistryManagementService`'s
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
         :attr:`namespace_devices` attribute.
     """
 
@@ -5066,6 +6120,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -5273,6 +6334,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -5545,6 +6613,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -5667,6 +6742,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -5822,6 +6904,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -5973,6 +7062,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -6095,6 +7191,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -6427,6 +7530,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -6582,6 +7692,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -6790,6 +7907,13 @@ class NamespaceDevicesOperations:
                                                 }
                                             ],
                                             "message": "str"
+                                        },
+                                        "healthState": {
+                                            "lastTransitionTime": "str",
+                                            "lastUpdateTime": "str",
+                                            "message": "str",
+                                            "reasonCode": "str",
+                                            "status": "str"
                                         }
                                     }
                                 }
@@ -6974,12 +8098,246 @@ class NamespaceDevicesOperations:
             )
         return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
 
-    def _revoke_initial(
+
+class GroupsOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
+        :attr:`groups` attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        input_args = list(args)
+        self._client: PipelineClient = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config: MicrosoftDeviceRegistryManagementServiceConfiguration = (
+            input_args.pop(0) if input_args else kwargs.pop("config")
+        )
+        self._serialize: Serializer = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
+
+    @distributed_trace
+    def list_by_namespace(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
+        """List Group resources by Namespace.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :return: An iterator like instance of JSON object
+        :rtype: ~azure.core.paging.ItemPaged[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        def prepare_request(next_link=None):
+            if not next_link:
+
+                _request = build_groups_list_by_namespace_request(
+                    resource_group_name=resource_group_name,
+                    namespace_name=namespace_name,
+                    subscription_id=self._config.subscription_id,
+                    api_version=self._config.api_version,
+                    headers=_headers,
+                    params=_params,
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            else:
+                # make call to next link with the client's api-version
+                _parsed_next_link = urllib.parse.urlparse(next_link)
+                _next_request_params = case_insensitive_dict(
+                    {
+                        key: [urllib.parse.quote(v) for v in value]
+                        for key, value in urllib.parse.parse_qs(_parsed_next_link.query).items()
+                    }
+                )
+                _next_request_params["api-version"] = self._config.api_version
+                _request = HttpRequest(
+                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            return _request
+
+        def extract_data(pipeline_response):
+            deserialized = pipeline_response.http_response.json()
+            list_of_elem = deserialized.get("value", [])
+            if cls:
+                list_of_elem = cls(list_of_elem)  # type: ignore
+            return deserialized.get("nextLink") or None, iter(list_of_elem)
+
+        def get_next(next_link=None):
+            _request = prepare_request(next_link)
+
+            _stream = False
+            pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+                _request, stream=_stream, **kwargs
+            )
+            response = pipeline_response.http_response
+
+            if response.status_code not in [200]:
+                map_error(status_code=response.status_code, response=response, error_map=error_map)
+                raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+            return pipeline_response
+
+        return ItemPaged(get_next, extract_data)
+
+    @distributed_trace
+    def get(self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any) -> JSON:
+        """Get a Group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_groups_get_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    def _create_or_replace_initial(
         self,
         resource_group_name: str,
         namespace_name: str,
-        device_name: str,
-        body: Union[JSON, IO[bytes]],
+        group_name: str,
+        resource: Union[JSON, IO[bytes]],
         **kwargs: Any
     ) -> Iterator[bytes]:
         error_map: MutableMapping = {
@@ -6999,15 +8357,402 @@ class NamespaceDevicesOperations:
         content_type = content_type or "application/json"
         _json = None
         _content = None
-        if isinstance(body, (IOBase, bytes)):
-            _content = body
+        if isinstance(resource, (IOBase, bytes)):
+            _content = resource
         else:
-            _json = body
+            _json = resource
 
-        _request = build_namespace_devices_revoke_request(
+        _request = build_groups_create_or_replace_request(
             resource_group_name=resource_group_name,
             namespace_name=namespace_name,
-            device_name=device_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200, 201]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 201:
+            response_headers["Azure-AsyncOperation"] = self._deserialize(
+                "str", response.headers.get("Azure-AsyncOperation")
+            )
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @overload
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        group_name: str,
+        resource: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param resource: Resource create parameters. Required.
+        :type resource: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                resource = {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @overload
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        group_name: str,
+        resource: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param resource: Resource create parameters. Required.
+        :type resource: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @distributed_trace
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        group_name: str,
+        resource: Union[JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param resource: Resource create parameters. Is either a JSON type or a IO[bytes] type.
+         Required.
+        :type resource: JSON or IO[bytes]
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                resource = {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._create_or_replace_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                group_name=group_name,
+                resource=resource,
+                content_type=content_type,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):
+            response = pipeline_response.http_response
+            if response.content:
+                deserialized = response.json()
+            else:
+                deserialized = None
+            if cls:
+                return cls(pipeline_response, deserialized, {})  # type: ignore
+            return deserialized
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "azure-async-operation"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[JSON].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[JSON](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    def _update_initial(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        group_name: str,
+        properties: Union[JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _json = None
+        _content = None
+        if isinstance(properties, (IOBase, bytes)):
+            _content = properties
+        else:
+            _json = properties
+
+        _request = build_groups_update_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
             subscription_id=self._config.subscription_id,
             content_type=content_type,
             api_version=self._config.api_version,
@@ -7035,9 +8780,6 @@ class NamespaceDevicesOperations:
 
         response_headers = {}
         if response.status_code == 202:
-            response_headers["Azure-AsyncOperation"] = self._deserialize(
-                "str", response.headers.get("Azure-AsyncOperation")
-            )
             response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
             response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
 
@@ -7049,27 +8791,27 @@ class NamespaceDevicesOperations:
         return cast(Iterator[bytes], deserialized)  # type: ignore
 
     @overload
-    def begin_revoke(
+    def begin_update(
         self,
         resource_group_name: str,
         namespace_name: str,
-        device_name: str,
-        body: JSON,
+        group_name: str,
+        properties: JSON,
         *,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> LROPoller[JSON]:
-        """A long-running resource action.
+        """Update a Group.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param device_name: The name of the device. Required.
-        :type device_name: str
-        :param body: The content of the action request. Required.
-        :type body: JSON
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param properties: The resource properties to be updated. Required.
+        :type properties: JSON
         :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
          Default value is "application/json".
         :paramtype content_type: str
@@ -7081,50 +8823,87 @@ class NamespaceDevicesOperations:
             .. code-block:: python
 
                 # JSON input template you can fill out and use as your body input.
-                body = {
-                    "disable": bool
+                properties = {
+                    "id": "str",
+                    "identity": {
+                        "type": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "description": "str",
+                        "displayName": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
                 response == {
-                    "result": "str",
-                    "error": {
-                        "code": "str",
-                        "details": [
-                            {
-                                "code": "str",
-                                "correlationId": "str",
-                                "info": "str",
-                                "message": "str"
-                            }
-                        ],
-                        "message": "str"
-                    }
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
                 }
         """
 
     @overload
-    def begin_revoke(
+    def begin_update(
         self,
         resource_group_name: str,
         namespace_name: str,
-        device_name: str,
-        body: IO[bytes],
+        group_name: str,
+        properties: IO[bytes],
         *,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> LROPoller[JSON]:
-        """A long-running resource action.
+        """Update a Group.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param device_name: The name of the device. Required.
-        :type device_name: str
-        :param body: The content of the action request. Required.
-        :type body: IO[bytes]
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param properties: The resource properties to be updated. Required.
+        :type properties: IO[bytes]
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Default value is "application/json".
         :paramtype content_type: str
@@ -7137,43 +8916,60 @@ class NamespaceDevicesOperations:
 
                 # response body for status code(s): 200
                 response == {
-                    "result": "str",
-                    "error": {
-                        "code": "str",
-                        "details": [
-                            {
-                                "code": "str",
-                                "correlationId": "str",
-                                "info": "str",
-                                "message": "str"
-                            }
-                        ],
-                        "message": "str"
-                    }
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
                 }
         """
 
     @distributed_trace
-    def begin_revoke(
+    def begin_update(
         self,
         resource_group_name: str,
         namespace_name: str,
-        device_name: str,
-        body: Union[JSON, IO[bytes]],
+        group_name: str,
+        properties: Union[JSON, IO[bytes]],
         **kwargs: Any
     ) -> LROPoller[JSON]:
-        """A long-running resource action.
+        """Update a Group.
 
         :param resource_group_name: The name of the resource group. The name is case insensitive.
          Required.
         :type resource_group_name: str
         :param namespace_name: The name of the namespace. Required.
         :type namespace_name: str
-        :param device_name: The name of the device. Required.
-        :type device_name: str
-        :param body: The content of the action request. Is either a JSON type or a IO[bytes] type.
-         Required.
-        :type body: JSON or IO[bytes]
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :param properties: The resource properties to be updated. Is either a JSON type or a IO[bytes]
+         type. Required.
+        :type properties: JSON or IO[bytes]
         :return: An instance of LROPoller that returns JSON object
         :rtype: ~azure.core.polling.LROPoller[JSON]
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -7182,25 +8978,62 @@ class NamespaceDevicesOperations:
             .. code-block:: python
 
                 # JSON input template you can fill out and use as your body input.
-                body = {
-                    "disable": bool
+                properties = {
+                    "id": "str",
+                    "identity": {
+                        "type": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "description": "str",
+                        "displayName": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
                 }
 
                 # response body for status code(s): 200
                 response == {
-                    "result": "str",
-                    "error": {
-                        "code": "str",
-                        "details": [
-                            {
-                                "code": "str",
-                                "correlationId": "str",
-                                "info": "str",
-                                "message": "str"
-                            }
-                        ],
-                        "message": "str"
-                    }
+                    "location": "str",
+                    "id": "str",
+                    "identity": {
+                        "type": "str",
+                        "principalId": "str",
+                        "tenantId": "str"
+                    },
+                    "name": "str",
+                    "properties": {
+                        "groupType": "str",
+                        "query": "str",
+                        "description": "str",
+                        "displayName": "str",
+                        "lastMembershipRefreshTime": "2020-02-20 00:00:00",
+                        "membershipState": "str",
+                        "provisioningState": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
                 }
         """
         _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -7212,11 +9045,11 @@ class NamespaceDevicesOperations:
         lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
         cont_token: Optional[str] = kwargs.pop("continuation_token", None)
         if cont_token is None:
-            raw_result = self._revoke_initial(
+            raw_result = self._update_initial(
                 resource_group_name=resource_group_name,
                 namespace_name=namespace_name,
-                device_name=device_name,
-                body=body,
+                group_name=group_name,
+                properties=properties,
                 content_type=content_type,
                 cls=lambda x, y, z: x,
                 headers=_headers,
@@ -7252,3 +9085,2054 @@ class NamespaceDevicesOperations:
                 deserialization_callback=get_long_running_output,
             )
         return LROPoller[JSON](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    def _delete_initial(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        _request = build_groups_delete_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [202, 204]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 202:
+            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @distributed_trace
+    def begin_delete(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        """Delete a Group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._delete_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                group_name=group_name,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    @distributed_trace
+    def get_current_member_count(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> JSON:
+        """Returns the current count of members of this group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "count": 0
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_groups_get_current_member_count_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    @distributed_trace
+    def get_sample_of_members(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> JSON:
+        """Gets a stored sample of members that was determined during the last refresh.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "members": [
+                        "str"
+                    ]
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_groups_get_sample_of_members_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    def _refresh_members_initial(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        _request = build_groups_refresh_members_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            group_name=group_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [202]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+        response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @distributed_trace
+    def begin_refresh_members(
+        self, resource_group_name: str, namespace_name: str, group_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        """Refreshes the members of this group.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param group_name: The name of the group. Required.
+        :type group_name: str
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._refresh_members_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                group_name=group_name,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+
+class JobsOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
+        :attr:`jobs` attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        input_args = list(args)
+        self._client: PipelineClient = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config: MicrosoftDeviceRegistryManagementServiceConfiguration = (
+            input_args.pop(0) if input_args else kwargs.pop("config")
+        )
+        self._serialize: Serializer = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
+
+    @distributed_trace
+    def list_by_namespace(self, resource_group_name: str, namespace_name: str, **kwargs: Any) -> Iterable[JSON]:
+        """List Job resources by Namespace.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :return: An iterator like instance of JSON object
+        :rtype: ~azure.core.paging.ItemPaged[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        def prepare_request(next_link=None):
+            if not next_link:
+
+                _request = build_jobs_list_by_namespace_request(
+                    resource_group_name=resource_group_name,
+                    namespace_name=namespace_name,
+                    subscription_id=self._config.subscription_id,
+                    api_version=self._config.api_version,
+                    headers=_headers,
+                    params=_params,
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            else:
+                # make call to next link with the client's api-version
+                _parsed_next_link = urllib.parse.urlparse(next_link)
+                _next_request_params = case_insensitive_dict(
+                    {
+                        key: [urllib.parse.quote(v) for v in value]
+                        for key, value in urllib.parse.parse_qs(_parsed_next_link.query).items()
+                    }
+                )
+                _next_request_params["api-version"] = self._config.api_version
+                _request = HttpRequest(
+                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            return _request
+
+        def extract_data(pipeline_response):
+            deserialized = pipeline_response.http_response.json()
+            list_of_elem = deserialized.get("value", [])
+            if cls:
+                list_of_elem = cls(list_of_elem)  # type: ignore
+            return deserialized.get("nextLink") or None, iter(list_of_elem)
+
+        def get_next(next_link=None):
+            _request = prepare_request(next_link)
+
+            _stream = False
+            pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+                _request, stream=_stream, **kwargs
+            )
+            response = pipeline_response.http_response
+
+            if response.status_code not in [200]:
+                map_error(status_code=response.status_code, response=response, error_map=error_map)
+                raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+            return pipeline_response
+
+        return ItemPaged(get_next, extract_data)
+
+    @distributed_trace
+    def get(self, resource_group_name: str, namespace_name: str, job_name: str, **kwargs: Any) -> JSON:
+        """Get a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_jobs_get_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    def _create_or_replace_initial(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        resource: Union[JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _json = None
+        _content = None
+        if isinstance(resource, (IOBase, bytes)):
+            _content = resource
+        else:
+            _json = resource
+
+        _request = build_jobs_create_or_replace_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200, 201]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 201:
+            response_headers["Azure-AsyncOperation"] = self._deserialize(
+                "str", response.headers.get("Azure-AsyncOperation")
+            )
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @overload
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        resource: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param resource: Resource create parameters. Required.
+        :type resource: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The input is polymorphic. The following are possible polymorphic inputs based off
+                  discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # JSON input template you can fill out and use as your body input.
+                resource = {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @overload
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        resource: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param resource: Resource create parameters. Required.
+        :type resource: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @distributed_trace
+    def begin_create_or_replace(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        resource: Union[JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> LROPoller[JSON]:
+        """Create a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param resource: Resource create parameters. Is either a JSON type or a IO[bytes] type.
+         Required.
+        :type resource: JSON or IO[bytes]
+        :return: An instance of LROPoller that returns JSON object
+        :rtype: ~azure.core.polling.LROPoller[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The input is polymorphic. The following are possible polymorphic inputs based off
+                  discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # JSON input template you can fill out and use as your body input.
+                resource = {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200, 201
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._create_or_replace_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                job_name=job_name,
+                resource=resource,
+                content_type=content_type,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):
+            response = pipeline_response.http_response
+            if response.content:
+                deserialized = response.json()
+            else:
+                deserialized = None
+            if cls:
+                return cls(pipeline_response, deserialized, {})  # type: ignore
+            return deserialized
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "azure-async-operation"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[JSON].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[JSON](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    @overload
+    def update(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        properties: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> JSON:
+        """Update a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param properties: The resource properties to be updated. Required.
+        :type properties: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                properties = {
+                    "tags": {
+                        "str": "str"
+                    }
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @overload
+    def update(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        properties: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> JSON:
+        """Update a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param properties: The resource properties to be updated. Required.
+        :type properties: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+
+    @distributed_trace
+    def update(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        properties: Union[JSON, IO[bytes]],
+        **kwargs: Any
+    ) -> JSON:
+        """Update a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param properties: The resource properties to be updated. Is either a JSON type or a IO[bytes]
+         type. Required.
+        :type properties: JSON or IO[bytes]
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                properties = {
+                    "tags": {
+                        "str": "str"
+                    }
+                }
+
+                # The response is polymorphic. The following are possible polymorphic responses based
+                  off discriminator "jobType":
+
+                # JSON input template for discriminator value "Update":
+                job_properties = {
+                    "definition": {
+                        "schedulingType": "str",
+                        "update": {
+                            "updateId": {
+                                "name": "str",
+                                "provider": "str",
+                                "version": "str"
+                            }
+                        }
+                    },
+                    "jobType": "Update",
+                    "target": {
+                        "targetResourceId": "str"
+                    },
+                    "provisioningState": "str",
+                    "uuid": "str"
+                }
+
+                # response body for status code(s): 200
+                response == {
+                    "location": "str",
+                    "id": "str",
+                    "name": "str",
+                    "properties": job_properties,
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "tags": {
+                        "str": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _json = None
+        _content = None
+        if isinstance(properties, (IOBase, bytes)):
+            _content = properties
+        else:
+            _json = properties
+
+        _request = build_jobs_update_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    def _delete_initial(
+        self, resource_group_name: str, namespace_name: str, job_name: str, **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        _request = build_jobs_delete_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [202, 204]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        if response.status_code == 202:
+            response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+            response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @distributed_trace
+    def begin_delete(
+        self, resource_group_name: str, namespace_name: str, job_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        """Delete a Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._delete_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                job_name=job_name,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+    def _schedule_initial(
+        self, resource_group_name: str, namespace_name: str, job_name: str, body: Union[JSON, IO[bytes]], **kwargs: Any
+    ) -> Iterator[bytes]:
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[Iterator[bytes]] = kwargs.pop("cls", None)
+
+        content_type = content_type or "application/json"
+        _json = None
+        _content = None
+        if isinstance(body, (IOBase, bytes)):
+            _content = body
+        else:
+            _json = body
+
+        _request = build_jobs_schedule_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            subscription_id=self._config.subscription_id,
+            content_type=content_type,
+            api_version=self._config.api_version,
+            json=_json,
+            content=_content,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = True
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [202]:
+            try:
+                response.read()  # Load the body in memory and close the socket
+            except (StreamConsumedError, StreamClosedError):
+                pass
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        response_headers = {}
+        response_headers["Location"] = self._deserialize("str", response.headers.get("Location"))
+        response_headers["Retry-After"] = self._deserialize("int", response.headers.get("Retry-After"))
+
+        deserialized = response.iter_bytes()
+
+        if cls:
+            return cls(pipeline_response, cast(Iterator[bytes], deserialized), response_headers)  # type: ignore
+
+        return cast(Iterator[bytes], deserialized)  # type: ignore
+
+    @overload
+    def begin_schedule(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        body: JSON,
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[None]:
+        """Schedule the job for execution.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param body: The content of the action request. Required.
+        :type body: JSON
+        :keyword content_type: Body Parameter content-type. Content type parameter for JSON body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                body = {
+                    "scheduledTime": "2020-02-20 00:00:00",
+                    "timeout": "1 day, 0:00:00"
+                }
+        """
+
+    @overload
+    def begin_schedule(
+        self,
+        resource_group_name: str,
+        namespace_name: str,
+        job_name: str,
+        body: IO[bytes],
+        *,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> LROPoller[None]:
+        """Schedule the job for execution.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param body: The content of the action request. Required.
+        :type body: IO[bytes]
+        :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
+         Default value is "application/json".
+        :paramtype content_type: str
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    def begin_schedule(
+        self, resource_group_name: str, namespace_name: str, job_name: str, body: Union[JSON, IO[bytes]], **kwargs: Any
+    ) -> LROPoller[None]:
+        """Schedule the job for execution.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param body: The content of the action request. Is either a JSON type or a IO[bytes] type.
+         Required.
+        :type body: JSON or IO[bytes]
+        :return: An instance of LROPoller that returns None
+        :rtype: ~azure.core.polling.LROPoller[None]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # JSON input template you can fill out and use as your body input.
+                body = {
+                    "scheduledTime": "2020-02-20 00:00:00",
+                    "timeout": "1 day, 0:00:00"
+                }
+        """
+        _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
+        _params = kwargs.pop("params", {}) or {}
+
+        content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
+        cls: ClsType[None] = kwargs.pop("cls", None)
+        polling: Union[bool, PollingMethod] = kwargs.pop("polling", True)
+        lro_delay = kwargs.pop("polling_interval", self._config.polling_interval)
+        cont_token: Optional[str] = kwargs.pop("continuation_token", None)
+        if cont_token is None:
+            raw_result = self._schedule_initial(
+                resource_group_name=resource_group_name,
+                namespace_name=namespace_name,
+                job_name=job_name,
+                body=body,
+                content_type=content_type,
+                cls=lambda x, y, z: x,
+                headers=_headers,
+                params=_params,
+                **kwargs
+            )
+            raw_result.http_response.read()  # type: ignore
+        kwargs.pop("error_map", None)
+
+        def get_long_running_output(pipeline_response):  # pylint: disable=inconsistent-return-statements
+            if cls:
+                return cls(pipeline_response, None, {})  # type: ignore
+
+        if polling is True:
+            polling_method: PollingMethod = cast(
+                PollingMethod, ARMPolling(lro_delay, lro_options={"final-state-via": "location"}, **kwargs)
+            )
+        elif polling is False:
+            polling_method = cast(PollingMethod, NoPolling())
+        else:
+            polling_method = polling
+        if cont_token:
+            return LROPoller[None].from_continuation_token(
+                polling_method=polling_method,
+                continuation_token=cont_token,
+                client=self._client,
+                deserialization_callback=get_long_running_output,
+            )
+        return LROPoller[None](self._client, raw_result, get_long_running_output, polling_method)  # type: ignore
+
+
+class JobRunsOperations:
+    """
+    .. warning::
+        **DO NOT** instantiate this class directly.
+
+        Instead, you should access the following operations through
+        :class:`~azext_iot.sdk.deviceregistry.MicrosoftDeviceRegistryManagementService`'s
+        :attr:`job_runs` attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        input_args = list(args)
+        self._client: PipelineClient = input_args.pop(0) if input_args else kwargs.pop("client")
+        self._config: MicrosoftDeviceRegistryManagementServiceConfiguration = (
+            input_args.pop(0) if input_args else kwargs.pop("config")
+        )
+        self._serialize: Serializer = input_args.pop(0) if input_args else kwargs.pop("serializer")
+        self._deserialize: Deserializer = input_args.pop(0) if input_args else kwargs.pop("deserializer")
+
+    @distributed_trace
+    def list_by_job(
+        self, resource_group_name: str, namespace_name: str, job_name: str, **kwargs: Any
+    ) -> Iterable[JSON]:
+        """List JobRun resources by Job.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :return: An iterator like instance of JSON object
+        :rtype: ~azure.core.paging.ItemPaged[JSON]
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "id": "str",
+                    "name": "str",
+                    "properties": {
+                        "cancellationReason": "str",
+                        "endTime": "2020-02-20 00:00:00",
+                        "provisioningState": "str",
+                        "results": {
+                            "canceled": 0,
+                            "failed": 0,
+                            "inProgress": 0,
+                            "notApplied": 0,
+                            "pending": 0,
+                            "succeeded": 0,
+                            "total": 0
+                        },
+                        "scheduledTime": "2020-02-20 00:00:00",
+                        "startTime": "2020-02-20 00:00:00",
+                        "status": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        def prepare_request(next_link=None):
+            if not next_link:
+
+                _request = build_job_runs_list_by_job_request(
+                    resource_group_name=resource_group_name,
+                    namespace_name=namespace_name,
+                    job_name=job_name,
+                    subscription_id=self._config.subscription_id,
+                    api_version=self._config.api_version,
+                    headers=_headers,
+                    params=_params,
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            else:
+                # make call to next link with the client's api-version
+                _parsed_next_link = urllib.parse.urlparse(next_link)
+                _next_request_params = case_insensitive_dict(
+                    {
+                        key: [urllib.parse.quote(v) for v in value]
+                        for key, value in urllib.parse.parse_qs(_parsed_next_link.query).items()
+                    }
+                )
+                _next_request_params["api-version"] = self._config.api_version
+                _request = HttpRequest(
+                    "GET", urllib.parse.urljoin(next_link, _parsed_next_link.path), params=_next_request_params
+                )
+                _request.url = self._client.format_url(_request.url)
+
+            return _request
+
+        def extract_data(pipeline_response):
+            deserialized = pipeline_response.http_response.json()
+            list_of_elem = deserialized.get("value", [])
+            if cls:
+                list_of_elem = cls(list_of_elem)  # type: ignore
+            return deserialized.get("nextLink") or None, iter(list_of_elem)
+
+        def get_next(next_link=None):
+            _request = prepare_request(next_link)
+
+            _stream = False
+            pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+                _request, stream=_stream, **kwargs
+            )
+            response = pipeline_response.http_response
+
+            if response.status_code not in [200]:
+                map_error(status_code=response.status_code, response=response, error_map=error_map)
+                raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+            return pipeline_response
+
+        return ItemPaged(get_next, extract_data)
+
+    @distributed_trace
+    def get(self, resource_group_name: str, namespace_name: str, job_name: str, run_name: str, **kwargs: Any) -> JSON:
+        """Get a JobRun.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param run_name: The name of the job run. Required.
+        :type run_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "id": "str",
+                    "name": "str",
+                    "properties": {
+                        "cancellationReason": "str",
+                        "endTime": "2020-02-20 00:00:00",
+                        "provisioningState": "str",
+                        "results": {
+                            "canceled": 0,
+                            "failed": 0,
+                            "inProgress": 0,
+                            "notApplied": 0,
+                            "pending": 0,
+                            "succeeded": 0,
+                            "total": 0
+                        },
+                        "scheduledTime": "2020-02-20 00:00:00",
+                        "startTime": "2020-02-20 00:00:00",
+                        "status": "str",
+                        "uuid": "str"
+                    },
+                    "systemData": {
+                        "createdAt": "2020-02-20 00:00:00",
+                        "createdBy": "str",
+                        "createdByType": "str",
+                        "lastModifiedAt": "2020-02-20 00:00:00",
+                        "lastModifiedBy": "str",
+                        "lastModifiedByType": "str"
+                    },
+                    "type": "str"
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_job_runs_get_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            run_name=run_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore
+
+    @distributed_trace
+    def results(
+        self, resource_group_name: str, namespace_name: str, job_name: str, run_name: str, **kwargs: Any
+    ) -> JSON:
+        """Browse the results of a job run to find individual device statuses.
+
+        :param resource_group_name: The name of the resource group. The name is case insensitive.
+         Required.
+        :type resource_group_name: str
+        :param namespace_name: The name of the namespace. Required.
+        :type namespace_name: str
+        :param job_name: The name of the job. Required.
+        :type job_name: str
+        :param run_name: The name of the job run. Required.
+        :type run_name: str
+        :return: JSON object
+        :rtype: JSON
+        :raises ~azure.core.exceptions.HttpResponseError:
+
+        Example:
+            .. code-block:: python
+
+                # response body for status code(s): 200
+                response == {
+                    "value": [
+                        {
+                            "deviceUuid": "str",
+                            "reason": "str",
+                            "status": "str"
+                        }
+                    ],
+                    "nextLink": "str"
+                }
+        """
+        error_map: MutableMapping = {
+            401: ClientAuthenticationError,
+            404: ResourceNotFoundError,
+            409: ResourceExistsError,
+            304: ResourceNotModifiedError,
+        }
+        error_map.update(kwargs.pop("error_map", {}) or {})
+
+        _headers = kwargs.pop("headers", {}) or {}
+        _params = kwargs.pop("params", {}) or {}
+
+        cls: ClsType[JSON] = kwargs.pop("cls", None)
+
+        _request = build_job_runs_results_request(
+            resource_group_name=resource_group_name,
+            namespace_name=namespace_name,
+            job_name=job_name,
+            run_name=run_name,
+            subscription_id=self._config.subscription_id,
+            api_version=self._config.api_version,
+            headers=_headers,
+            params=_params,
+        )
+        _request.url = self._client.format_url(_request.url)
+
+        _stream = False
+        pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
+            _request, stream=_stream, **kwargs
+        )
+
+        response = pipeline_response.http_response
+
+        if response.status_code not in [200]:
+            map_error(status_code=response.status_code, response=response, error_map=error_map)
+            raise HttpResponseError(response=response, error_format=ARMErrorFormat)
+
+        if response.content:
+            deserialized = response.json()
+        else:
+            deserialized = None
+
+        if cls:
+            return cls(pipeline_response, cast(JSON, deserialized), {})  # type: ignore
+
+        return cast(JSON, deserialized)  # type: ignore

--- a/azext_iot/tests/adr/conftest.py
+++ b/azext_iot/tests/adr/conftest.py
@@ -13,6 +13,9 @@ import pytest
 from azext_iot.adr.providers.base import ADRProvider
 from azext_iot.adr.providers.credential import CredentialProvider
 from azext_iot.adr.providers.device import DeviceProvider
+from azext_iot.adr.providers.group import GroupProvider
+from azext_iot.adr.providers.job import JobProvider
+from azext_iot.adr.providers.linking import LinkProvider
 from azext_iot.adr.providers.namespace import NamespaceProvider
 from azext_iot.adr.providers.policy import PolicyProvider
 from azext_iot.tests.generators import generate_generic_id
@@ -74,6 +77,9 @@ def mock_wait_for_terminal_state(request, monkeypatch):
     monkeypatch.setattr("azext_iot.adr.providers.credential.wait_for_terminal_state", fast_wait)
     monkeypatch.setattr("azext_iot.adr.providers.policy.wait_for_terminal_state", fast_wait)
     monkeypatch.setattr("azext_iot.adr.providers.device.wait_for_terminal_state", fast_wait)
+    monkeypatch.setattr("azext_iot.adr.providers.group.wait_for_terminal_state", fast_wait)
+    monkeypatch.setattr("azext_iot.adr.providers.job.wait_for_terminal_state", fast_wait)
+    monkeypatch.setattr("azext_iot.adr.providers.linking.wait_for_terminal_state", fast_wait)
 
 
 @pytest.fixture()
@@ -139,6 +145,42 @@ def fixture_device_provider(fixture_cmd):
         mock_client = Mock()
         mock_factory.return_value = mock_client
         provider = DeviceProvider(fixture_cmd)
+        provider.client = mock_client
+        return provider
+
+
+@pytest.fixture()
+def fixture_group_provider(fixture_cmd):
+    """Group provider fixture for testing."""
+    with patch("azext_iot.adr.providers.base.adr_service_factory") as mock_factory:
+        mock_client = Mock()
+        mock_factory.return_value = mock_client
+        provider = GroupProvider(fixture_cmd)
+        provider.client = mock_client
+        # Stub out location lookup so create() doesn't hit ARM.
+        provider._ensure_location = lambda *a, **kw: "westus"
+        return provider
+
+
+@pytest.fixture()
+def fixture_job_provider(fixture_cmd):
+    """Job provider fixture for testing."""
+    with patch("azext_iot.adr.providers.base.adr_service_factory") as mock_factory:
+        mock_client = Mock()
+        mock_factory.return_value = mock_client
+        provider = JobProvider(fixture_cmd)
+        provider.client = mock_client
+        provider._ensure_location = lambda *a, **kw: "westus"
+        return provider
+
+
+@pytest.fixture()
+def fixture_link_provider(fixture_cmd):
+    """Link provider fixture for testing."""
+    with patch("azext_iot.adr.providers.base.adr_service_factory") as mock_factory:
+        mock_client = Mock()
+        mock_factory.return_value = mock_client
+        provider = LinkProvider(fixture_cmd)
         provider.client = mock_client
         return provider
 

--- a/azext_iot/tests/adr/conftest.py
+++ b/azext_iot/tests/adr/conftest.py
@@ -33,7 +33,7 @@ CUSTOM_CERT_UPDATE_VALIDITY_DAYS = 20
 CUSTOM_CERT_KEY_TYPE = "ECC"
 CUSTOM_CERT_SUBJECT = "CN=test-device"
 
-TEST_LOCATION = os.getenv("azext_iot_adr_location", "westus")
+TEST_LOCATION = os.getenv("azext_iot_adr_location", "centraluseuap")
 
 
 def pytest_runtest_logreport(report):

--- a/azext_iot/tests/adr/test_adr_group_int.py
+++ b/azext_iot/tests/adr/test_adr_group_int.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Integration tests for ``iot adr ns group {create|show|list|delete}``.
+
+Lightweight: only requires a namespace, no Hub / DPS / UAMI.
+"""
+
+import pytest
+
+from azext_iot.tests import CaptureOutputLiveScenarioTest
+from azext_iot.tests.adr._log import LogKind, _log, timed_step
+from azext_iot.tests.adr.conftest import (
+    TEST_LOCATION,
+    TEST_RG,
+    generate_adr_namespace_name,
+)
+from azext_iot.tests.generators import generate_generic_id
+
+
+def _gen_group_name() -> str:
+    return f"testgrp{generate_generic_id()[:8]}"
+
+
+# Simple membership query — service accepts arbitrary KQL-style filter strings
+# on create; we only need the round-trip to work for CRUD coverage.
+_TEST_QUERY = "true"
+
+
+@pytest.mark.usefixtures("set_cwd")
+class TestADRGroupCrudLifecycle(CaptureOutputLiveScenarioTest):
+    """Lifecycle: create namespace -> CRUD groups -> cleanup."""
+
+    def test_group_crud_lifecycle(self):
+        _log(LogKind.TEST, "test_group_crud_lifecycle")
+        rg = TEST_RG
+        ns = generate_adr_namespace_name()
+        group_a = _gen_group_name()
+        group_b = _gen_group_name()
+
+        try:
+            with timed_step("Step 1 ❯ Create ADR Namespace"):
+                ns_cmd = f"iot adr ns create -n {ns} -g {rg} --location {TEST_LOCATION}"
+                _log(LogKind.CMD, "az %s", ns_cmd)
+                self.cmd(ns_cmd)
+                _log(LogKind.RESULT, "namespace=%s", ns)
+
+            with timed_step("Step 2 ❯ Create group (minimal)"):
+                create_a = (
+                    f"iot adr ns group create -n {group_a} --ns {ns} -g {rg} "
+                    f'--query-string "{_TEST_QUERY}"'
+                )
+                _log(LogKind.CMD, "az %s", create_a)
+                a = self.cmd(create_a).get_output_in_json()
+                assert a["name"] == group_a
+                assert a["properties"]["groupType"] == "Device"
+                assert a["properties"]["query"] == _TEST_QUERY
+                assert a["properties"]["provisioningState"] == "Succeeded"
+                _log(LogKind.OK, "group_a created, groupType=Device")
+
+            with timed_step("Step 3 ❯ Create group (with display name, description, tags)"):
+                create_b = (
+                    f"iot adr ns group create -n {group_b} --ns {ns} -g {rg} "
+                    f'--query-string "{_TEST_QUERY}" '
+                    f'--display-name "Test Group B" --description "integration-test group" '
+                    f"--tags env=test owner=adr-tests"
+                )
+                _log(LogKind.CMD, "az %s", create_b)
+                b = self.cmd(create_b).get_output_in_json()
+                assert b["name"] == group_b
+                assert b["properties"]["displayName"] == "Test Group B"
+                assert b["properties"]["description"] == "integration-test group"
+                assert b.get("tags", {}).get("env") == "test"
+                assert b.get("tags", {}).get("owner") == "adr-tests"
+                _log(LogKind.OK, "group_b created with display name + tags")
+
+            with timed_step("Step 4 ❯ Show group"):
+                show_cmd = f"iot adr ns group show -n {group_a} --ns {ns} -g {rg}"
+                _log(LogKind.CMD, "az %s", show_cmd)
+                shown = self.cmd(show_cmd).get_output_in_json()
+                assert shown["name"] == group_a
+                assert shown["properties"]["query"] == _TEST_QUERY
+                _log(LogKind.OK, "group show roundtrip ok")
+
+            with timed_step("Step 5 ❯ List groups"):
+                list_cmd = f"iot adr ns group list --ns {ns} -g {rg}"
+                _log(LogKind.CMD, "az %s", list_cmd)
+                groups = self.cmd(list_cmd).get_output_in_json()
+                assert isinstance(groups, list)
+                names = {g["name"] for g in groups}
+                assert group_a in names and group_b in names, (
+                    f"missing groups in list: {names}"
+                )
+                _log(LogKind.OK, "list returned %d groups including both created", len(groups))
+
+            with timed_step("Step 6 ❯ Delete one group, verify gone"):
+                del_cmd = f"iot adr ns group delete -n {group_a} --ns {ns} -g {rg} -y"
+                _log(LogKind.CMD, "az %s", del_cmd)
+                self.cmd(del_cmd)
+
+                _log(LogKind.CMD, "az %s  (expect failure)", show_cmd)
+                self.cmd(show_cmd, expect_failure=True)
+
+                groups_after = self.cmd(list_cmd).get_output_in_json()
+                remaining = {g["name"] for g in groups_after}
+                assert group_a not in remaining
+                assert group_b in remaining
+                _log(LogKind.OK, "group_a deleted, group_b remains")
+
+            with timed_step("Step 7 ❯ Delete remaining group"):
+                self.cmd(f"iot adr ns group delete -n {group_b} --ns {ns} -g {rg} -y")
+                _log(LogKind.OK, "group_b deleted")
+
+        finally:
+            with timed_step("Cleanup ❯ Delete Namespace"):
+                try:
+                    self.cmd(f"iot adr ns delete -n {ns} -g {rg} -y")
+                except Exception as e:
+                    _log(LogKind.WARN, "namespace cleanup failed: %s", e)

--- a/azext_iot/tests/adr/test_adr_group_unit.py
+++ b/azext_iot/tests/adr/test_adr_group_unit.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import Mock
+
+
+def test_group_show(fixture_group_provider):
+    mock_group = Mock()
+    fixture_group_provider.client.groups.get.return_value = mock_group
+
+    result = fixture_group_provider.show(
+        group_name="g1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    assert result == mock_group
+    fixture_group_provider.client.groups.get.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        group_name="g1",
+    )
+
+
+def test_group_list(fixture_group_provider):
+    fixture_group_provider.client.groups.list_by_namespace.return_value = [Mock(), Mock()]
+
+    result = fixture_group_provider.list(
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    assert len(result) == 2
+    fixture_group_provider.client.groups.list_by_namespace.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+    )
+
+
+def test_group_create_minimal(fixture_group_provider, mock_poller):
+    expected = {"name": "g1"}
+    fixture_group_provider.client.groups.begin_create_or_replace.return_value = mock_poller(expected)
+
+    result = fixture_group_provider.create(
+        group_name="g1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        query="attributes.x == 'y'",
+    )
+
+    assert result == expected
+    fixture_group_provider.client.groups.begin_create_or_replace.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        group_name="g1",
+        resource={
+            "location": "westus",
+            "properties": {
+                "groupType": "Device",
+                "query": "attributes.x == 'y'",
+            },
+        },
+    )
+
+
+def test_group_create_full(fixture_group_provider, mock_poller):
+    fixture_group_provider.client.groups.begin_create_or_replace.return_value = mock_poller(Mock())
+
+    fixture_group_provider.create(
+        group_name="g1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        query="q",
+        group_type="Device",
+        display_name="My group",
+        description="hello",
+        location="eastus",
+        tags={"env": "demo"},
+    )
+
+    fixture_group_provider.client.groups.begin_create_or_replace.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        group_name="g1",
+        resource={
+            "location": "eastus",
+            "properties": {
+                "groupType": "Device",
+                "query": "q",
+                "displayName": "My group",
+                "description": "hello",
+            },
+            "tags": {"env": "demo"},
+        },
+    )
+
+
+def test_group_delete(fixture_group_provider, mock_poller):
+    fixture_group_provider.client.groups.begin_delete.return_value = mock_poller(None)
+
+    fixture_group_provider.delete(
+        group_name="g1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    fixture_group_provider.client.groups.begin_delete.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        group_name="g1",
+    )

--- a/azext_iot/tests/adr/test_adr_job_int.py
+++ b/azext_iot/tests/adr/test_adr_job_int.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Integration tests for ``iot adr ns job {create|show|list|delete}``.
+
+Lightweight: namespace + one target group; no Hub / DPS / UAMI required.
+"""
+
+import pytest
+
+from azext_iot.tests import CaptureOutputLiveScenarioTest
+from azext_iot.tests.adr._log import LogKind, _log, timed_step
+from azext_iot.tests.adr.conftest import (
+    TEST_LOCATION,
+    TEST_RG,
+    generate_adr_namespace_name,
+)
+from azext_iot.tests.generators import generate_generic_id
+
+
+def _gen_group_name() -> str:
+    return f"testgrp{generate_generic_id()[:8]}"
+
+
+def _gen_job_name() -> str:
+    return f"testjob{generate_generic_id()[:8]}"
+
+
+_TEST_QUERY = "true"
+
+
+@pytest.mark.usefixtures("set_cwd")
+class TestADRJobCrudLifecycle(CaptureOutputLiveScenarioTest):
+    """Lifecycle: create namespace + target group -> CRUD jobs -> cleanup.
+
+    Job creation requires a group resource ID as the target, so this test
+    provisions a group first.
+    """
+
+    def test_job_crud_lifecycle(self):
+        _log(LogKind.TEST, "test_job_crud_lifecycle")
+        rg = TEST_RG
+        ns = generate_adr_namespace_name()
+        group = _gen_group_name()
+        job = _gen_job_name()
+
+        update_provider = "Contoso"
+        update_name = "Firmware"
+        update_version = "1.2.3"
+
+        try:
+            with timed_step("Step 1 ❯ Create namespace + target group"):
+                self.cmd(f"iot adr ns create -n {ns} -g {rg} --location {TEST_LOCATION}")
+                group_obj = self.cmd(
+                    f"iot adr ns group create -n {group} --ns {ns} -g {rg} "
+                    f'--query-string "{_TEST_QUERY}"'
+                ).get_output_in_json()
+                group_id = group_obj["id"]
+                _log(LogKind.RESULT, "group id=%s", group_id)
+
+            with timed_step("Step 2 ❯ Create job"):
+                create_cmd = (
+                    f"iot adr ns job create -n {job} --ns {ns} -g {rg} "
+                    f"--tgid {group_id} "
+                    f"--up {update_provider} --un {update_name} --uv {update_version} "
+                    f"--tags env=test"
+                )
+                _log(LogKind.CMD, "az %s", create_cmd)
+                job_obj = self.cmd(create_cmd).get_output_in_json()
+                assert job_obj["name"] == job
+                assert job_obj["properties"]["jobType"] == "Update"
+                assert job_obj["properties"]["target"]["targetResourceId"] == group_id
+                update_id = job_obj["properties"]["definition"]["update"]["updateId"]
+                assert update_id["provider"] == update_provider
+                assert update_id["name"] == update_name
+                assert update_id["version"] == update_version
+                assert job_obj["properties"]["provisioningState"] == "Succeeded"
+                assert job_obj.get("tags", {}).get("env") == "test"
+                _log(LogKind.OK, "job created with correct target + update id")
+
+            with timed_step("Step 3 ❯ Show + list"):
+                show_cmd = f"iot adr ns job show -n {job} --ns {ns} -g {rg}"
+                shown = self.cmd(show_cmd).get_output_in_json()
+                assert shown["name"] == job
+                assert shown["properties"]["target"]["targetResourceId"] == group_id
+
+                list_cmd = f"iot adr ns job list --ns {ns} -g {rg}"
+                jobs = self.cmd(list_cmd).get_output_in_json()
+                assert isinstance(jobs, list)
+                assert job in {j["name"] for j in jobs}
+                _log(LogKind.OK, "show + list roundtrip ok (%d jobs)", len(jobs))
+
+            with timed_step("Step 4 ❯ Delete job, verify gone"):
+                self.cmd(f"iot adr ns job delete -n {job} --ns {ns} -g {rg} -y")
+                self.cmd(show_cmd, expect_failure=True)
+                jobs_after = self.cmd(list_cmd).get_output_in_json()
+                assert job not in {j["name"] for j in jobs_after}
+                _log(LogKind.OK, "job deleted")
+
+        finally:
+            with timed_step("Cleanup ❯ Delete Namespace (also deletes child group)"):
+                try:
+                    self.cmd(f"iot adr ns delete -n {ns} -g {rg} -y")
+                except Exception as e:
+                    _log(LogKind.WARN, "namespace cleanup failed: %s", e)

--- a/azext_iot/tests/adr/test_adr_job_unit.py
+++ b/azext_iot/tests/adr/test_adr_job_unit.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import Mock
+
+TARGET_GROUP_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.DeviceRegistry/"
+    "namespaces/ns/groups/g1"
+)
+
+
+def test_job_show(fixture_job_provider):
+    mock_job = Mock()
+    fixture_job_provider.client.jobs.get.return_value = mock_job
+
+    result = fixture_job_provider.show(
+        job_name="j1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    assert result == mock_job
+    fixture_job_provider.client.jobs.get.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        job_name="j1",
+    )
+
+
+def test_job_list(fixture_job_provider):
+    fixture_job_provider.client.jobs.list_by_namespace.return_value = [Mock()]
+
+    result = fixture_job_provider.list(
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    assert len(result) == 1
+    fixture_job_provider.client.jobs.list_by_namespace.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+    )
+
+
+def test_job_create(fixture_job_provider, mock_poller):
+    expected = {"name": "j1"}
+    fixture_job_provider.client.jobs.begin_create_or_replace.return_value = mock_poller(expected)
+
+    result = fixture_job_provider.create(
+        job_name="j1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        target_group_id=TARGET_GROUP_ID,
+        update_provider="Contoso",
+        update_name="Toaster",
+        update_version="1.0.0",
+    )
+
+    assert result == expected
+    fixture_job_provider.client.jobs.begin_create_or_replace.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        job_name="j1",
+        resource={
+            "location": "westus",
+            "properties": {
+                "jobType": "Update",
+                "target": {"targetResourceId": TARGET_GROUP_ID},
+                "definition": {
+                    "schedulingType": "continuous",
+                    "update": {
+                        "updateId": {
+                            "provider": "Contoso",
+                            "name": "Toaster",
+                            "version": "1.0.0",
+                        }
+                    },
+                },
+            },
+        },
+    )
+
+
+def test_job_create_with_tags_and_location(fixture_job_provider, mock_poller):
+    fixture_job_provider.client.jobs.begin_create_or_replace.return_value = mock_poller(Mock())
+
+    fixture_job_provider.create(
+        job_name="j1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        target_group_id=TARGET_GROUP_ID,
+        update_provider="p",
+        update_name="n",
+        update_version="v",
+        location="eastus",
+        tags={"env": "demo"},
+    )
+
+    called_kwargs = fixture_job_provider.client.jobs.begin_create_or_replace.call_args.kwargs
+    assert called_kwargs["resource"]["location"] == "eastus"
+    assert called_kwargs["resource"]["tags"] == {"env": "demo"}
+
+
+def test_job_delete(fixture_job_provider, mock_poller):
+    fixture_job_provider.client.jobs.begin_delete.return_value = mock_poller(None)
+
+    fixture_job_provider.delete(
+        job_name="j1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    fixture_job_provider.client.jobs.begin_delete.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        job_name="j1",
+    )

--- a/azext_iot/tests/adr/test_adr_link_int.py
+++ b/azext_iot/tests/adr/test_adr_link_int.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Integration tests for ``iot adr ns link {hub|dps} {add|show|list|remove}``.
+
+Contains two classes:
+
+* ``TestADRLinkIdentityValidation`` — fast CLI-validation negative tests
+  (namespace only; no Hub / DPS create).
+* ``TestADRLinkLifecycle`` — end-to-end add/show/list/remove for both hub and
+  dps link kinds against real Gen2 Hub + DPS (heavyweight, slowest).
+"""
+
+import pytest
+
+from azext_iot.tests import CaptureOutputLiveScenarioTest
+from azext_iot.tests.adr._helpers import ADRHubInfraHelper
+from azext_iot.tests.adr._log import LogKind, _log, timed_step
+from azext_iot.tests.adr.conftest import (
+    CUSTOM_POLICY_NAME,
+    TEST_LOCATION,
+    TEST_RG,
+    generate_adr_namespace_name,
+    generate_dps_name,
+    generate_hub_name,
+    generate_identity_name,
+)
+from azext_iot.tests.generators import generate_generic_id
+
+
+def _gen_link_name(prefix: str) -> str:
+    return f"{prefix}{generate_generic_id()[:6]}"
+
+
+# ---------- 1. Link command identity validation (no Hub/DPS required) ----------
+
+@pytest.mark.usefixtures("set_cwd")
+class TestADRLinkIdentityValidation(CaptureOutputLiveScenarioTest):
+    """Validation-only: confirm the CLI rejects bad identity arg combinations
+    before any ARM call is made. Uses bogus resource IDs because the request
+    should fail at the parameter-validation layer.
+    """
+
+    def test_link_add_identity_validation(self):
+        _log(LogKind.TEST, "test_link_add_identity_validation")
+        rg = TEST_RG
+        ns = generate_adr_namespace_name()
+        link_name = _gen_link_name("hub")
+        bogus_hub_id = (
+            f"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/{rg}"
+            f"/providers/Microsoft.Devices/IotHubs/nonexistent-hub"
+        )
+        bogus_uami_id = (
+            f"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/{rg}"
+            f"/providers/Microsoft.ManagedIdentity/userAssignedIdentities/nonexistent"
+        )
+
+        try:
+            with timed_step("Step 1 ❯ Create namespace"):
+                self.cmd(f"iot adr ns create -n {ns} -g {rg} --location {TEST_LOCATION}")
+
+            with timed_step("Step 2 ❯ Reject add with no identity flag"):
+                # Neither --mi-system-assigned nor --mi-user-assigned: must fail
+                # at the validator stage with RequiredArgumentMissingError.
+                no_id_cmd = (
+                    f"iot adr ns link hub add -n {link_name} --ns {ns} -g {rg} "
+                    f"--hub-resource-id {bogus_hub_id}"
+                )
+                _log(LogKind.CMD, "az %s  (expect failure)", no_id_cmd)
+                self.cmd(no_id_cmd, expect_failure=True)
+                _log(LogKind.OK, "rejected as expected")
+
+            with timed_step("Step 3 ❯ Reject add with both identity flags"):
+                # Both flags set: must fail with MutuallyExclusiveArgumentError.
+                both_cmd = (
+                    f"iot adr ns link hub add -n {link_name} --ns {ns} -g {rg} "
+                    f"--hub-resource-id {bogus_hub_id} "
+                    f"--mi-system-assigned --mi-user-assigned {bogus_uami_id}"
+                )
+                _log(LogKind.CMD, "az %s  (expect failure)", both_cmd)
+                self.cmd(both_cmd, expect_failure=True)
+                _log(LogKind.OK, "rejected as expected")
+
+        finally:
+            with timed_step("Cleanup ❯ Delete Namespace"):
+                try:
+                    self.cmd(f"iot adr ns delete -n {ns} -g {rg} -y")
+                except Exception as e:
+                    _log(LogKind.WARN, "namespace cleanup failed: %s", e)
+
+
+# ---------- 2. Link lifecycle: Hub + DPS end-to-end (heavyweight) ----------
+
+@pytest.mark.usefixtures("set_cwd")
+class TestADRLinkLifecycle(ADRHubInfraHelper, CaptureOutputLiveScenarioTest):
+    """End-to-end add/show/list/remove for both hub and dps link kinds.
+
+    Reuses ``ADRHubInfraHelper.setup_full_infra`` to provision the namespace +
+    Gen2 Hub + UAMI (so the namespace already has a system-assigned identity
+    suitable for ``--mi-system-assigned``). DPS is added inline to keep the
+    test self-contained.
+    """
+
+    def test_link_hub_and_dps_lifecycle(self):
+        _log(LogKind.TEST, "test_link_hub_and_dps_lifecycle")
+        rg = TEST_RG
+        ns = generate_adr_namespace_name()
+        hub_name = generate_hub_name()
+        dps_name = generate_dps_name()
+        identity_name = generate_identity_name()
+        hub_link = _gen_link_name("hublink")
+        dps_link = _gen_link_name("dpslink")
+
+        try:
+            infra = self.setup_full_infra(
+                resource_group=rg,
+                namespace_name=ns,
+                hub_name=hub_name,
+                identity_name=identity_name,
+                policy_name=CUSTOM_POLICY_NAME,
+            )
+            hub_id = self.cmd(
+                f"iot hub show -n {hub_name} -g {rg}"
+            ).get_output_in_json()["id"]
+
+            # ---------- Hub link CRUD ----------
+
+            with timed_step("Hub link 1 ❯ Add (system-assigned identity)"):
+                add_cmd = (
+                    f"iot adr ns link hub add -n {hub_link} --ns {ns} -g {rg} "
+                    f"--hub-resource-id {hub_id} --mi-system-assigned"
+                )
+                _log(LogKind.CMD, "az %s", add_cmd)
+                added = self.cmd(add_cmd).get_output_in_json()
+                # Provider normalizes the response into a flat dict with
+                # 'name' + endpoint properties.
+                assert added.get("name") == hub_link or added.get("resourceId") == hub_id
+                _log(LogKind.OK, "hub link added")
+
+            with timed_step("Hub link 2 ❯ Show"):
+                show_cmd = f"iot adr ns link hub show -n {hub_link} --ns {ns} -g {rg}"
+                _log(LogKind.CMD, "az %s", show_cmd)
+                shown = self.cmd(show_cmd).get_output_in_json()
+                assert shown["resourceId"] == hub_id
+                identity = shown.get("inboundCallerIdentity", {})
+                assert identity.get("type") == "SystemAssigned"
+                _log(LogKind.OK, "hub link show roundtrip ok")
+
+            with timed_step("Hub link 3 ❯ List"):
+                list_cmd = f"iot adr ns link hub list --ns {ns} -g {rg}"
+                _log(LogKind.CMD, "az %s", list_cmd)
+                links = self.cmd(list_cmd).get_output_in_json()
+                assert isinstance(links, list)
+                assert hub_link in {entry["name"] for entry in links}
+                _log(LogKind.OK, "hub link present in list (%d total)", len(links))
+
+            with timed_step("Hub link 4 ❯ Remove"):
+                _log(LogKind.CMD, "az iot adr ns link hub remove -n %s --ns %s -g %s -y",
+                     hub_link, ns, rg)
+                self.cmd(
+                    f"iot adr ns link hub remove -n {hub_link} --ns {ns} -g {rg} -y"
+                )
+                self.cmd(show_cmd, expect_failure=True)
+                links_after = self.cmd(list_cmd).get_output_in_json()
+                assert hub_link not in {entry["name"] for entry in links_after}
+                _log(LogKind.OK, "hub link removed")
+
+            # ---------- DPS link CRUD ----------
+
+            with timed_step("DPS setup ❯ Create DPS"):
+                identity_resource_id = infra["identity_resource_id"]
+                adr_resource_id = infra["adr_resource_id"]
+                dps_cmd = (
+                    f"iot dps create --name {dps_name} -g {rg} --location {TEST_LOCATION} "
+                    f"--mi-user-assigned {identity_resource_id} "
+                    f"--ns-resource-id {adr_resource_id} "
+                    f"--ns-identity-id {identity_resource_id}"
+                )
+                _log(LogKind.CMD, "az %s", dps_cmd)
+                dps = self.cmd(dps_cmd).get_output_in_json()
+                dps_id = dps["id"]
+                _log(LogKind.RESULT, "dps id=%s", dps_id)
+
+            with timed_step("DPS link 1 ❯ Add (system-assigned identity)"):
+                add_cmd = (
+                    f"iot adr ns link dps add -n {dps_link} --ns {ns} -g {rg} "
+                    f"--dps-resource-id {dps_id} --mi-system-assigned"
+                )
+                _log(LogKind.CMD, "az %s", add_cmd)
+                self.cmd(add_cmd)
+                _log(LogKind.OK, "dps link added")
+
+            with timed_step("DPS link 2 ❯ Show + List"):
+                show_dps = f"iot adr ns link dps show -n {dps_link} --ns {ns} -g {rg}"
+                shown = self.cmd(show_dps).get_output_in_json()
+                assert shown["resourceId"] == dps_id
+                assert shown.get("inboundCallerIdentity", {}).get("type") == "SystemAssigned"
+
+                list_dps = f"iot adr ns link dps list --ns {ns} -g {rg}"
+                links = self.cmd(list_dps).get_output_in_json()
+                assert dps_link in {entry["name"] for entry in links}
+                _log(LogKind.OK, "dps link present in show + list")
+
+            with timed_step("DPS link 3 ❯ Remove"):
+                self.cmd(
+                    f"iot adr ns link dps remove -n {dps_link} --ns {ns} -g {rg} -y"
+                )
+                self.cmd(show_dps, expect_failure=True)
+                _log(LogKind.OK, "dps link removed")
+
+        finally:
+            with timed_step("Cleanup ❯ Delete Hub + DPS + Namespace + UAMI"):
+                self.cleanup_full_infra(
+                    resource_group=rg,
+                    hub_name=hub_name,
+                    namespace_name=ns,
+                    identity_name=identity_name,
+                    dps_name=dps_name,
+                )

--- a/azext_iot/tests/adr/test_adr_link_unit.py
+++ b/azext_iot/tests/adr/test_adr_link_unit.py
@@ -1,0 +1,265 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from unittest.mock import Mock
+
+import pytest
+from azure.cli.core.azclierror import (
+    MutuallyExclusiveArgumentError,
+    RequiredArgumentMissingError,
+    ResourceNotFoundError,
+)
+
+from azext_iot.adr.providers.linking import (
+    DEFAULT_DPS_ENDPOINT_TYPE,
+    DEFAULT_HUB_ENDPOINT_TYPE,
+    LINK_KIND_DPS,
+    LINK_KIND_HUB,
+)
+
+HUB_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Devices/IotHubs/myhub"
+)
+DPS_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Devices/"
+    "ProvisioningServices/mydps"
+)
+UAMI_ID = (
+    "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/"
+    "userAssignedIdentities/myuami"
+)
+
+
+def _ns_with_messaging(endpoints):
+    return {"properties": {"messaging": {"endpoints": endpoints}}}
+
+
+def _ns_with_provisioning(endpoints):
+    return {"properties": {"provisioning": {"endpoints": endpoints}}}
+
+
+# ---------- show ----------
+
+def test_link_hub_show(fixture_link_provider):
+    body = {"resourceId": HUB_ID, "inboundCallerIdentity": {"type": "SystemAssigned"}}
+    fixture_link_provider.client.namespaces.get.return_value = _ns_with_messaging({"hub1": body})
+
+    result = fixture_link_provider.show(
+        kind=LINK_KIND_HUB, link_name="hub1", namespace_name="ns1", resource_group_name="rg1",
+    )
+
+    assert result == body
+
+
+def test_link_dps_show_missing_raises(fixture_link_provider):
+    fixture_link_provider.client.namespaces.get.return_value = _ns_with_provisioning({})
+
+    with pytest.raises(ResourceNotFoundError):
+        fixture_link_provider.show(
+            kind=LINK_KIND_DPS, link_name="dps1", namespace_name="ns1", resource_group_name="rg1",
+        )
+
+
+# ---------- list ----------
+
+def test_link_hub_list_normalizes_dict(fixture_link_provider):
+    body = {"resourceId": HUB_ID, "inboundCallerIdentity": {"type": "SystemAssigned"}}
+    fixture_link_provider.client.namespaces.get.return_value = _ns_with_messaging(
+        {"hub1": body, "hub2": body}
+    )
+
+    result = fixture_link_provider.list(
+        kind=LINK_KIND_HUB, namespace_name="ns1", resource_group_name="rg1",
+    )
+
+    assert len(result) == 2
+    names = sorted(entry["name"] for entry in result)
+    assert names == ["hub1", "hub2"]
+    for entry in result:
+        assert entry["resourceId"] == HUB_ID
+
+
+def test_link_dps_list_empty_when_section_missing(fixture_link_provider):
+    fixture_link_provider.client.namespaces.get.return_value = {"properties": {}}
+
+    result = fixture_link_provider.list(
+        kind=LINK_KIND_DPS, namespace_name="ns1", resource_group_name="rg1",
+    )
+
+    assert result == []
+
+
+# ---------- add (hub) ----------
+
+def test_link_hub_add_system_assigned(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.add(
+        kind=LINK_KIND_HUB,
+        link_name="hub1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        resource_id=HUB_ID,
+        mi_system_assigned=True,
+    )
+
+    fixture_link_provider.client.namespaces.begin_update.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        properties={
+            "properties": {
+                "messaging": {
+                    "endpoints": {
+                        "hub1": {
+                            "resourceId": HUB_ID,
+                            "inboundCallerIdentity": {"type": "SystemAssigned"},
+                            "endpointType": DEFAULT_HUB_ENDPOINT_TYPE,
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_link_hub_add_user_assigned(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.add(
+        kind=LINK_KIND_HUB,
+        link_name="hub1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        resource_id=HUB_ID,
+        mi_user_assigned=UAMI_ID,
+    )
+
+    called = fixture_link_provider.client.namespaces.begin_update.call_args.kwargs["properties"]
+    identity = called["properties"]["messaging"]["endpoints"]["hub1"]["inboundCallerIdentity"]
+    assert identity == {"type": "UserAssigned", "userAssignedIdentity": UAMI_ID}
+
+
+# ---------- add (dps) ----------
+
+def test_link_dps_add_system_assigned(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.add(
+        kind=LINK_KIND_DPS,
+        link_name="dps1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        resource_id=DPS_ID,
+        mi_system_assigned=True,
+    )
+
+    fixture_link_provider.client.namespaces.begin_update.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        properties={
+            "properties": {
+                "provisioning": {
+                    "endpoints": {
+                        "dps1": {
+                            "resourceId": DPS_ID,
+                            "inboundCallerIdentity": {"type": "SystemAssigned"},
+                            "endpointType": DEFAULT_DPS_ENDPOINT_TYPE,
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_link_add_requires_identity(fixture_link_provider):
+    with pytest.raises(RequiredArgumentMissingError):
+        fixture_link_provider.add(
+            kind=LINK_KIND_HUB,
+            link_name="hub1",
+            namespace_name="ns1",
+            resource_group_name="rg1",
+            resource_id=HUB_ID,
+        )
+
+
+def test_link_add_rejects_both_identities(fixture_link_provider):
+    with pytest.raises(MutuallyExclusiveArgumentError):
+        fixture_link_provider.add(
+            kind=LINK_KIND_HUB,
+            link_name="hub1",
+            namespace_name="ns1",
+            resource_group_name="rg1",
+            resource_id=HUB_ID,
+            mi_system_assigned=True,
+            mi_user_assigned=UAMI_ID,
+        )
+
+
+def test_link_add_custom_endpoint_type(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.add(
+        kind=LINK_KIND_HUB,
+        link_name="hub1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+        resource_id=HUB_ID,
+        mi_system_assigned=True,
+        endpoint_type="Microsoft.Custom/Thing",
+    )
+
+    called = fixture_link_provider.client.namespaces.begin_update.call_args.kwargs["properties"]
+    assert called["properties"]["messaging"]["endpoints"]["hub1"]["endpointType"] == \
+        "Microsoft.Custom/Thing"
+
+
+# ---------- remove ----------
+
+def test_link_hub_remove(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.remove(
+        kind=LINK_KIND_HUB,
+        link_name="hub1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    fixture_link_provider.client.namespaces.begin_update.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        properties={
+            "properties": {
+                "messaging": {
+                    "endpoints": {"hub1": None}
+                }
+            }
+        },
+    )
+
+
+def test_link_dps_remove(fixture_link_provider, mock_poller):
+    fixture_link_provider.client.namespaces.begin_update.return_value = mock_poller(Mock())
+
+    fixture_link_provider.remove(
+        kind=LINK_KIND_DPS,
+        link_name="dps1",
+        namespace_name="ns1",
+        resource_group_name="rg1",
+    )
+
+    fixture_link_provider.client.namespaces.begin_update.assert_called_once_with(
+        resource_group_name="rg1",
+        namespace_name="ns1",
+        properties={
+            "properties": {
+                "provisioning": {
+                    "endpoints": {"dps1": None}
+                }
+            }
+        },
+    )


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs-pr/pull/28010
`2026-11-02-preview`
- Linking
- Groups
- Jobs
- Job Runs

---
`0.33.0b1`: ADR Ignite (M1) — Groups, Jobs, and Namespace Endpoint Links

Preview release `0.33.0b1` adding the first PoC slice of ADR Ignite commands on top of the regenerated DeviceRegistry SDK (`2026-11-02-preview`).

Wires up **16 new CLI commands** across three domains so customers can manage device groups, update jobs, and IoT Hub / DPS endpoint links on an ADR namespace:

| Command group | Commands |
|---|---|
| `az iot adr ns group` | `create`, `show`, `list`, `delete` |
| `az iot adr ns job` | `create`, `show`, `list`, `delete` |
| `az iot adr ns link hub` | `add`, `show`, `list`, `remove` |
| `az iot adr ns link dps` | `add`, `show`, `list`, `remove` |
