### PR TITLE
feat: support switching on `dps linked-hub update`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,15 @@ Release History
   - Device-level (``-d``) and module-level (``-d -m``) default to the device hostname.
   - ``service``, ``device`` and ``classic`` are explicitly selectable.
 
+**DPS updates**
+
+* ``az iot dps linked-hub update`` can now switch a linked hub's endpoint and authentication type, enabling a single-step TLS 1.3 + managed-identity migration:
+
+  - ``--hub-name`` (preferred) or ``--linked-hub <full-hostname>`` identifies the entry to update. ``--hub-name`` resolves to the correct entry regardless of classic or device hostname; if the same hub is linked at multiple endpoints, the CLI errors with a clear disambiguation hint pointing to ``--linked-hub``.
+  - ``--hostname-type {auto, device, classic}`` switches the linked hub's endpoint hostname. For KeyBased links the existing connection string is rewritten in place, preserving the existing key.
+  - ``--authentication-type {KeyBased, SystemAssigned, UserAssigned}`` (with optional ``--user-assigned-identity`` / ``--connection-string``) switches the authentication type. When switching to KeyBased without ``--connection-string``, the hub key is auto-fetched via ``--hub-name``.
+  - Endpoint and authentication-type changes can be combined in a single call.
+
 0.31.0b1 (Preview)
 +++++++++++++++
 

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -160,8 +160,45 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('allocation_weight', help='Allocation weight of the IoT hub.')
 
     with self.argument_context('iot dps linked-hub update') as c:
+        c.argument('linked_hub',
+                   options_list=['--linked-hub'],
+                   help='Full host name of the linked IoT Hub (e.g. <hub>.device.azure-devices.net). '
+                   'Use this to disambiguate when --hub-name resolves to multiple entries.',
+                   arg_group='Linked Hub Identifier')
+        c.argument('hub_name',
+                   options_list=['--hub-name', '--hn'],
+                   help='IoT Hub short name. Preferred over --linked-hub; resolves to the correct '
+                   'entry regardless of classic/device hostname.',
+                   arg_group='Linked Hub Identifier')
+        c.argument('hub_resource_group',
+                   options_list=['--hub-resource-group', '--hrg'],
+                   help='Resource group of the IoT Hub. Used when looking up hub metadata.',
+                   arg_group='Linked Hub Identifier')
+        c.argument('hostname_type',
+                   options_list=['--hostname-type', '--ht'],
+                   arg_type=get_enum_type(["auto", "device", "classic"]),
+                   help="Switch the linked hub to a different endpoint hostname. "
+                   "'auto' uses the TLS 1.3 device hostname when available, classic otherwise. "
+                   "'device' uses the TLS 1.3 device hostname (errors on non-GWv2 hubs). "
+                   "'classic' uses the classic hostname.")
+        c.argument('authentication_type',
+                   options_list=['--authentication-type', '--auth-type'],
+                   arg_type=get_enum_type(IotHubAuthenticationType),
+                   help='Switch the linked hub to a different authentication type. '
+                   "'KeyBased' uses a connection string (supplied via --connection-string, "
+                   "otherwise auto-fetched from the identified hub). "
+                   "'SystemAssigned' uses the DPS system-assigned managed identity. "
+                   "'UserAssigned' uses a user-assigned managed identity.")
+        c.argument('user_assigned_identity',
+                   options_list=['--user-assigned-identity', '--uai'],
+                   help='User-assigned managed identity resource ID. '
+                   'Required when --authentication-type is UserAssigned.')
+        c.argument('connection_string',
+                   options_list=['--connection-string', '--cs'],
+                   help='IoT Hub connection string to use when switching to KeyBased authentication. '
+                   'If omitted, the key is auto-fetched from the identified hub.')
         c.argument('apply_allocation_policy',
-                   help='A boolean indicating whether to apply allocation policy to the Iot hub.',
+                   help='A boolean indicating whether to apply allocation policy to the IoT hub.',
                    arg_type=get_three_state_flag())
         c.argument('allocation_weight', help='Allocation weight of the IoT hub.')
 

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -162,17 +162,13 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('iot dps linked-hub update') as c:
         c.argument('linked_hub',
                    options_list=['--linked-hub'],
-                   help='Full host name of the linked IoT Hub (e.g. <hub>.device.azure-devices.net). '
+                   help='Full host name of the linked IoT Hub (e.g. `myhub.device.azure-devices.net`). '
                    'Use this to disambiguate when --hub-name resolves to multiple entries.',
                    arg_group='Linked Hub Identifier')
         c.argument('hub_name',
                    options_list=['--hub-name', '--hn'],
                    help='IoT Hub short name. Preferred over --linked-hub; resolves to the correct '
                    'entry regardless of classic/device hostname.',
-                   arg_group='Linked Hub Identifier')
-        c.argument('hub_resource_group',
-                   options_list=['--hub-resource-group', '--hrg'],
-                   help='Resource group of the IoT Hub. Used when looking up hub metadata.',
                    arg_group='Linked Hub Identifier')
         c.argument('hostname_type',
                    options_list=['--hostname-type', '--ht'],

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -157,7 +157,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('apply_allocation_policy',
                    help='A boolean indicating whether to apply allocation policy to the IoT hub.',
                    arg_type=get_three_state_flag())
-        c.argument('allocation_weight', help='Allocation weight of the IoT hub.')
+        c.argument('allocation_weight', help='Allocation weight of the IoT hub.', type=int)
 
     with self.argument_context('iot dps linked-hub update') as c:
         c.argument('linked_hub',
@@ -196,7 +196,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('apply_allocation_policy',
                    help='A boolean indicating whether to apply allocation policy to the IoT hub.',
                    arg_type=get_three_state_flag())
-        c.argument('allocation_weight', help='Allocation weight of the IoT hub.')
+        c.argument('allocation_weight', help='Allocation weight of the IoT hub.', type=int)
 
     with self.argument_context('iot dps certificate') as c:
         c.argument('certificate_path', options_list=['--path', '-p'], type=file_type,

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -557,6 +557,10 @@ def iot_dps_linked_hub_update(
             "Specify either --hub-name or --linked-hub, not both."
         )
 
+    if linked_hub and '.' not in linked_hub:
+        hub_name = linked_hub
+        linked_hub = None
+
     if not hub_name:
         hub_name = linked_hub.split(".")[0]
 
@@ -572,6 +576,10 @@ def iot_dps_linked_hub_update(
     if authentication_type == IotHubAuthenticationType.USER_ASSIGNED.value and not user_assigned_identity:
         raise RequiredArgumentMissingError(
             "--user-assigned-identity is required when --authentication-type is UserAssigned."
+        )
+    if user_assigned_identity and authentication_type != IotHubAuthenticationType.USER_ASSIGNED.value:
+        raise MutuallyExclusiveArgumentError(
+            "--user-assigned-identity only applies with --authentication-type UserAssigned."
         )
 
     resource_group_name = _ensure_dps_resource_group_name(client, resource_group_name, dps_name)
@@ -617,9 +625,16 @@ def iot_dps_linked_hub_update(
             target_entry["connectionString"] = ""
 
     target_auth = target_entry["authenticationType"]
+    if connection_string and target_auth != IotHubAuthenticationType.KEY_BASED.value:
+        raise MutuallyExclusiveArgumentError(
+            "--connection-string only applies to KeyBased authentication. "
+            "The linked hub uses managed identity; provide --authentication-type KeyBased "
+            "to switch, or omit --connection-string."
+        )
+
     cs_needs_rebuild = (
         target_auth == IotHubAuthenticationType.KEY_BASED.value
-        and (authentication_type or new_hostname)
+        and (authentication_type or new_hostname or connection_string)
     )
     if cs_needs_rebuild:
         if connection_string:

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -557,6 +557,19 @@ def iot_dps_linked_hub_update(
             "Specify either --hub-name or --linked-hub, not both."
         )
 
+    mutation_args = {
+        "--hostname-type": hostname_type,
+        "--authentication-type": authentication_type,
+        "--connection-string": connection_string,
+        "--user-assigned-identity": user_assigned_identity,
+        "--allocation-weight": allocation_weight,
+        "--apply-allocation-policy": apply_allocation_policy,
+    }
+    if all(v is None for v in mutation_args.values()):
+        raise RequiredArgumentMissingError(
+            "Provide at least one update parameter: " + ", ".join(mutation_args.keys()) + "."
+        )
+
     if linked_hub and '.' not in linked_hub:
         hub_name = linked_hub
         linked_hub = None
@@ -588,7 +601,7 @@ def iot_dps_linked_hub_update(
     target_entry = _find_linked_hub_entry(linked_hubs, hub_name=hub_name, linked_hub=linked_hub)
 
     if is_mi:
-        identity_type = dps["identity"]["type"]
+        identity_type = (dps.get("identity") or {}).get("type", "None")
         if authentication_type == IotHubAuthenticationType.SYSTEM_ASSIGNED.value and "SystemAssigned" not in identity_type:
             raise InvalidArgumentValueError(
                 f"System-assigned managed identity is not enabled on DPS '{dps_name}'. "

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -536,7 +536,6 @@ def iot_dps_linked_hub_update(
     dps_name,
     linked_hub=None,
     hub_name=None,
-    hub_resource_group=None,
     hostname_type=None,
     authentication_type=None,
     user_assigned_identity=None,
@@ -600,7 +599,7 @@ def iot_dps_linked_hub_update(
     )
     if needs_hub_fetch:
         hub_client = iot_hub_service_factory(cmd.cli_ctx)
-        hub = iot_hub_get(cmd, hub_client, hub_name=hub_name, resource_group_name=hub_resource_group)
+        hub = iot_hub_get(cmd, hub_client, hub_name=hub_name)
 
     new_hostname = None
     if hostname_type:

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -31,6 +31,7 @@ from knack.util import CLIError
 
 from azext_iot._factory import iot_hub_service_factory, resource_service_factory
 from azext_iot.common._azure import IOT_SERVICE_CS_TEMPLATE
+from azext_iot.common.utility import validate_key_value_pairs
 from azext_iot.constants import IOT_HUB_DEFAULT_POLICY
 from azext_iot.common.certops import open_certificate
 from azext_iot.core.shared import (
@@ -658,8 +659,10 @@ def iot_dps_linked_hub_update(
                 )
             target_entry["connectionString"] = connection_string
         else:
+            parsed_existing_cs = validate_key_value_pairs(target_entry.get("connectionString")) or {}
+            existing_policy = parsed_existing_cs.get("SharedAccessKeyName") or IOT_HUB_DEFAULT_POLICY
             policies = iot_hub_policy_get(
-                hub_client, hub_name, IOT_HUB_DEFAULT_POLICY, _get_resource_group_from_hub(hub)
+                hub_client, hub_name, existing_policy, _get_resource_group_from_hub(hub)
             )
             target_entry["connectionString"] = IOT_SERVICE_CS_TEMPLATE.format(
                 target_entry["hostName"], policies["keyName"], policies["primaryKey"]

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -126,6 +126,41 @@ def _warn_mixed_endpoint_types(linked_hubs):
         )
 
 
+def _find_linked_hub_entry(linked_hubs, hub_name=None, linked_hub=None):
+    """Find a linked-hub entry by short hub-name (prefix) or full hostname (exact).
+
+    Raises ResourceNotFoundError if no entry matches, or
+    InvalidArgumentValueError if --hub-name resolves to multiple entries
+    (caller must disambiguate with --linked-hub <full-hostname>).
+    """
+    if linked_hub:
+        for entry in linked_hubs:
+            if entry["name"].lower() == linked_hub.lower():
+                return entry
+        raise ResourceNotFoundError(
+            f"Linked hub '{linked_hub}' does not exist. "
+            "Use 'iot dps linked-hub list' to see all linked hubs."
+        )
+
+    short_name = hub_name.lower()
+    matches = [
+        entry for entry in linked_hubs
+        if entry["name"].lower().startswith(f"{short_name}.")
+    ]
+    if not matches:
+        raise ResourceNotFoundError(
+            f"No linked hub found for IoT Hub '{hub_name}'. "
+            "Use 'iot dps linked-hub list' to see all linked hubs."
+        )
+    if len(matches) > 1:
+        names = ", ".join(m["name"] for m in matches)
+        raise InvalidArgumentValueError(
+            f"Multiple linked-hub entries found for IoT Hub '{hub_name}': {names}. "
+            "Specify --linked-hub <full-hostname> to disambiguate."
+        )
+    return matches[0]
+
+
 # CUSTOM METHODS FOR DPS
 def iot_dps_list(client, resource_group_name=None):
     if resource_group_name is None:
@@ -495,38 +530,135 @@ def iot_dps_linked_hub_create(
     return iot_dps_linked_hub_list(client, dps_name, resource_group_name)
 
 
-def iot_dps_linked_hub_update(cmd, client, dps_name, linked_hub, resource_group_name=None,
-                              apply_allocation_policy=None, allocation_weight=None, no_wait=False):
-    if '.' not in linked_hub:
-        hub_client = iot_hub_service_factory(cmd.cli_ctx)
-        linked_hub = _get_iot_hub_hostname(hub_client, linked_hub)
+def iot_dps_linked_hub_update(
+    cmd,
+    client,
+    dps_name,
+    linked_hub=None,
+    hub_name=None,
+    hub_resource_group=None,
+    hostname_type=None,
+    authentication_type=None,
+    user_assigned_identity=None,
+    connection_string=None,
+    resource_group_name=None,
+    apply_allocation_policy=None,
+    allocation_weight=None,
+    no_wait=False,
+):
+    """Update a linked IoT Hub on a DPS — allocation policy/weight, endpoint hostname type,
+    and/or authentication type.
+    """
+    if not hub_name and not linked_hub:
+        raise RequiredArgumentMissingError(
+            "Specify --hub-name (preferred) or --linked-hub to identify the linked hub."
+        )
+    if hub_name and linked_hub:
+        raise MutuallyExclusiveArgumentError(
+            "Specify either --hub-name or --linked-hub, not both."
+        )
+
+    if not hub_name:
+        hub_name = linked_hub.split(".")[0]
+
+    is_mi = authentication_type in (
+        IotHubAuthenticationType.SYSTEM_ASSIGNED.value,
+        IotHubAuthenticationType.USER_ASSIGNED.value,
+    )
+    if is_mi and connection_string:
+        raise MutuallyExclusiveArgumentError(
+            "--connection-string cannot be used with --authentication-type SystemAssigned "
+            "or UserAssigned. Managed identity links do not use a connection string."
+        )
+    if authentication_type == IotHubAuthenticationType.USER_ASSIGNED.value and not user_assigned_identity:
+        raise RequiredArgumentMissingError(
+            "--user-assigned-identity is required when --authentication-type is UserAssigned."
+        )
 
     resource_group_name = _ensure_dps_resource_group_name(client, resource_group_name, dps_name)
-    dps_linked_hubs = []
-    dps_linked_hubs.extend(iot_dps_linked_hub_list(client, dps_name, resource_group_name))
-    if not _is_linked_hub_existed(dps_linked_hubs, linked_hub):
-        raise ResourceNotFoundError("Access policy {0} doesn't exist.".format(linked_hub))
-
-    for hub in dps_linked_hubs:
-        if hub["name"] == linked_hub:
-            if apply_allocation_policy is not None:
-                hub["applyAllocationPolicy"] = apply_allocation_policy
-            if allocation_weight is not None:
-                hub["allocationWeight"] = allocation_weight
-
     dps = iot_dps_get(client, dps_name, resource_group_name)
-    dps["properties"]["iotHubs"] = dps_linked_hubs
+    linked_hubs = dps["properties"]["iotHubs"]
+    target_entry = _find_linked_hub_entry(linked_hubs, hub_name=hub_name, linked_hub=linked_hub)
+
+    if is_mi:
+        identity_type = dps["identity"]["type"]
+        if authentication_type == IotHubAuthenticationType.SYSTEM_ASSIGNED.value and "SystemAssigned" not in identity_type:
+            raise InvalidArgumentValueError(
+                f"System-assigned managed identity is not enabled on DPS '{dps_name}'. "
+                "Enable it before linking with SystemAssigned authentication."
+            )
+        if authentication_type == IotHubAuthenticationType.USER_ASSIGNED.value and "UserAssigned" not in identity_type:
+            raise InvalidArgumentValueError(
+                f"User-assigned managed identity is not configured on DPS '{dps_name}'. "
+                "Assign a user identity before linking with UserAssigned authentication."
+            )
+
+    hub = None
+    hub_client = None
+    needs_hub_fetch = hostname_type or (
+        authentication_type == IotHubAuthenticationType.KEY_BASED.value and not connection_string
+    )
+    if needs_hub_fetch:
+        hub_client = iot_hub_service_factory(cmd.cli_ctx)
+        hub = iot_hub_get(cmd, hub_client, hub_name=hub_name, resource_group_name=hub_resource_group)
+
+    new_hostname = None
+    if hostname_type:
+        new_hostname = _resolve_linked_hub_hostname(hub, hostname_type)
+        target_entry["name"] = new_hostname
+        target_entry["hostName"] = new_hostname
+
+    if authentication_type:
+        target_entry["authenticationType"] = authentication_type
+        if authentication_type == IotHubAuthenticationType.USER_ASSIGNED.value:
+            target_entry["selectedUserAssignedIdentityResourceId"] = user_assigned_identity
+        else:
+            target_entry.pop("selectedUserAssignedIdentityResourceId", None)
+        if authentication_type != IotHubAuthenticationType.KEY_BASED.value:
+            target_entry["connectionString"] = ""
+
+    target_auth = target_entry["authenticationType"]
+    cs_needs_rebuild = (
+        target_auth == IotHubAuthenticationType.KEY_BASED.value
+        and (authentication_type or new_hostname)
+    )
+    if cs_needs_rebuild:
+        if connection_string:
+            if ".service.azure-devices" in connection_string.lower():
+                raise InvalidArgumentValueError(
+                    "Service hostname is not supported for DPS hub linking. "
+                    "Use a connection string with device or classic hostname."
+                )
+            target_entry["connectionString"] = connection_string
+        else:
+            policies = iot_hub_policy_get(
+                hub_client, hub_name, IOT_HUB_DEFAULT_POLICY, _get_resource_group_from_hub(hub)
+            )
+            target_entry["connectionString"] = IOT_SERVICE_CS_TEMPLATE.format(
+                target_entry["hostName"], policies["keyName"], policies["primaryKey"]
+            )
+
+    if apply_allocation_policy is not None:
+        target_entry["applyAllocationPolicy"] = apply_allocation_policy
+    if allocation_weight is not None:
+        target_entry["allocationWeight"] = allocation_weight
+
+    _warn_mixed_endpoint_types(linked_hubs)
 
     if no_wait:
         return client.iot_dps_resource.begin_create_or_update(
-            resource_group_name=resource_group_name, provisioning_service_name=dps_name, iot_dps_description=dps
+            resource_group_name=resource_group_name,
+            provisioning_service_name=dps_name,
+            iot_dps_description=dps,
         )
     LongRunningOperation(cmd.cli_ctx)(
         client.iot_dps_resource.begin_create_or_update(
-            resource_group_name=resource_group_name, provisioning_service_name=dps_name, iot_dps_description=dps
+            resource_group_name=resource_group_name,
+            provisioning_service_name=dps_name,
+            iot_dps_description=dps,
         )
     )
-    return iot_dps_linked_hub_get(cmd, client, dps_name, linked_hub, resource_group_name)
+    return iot_dps_linked_hub_get(cmd, client, dps_name, target_entry["name"], resource_group_name)
 
 
 def iot_dps_linked_hub_delete(cmd, client, dps_name, linked_hub, resource_group_name=None, no_wait=False):

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
@@ -172,3 +172,60 @@ def test_linked_hub_list_shows_hostname(provisioned_iot_dps_no_hub_module):
             f"Should find linked hub with name '{device_hostname}'. Found: {[h['name'] for h in linked_hubs]}"
     finally:
         _cleanup_linked_hub(dps_name, dps_rg, device_hostname)
+
+
+def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module):
+    """Migrate a hub link from KeyBased + classic endpoint to
+    SystemAssigned + device endpoint in a single update call.
+    """
+    dps_name = provisioned_iot_dps_no_hub_module["name"]
+    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+
+    gwv2_hub = _find_gwv2_hub(dps_rg)
+    if not gwv2_hub:
+        pytest.skip("No GWv2 hub available in resource group")
+
+    hub_name = gwv2_hub["name"]
+    classic_hostname = gwv2_hub["properties"]["hostName"]
+    device_hostname = gwv2_hub["properties"]["deviceHostName"]
+
+    # Ensure DPS has SystemAssigned MI for the swap target
+    cli.invoke(f"iot dps identity assign --name {dps_name} -g {dps_rg} --system-assigned")
+
+    # Cleanup state for both possible end-state hostnames
+    cleanup_targets = [classic_hostname, device_hostname]
+
+    try:
+        # Initial state: link with KeyBased + classic
+        cli.invoke(
+            f"iot dps linked-hub create --dps-name {dps_name} -g {dps_rg} "
+            f"--hub-name {hub_name} --hostname-type classic"
+        )
+        initial = cli.invoke(
+            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
+        ).as_json()
+        assert any(
+            h["name"] == classic_hostname and h["authenticationType"] == "KeyBased"
+            for h in initial
+        ), f"Pre-condition failed; got: {[(h['name'], h['authenticationType']) for h in initial]}"
+
+        # Combined update: classic -> device endpoint + KeyBased -> SystemAssigned
+        cli.invoke(
+            f"iot dps linked-hub update --dps-name {dps_name} -g {dps_rg} "
+            f"--hub-name {hub_name} --hostname-type device "
+            f"--authentication-type SystemAssigned"
+        )
+
+        after = cli.invoke(
+            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
+        ).as_json()
+        matching = [h for h in after if h["name"] == device_hostname]
+        assert len(matching) == 1, (
+            f"Expected single entry at device hostname '{device_hostname}', "
+            f"got: {[h['name'] for h in after]}"
+        )
+        assert matching[0]["authenticationType"] == "SystemAssigned"
+        assert matching[0].get("connectionString", "") == ""
+    finally:
+        for hostname in cleanup_targets:
+            _cleanup_linked_hub(dps_name, dps_rg, hostname)

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -372,6 +372,15 @@ class TestLinkedHubUpdate:
         )
         assert existing_entries[0]["allocationWeight"] == 5
 
+    def test_no_mutation_params_errors(self, fixture_cmd, mock_deps):
+        """Identifier alone (no mutation flags) must error rather than issuing a no-op PUT
+        that could clobber concurrent changes."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(RequiredArgumentMissingError, match="at least one update parameter"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps", hub_name="myhub",
+            )
+
     def test_keybased_with_linked_hub_auto_fetches(self, fixture_cmd, mock_deps, existing_entries):
         """--linked-hub + --auth-type KeyBased (no CS) derives the hub short name to auto-fetch the key."""
         from azext_iot.core.custom import iot_dps_linked_hub_update

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -301,6 +301,27 @@ class TestLinkedHubUpdate:
                 hub_name="myhub", authentication_type="UserAssigned",
             )
 
+    def test_uami_alone_errors(self, fixture_cmd, mock_deps):
+        """--user-assigned-identity without --authentication-type UserAssigned must error,
+        not silently ignore the UAMI."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(MutuallyExclusiveArgumentError, match="--user-assigned-identity only applies"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub",
+                user_assigned_identity="/subscriptions/x/.../myuami",
+            )
+
+    def test_uami_with_keybased_errors(self, fixture_cmd, mock_deps):
+        """--user-assigned-identity + --authentication-type KeyBased is contradictory; must error."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(MutuallyExclusiveArgumentError, match="--user-assigned-identity only applies"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", authentication_type="KeyBased",
+                user_assigned_identity="/subscriptions/x/.../myuami",
+            )
+
     def test_mi_rejects_connection_string(self, fixture_cmd, mock_deps):
         from azext_iot.core.custom import iot_dps_linked_hub_update
         with pytest.raises(MutuallyExclusiveArgumentError, match="--connection-string cannot be used"):
@@ -309,6 +330,47 @@ class TestLinkedHubUpdate:
                 hub_name="myhub", authentication_type="SystemAssigned",
                 connection_string="HostName=x;SharedAccessKeyName=y;SharedAccessKey=z",
             )
+
+    def test_cs_on_existing_mi_link_errors(self, fixture_cmd, mock_deps, mocker):
+        """Providing --connection-string on an existing MI link without changing auth must error,
+        not silently no-op (Copilot review finding)."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        mi_entries = [{
+            "name": "myhub.device.azure-devices.net",
+            "hostName": "myhub.device.azure-devices.net",
+            "authenticationType": "SystemAssigned",
+            "connectionString": "",
+        }]
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value={
+            "identity": {"type": "SystemAssigned"},
+            "properties": {"iotHubs": mi_entries},
+        })
+        with pytest.raises(MutuallyExclusiveArgumentError, match="only applies to KeyBased"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub",
+                connection_string="HostName=myhub.device.azure-devices.net;SharedAccessKeyName=k;SharedAccessKey=v",
+            )
+
+    def test_cs_on_keybased_link_rotates_key(self, fixture_cmd, mock_deps, existing_entries):
+        """Providing --connection-string on an existing KeyBased link (without other changes)
+        must actually apply the CS — used for key rotation."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        new_cs = "HostName=myhub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=rotated-key"
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", connection_string=new_cs,
+        )
+        assert existing_entries[0]["connectionString"] == new_cs
+
+    def test_dotless_linked_hub_treated_as_hub_name(self, fixture_cmd, mock_deps, existing_entries):
+        """Backward compat: --linked-hub myhub (dotless) routes to the hub-name fuzzy match path."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            linked_hub="myhub", allocation_weight=5,
+        )
+        assert existing_entries[0]["allocationWeight"] == 5
 
     def test_keybased_with_linked_hub_auto_fetches(self, fixture_cmd, mock_deps, existing_entries):
         """--linked-hub + --auth-type KeyBased (no CS) derives the hub short name to auto-fetch the key."""

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -381,6 +381,29 @@ class TestLinkedHubUpdate:
                 cmd=fixture_cmd, client=mock_deps, dps_name="dps", hub_name="myhub",
             )
 
+    def test_hostname_swap_preserves_existing_policy(self, fixture_cmd, mock_deps, existing_entries, mocker):
+        """Hostname swap on KeyBased must re-fetch using the EXISTING policy (e.g., 'service'
+        for least-privilege setups) — must not silently downgrade to iothubowner."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        existing_entries[0]["connectionString"] = (
+            "HostName=myhub.azure-devices.net;"
+            "SharedAccessKeyName=service;SharedAccessKey=existing-key"
+        )
+        policy_spy = mocker.patch(
+            "azext_iot.core.custom.iot_hub_policy_get",
+            return_value={"keyName": "service", "primaryKey": "rotated-service-key"},
+        )
+
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", hostname_type="device",
+        )
+
+        assert policy_spy.call_args.args[2] == "service", (
+            f"Expected policy 'service' to be preserved, got {policy_spy.call_args.args[2]!r}"
+        )
+        assert "SharedAccessKeyName=service" in existing_entries[0]["connectionString"]
+
     def test_keybased_with_linked_hub_auto_fetches(self, fixture_cmd, mock_deps, existing_entries):
         """--linked-hub + --auth-type KeyBased (no CS) derives the hub short name to auto-fetch the key."""
         from azext_iot.core.custom import iot_dps_linked_hub_update

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -9,6 +9,7 @@ from azure.cli.core.azclierror import (
     InvalidArgumentValueError,
     MutuallyExclusiveArgumentError,
     RequiredArgumentMissingError,
+    ResourceNotFoundError,
 )
 from azext_iot.core.custom import _resolve_linked_hub_hostname, _warn_mixed_endpoint_types
 
@@ -169,3 +170,270 @@ class TestMixedEndpointWarning:
     def test_no_warning_empty(self, caplog):
         _warn_mixed_endpoint_types([])
         assert "mixed hostname types" not in caplog.text
+
+
+class TestFindLinkedHubEntry:
+    HUBS_GWV2 = [{"name": "myhub.device.azure-devices.net", "authenticationType": "SystemAssigned"}]
+    HUBS_CLASSIC = [{"name": "myhub.azure-devices.net", "authenticationType": "KeyBased"}]
+    HUBS_DUPLICATE = [
+        {"name": "myhub.device.azure-devices.net"},
+        {"name": "myhub.azure-devices.net"},
+        {"name": "other.azure-devices.net"},
+    ]
+
+    def test_hub_name_matches_gwv2_entry(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        result = _find_linked_hub_entry(self.HUBS_GWV2, hub_name="myhub")
+        assert result["name"] == "myhub.device.azure-devices.net"
+
+    def test_hub_name_matches_classic_entry(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        result = _find_linked_hub_entry(self.HUBS_CLASSIC, hub_name="myhub")
+        assert result["name"] == "myhub.azure-devices.net"
+
+    def test_hub_name_not_found(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        with pytest.raises(ResourceNotFoundError, match="No linked hub found"):
+            _find_linked_hub_entry(self.HUBS_GWV2, hub_name="missing")
+
+    def test_hub_name_duplicate_errors_with_hint(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        with pytest.raises(InvalidArgumentValueError, match="Multiple linked-hub entries"):
+            _find_linked_hub_entry(self.HUBS_DUPLICATE, hub_name="myhub")
+
+    def test_hub_name_prefix_does_not_overmatch(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        hubs = [{"name": "myhub2.azure-devices.net"}]
+        with pytest.raises(ResourceNotFoundError, match="No linked hub found"):
+            _find_linked_hub_entry(hubs, hub_name="myhub")
+
+    def test_linked_hub_exact_match(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        result = _find_linked_hub_entry(
+            self.HUBS_DUPLICATE, linked_hub="myhub.device.azure-devices.net")
+        assert result["name"] == "myhub.device.azure-devices.net"
+
+    def test_linked_hub_case_insensitive(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        result = _find_linked_hub_entry(
+            self.HUBS_GWV2, linked_hub="MYHUB.DEVICE.AZURE-DEVICES.NET")
+        assert result["name"] == "myhub.device.azure-devices.net"
+
+    def test_linked_hub_not_found(self):
+        from azext_iot.core.custom import _find_linked_hub_entry
+        with pytest.raises(ResourceNotFoundError, match="does not exist"):
+            _find_linked_hub_entry(self.HUBS_GWV2, linked_hub="ghost.azure-devices.net")
+
+
+class TestLinkedHubUpdate:
+    @pytest.fixture
+    def existing_entries(self):
+        return [
+            {
+                "name": "myhub.azure-devices.net",
+                "hostName": "myhub.azure-devices.net",
+                "authenticationType": "KeyBased",
+                "connectionString": (
+                    "HostName=myhub.azure-devices.net;"
+                    "SharedAccessKeyName=iothubowner;SharedAccessKey=existing-key"
+                ),
+                "location": "eastus2euap",
+                "allocationWeight": 1,
+                "applyAllocationPolicy": True,
+            }
+        ]
+
+    @pytest.fixture
+    def mock_deps(self, mocker, existing_entries):
+        mocker.patch("azext_iot.core.custom.iot_hub_service_factory")
+        mocker.patch("azext_iot.core.custom.iot_hub_get", return_value={
+            "name": "myhub",
+            "properties": {
+                "deviceHostName": "myhub.device.azure-devices.net",
+                "hostName": "myhub.azure-devices.net",
+            },
+            "location": "eastus2euap",
+            "resourcegroup": "test-rg",
+        })
+        mocker.patch("azext_iot.core.custom.iot_hub_policy_get", return_value={
+            "keyName": "iothubowner", "primaryKey": "fresh-key"
+        })
+        mocker.patch("azext_iot.core.custom._ensure_dps_resource_group_name", return_value="test-rg")
+        mock_dps = {
+            "identity": {"type": "SystemAssigned,UserAssigned"},
+            "properties": {"iotHubs": existing_entries},
+        }
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value=mock_dps)
+        mocker.patch("azext_iot.core.custom.LongRunningOperation")
+        mocker.patch("azext_iot.core.custom.iot_dps_linked_hub_get", side_effect=lambda *a, **kw: existing_entries[0])
+        mock_client = mocker.MagicMock()
+        mock_client.iot_dps_resource.begin_create_or_update.return_value = mocker.MagicMock()
+        return mock_client
+
+    def test_requires_identifier(self, fixture_cmd, mock_deps):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(RequiredArgumentMissingError, match="--hub-name"):
+            iot_dps_linked_hub_update(cmd=fixture_cmd, client=mock_deps, dps_name="dps")
+
+    def test_rejects_both_identifiers(self, fixture_cmd, mock_deps):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(MutuallyExclusiveArgumentError, match="not both"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", linked_hub="myhub.azure-devices.net",
+            )
+
+    def test_hostname_type_works_with_linked_hub(self, fixture_cmd, mock_deps, existing_entries):
+        """--linked-hub + --hostname-type derives the hub short name from the hostname."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            linked_hub="myhub.azure-devices.net", hostname_type="device",
+        )
+        assert existing_entries[0]["name"] == "myhub.device.azure-devices.net"
+        assert existing_entries[0]["hostName"] == "myhub.device.azure-devices.net"
+
+    def test_user_assigned_requires_identity(self, fixture_cmd, mock_deps):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(RequiredArgumentMissingError, match="--user-assigned-identity"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", authentication_type="UserAssigned",
+            )
+
+    def test_mi_rejects_connection_string(self, fixture_cmd, mock_deps):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(MutuallyExclusiveArgumentError, match="--connection-string cannot be used"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", authentication_type="SystemAssigned",
+                connection_string="HostName=x;SharedAccessKeyName=y;SharedAccessKey=z",
+            )
+
+    def test_keybased_with_linked_hub_auto_fetches(self, fixture_cmd, mock_deps, existing_entries):
+        """--linked-hub + --auth-type KeyBased (no CS) derives the hub short name to auto-fetch the key."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            linked_hub="myhub.azure-devices.net", authentication_type="KeyBased",
+        )
+        assert existing_entries[0]["authenticationType"] == "KeyBased"
+        assert "fresh-key" in existing_entries[0]["connectionString"]
+
+    def test_mi_not_enabled_errors(self, fixture_cmd, mock_deps, mocker):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value={
+            "identity": {"type": "None"},
+            "properties": {"iotHubs": [{
+                "name": "myhub.azure-devices.net",
+                "hostName": "myhub.azure-devices.net",
+                "authenticationType": "KeyBased",
+                "connectionString": "HostName=myhub.azure-devices.net;SharedAccessKeyName=k;SharedAccessKey=v",
+            }]},
+        })
+        with pytest.raises(InvalidArgumentValueError, match="System-assigned managed identity is not enabled"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", authentication_type="SystemAssigned",
+            )
+
+    def test_service_hostname_in_cs_rejected(self, fixture_cmd, mock_deps):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        with pytest.raises(InvalidArgumentValueError, match="Service hostname"):
+            iot_dps_linked_hub_update(
+                cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+                hub_name="myhub", authentication_type="KeyBased",
+                connection_string="HostName=myhub.service.azure-devices.net;SharedAccessKeyName=k;SharedAccessKey=v",
+            )
+
+    def test_allocation_only_preserves_auth_and_hostname(self, fixture_cmd, mock_deps, existing_entries):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", allocation_weight=5,
+        )
+        entry = existing_entries[0]
+        assert entry["allocationWeight"] == 5
+        assert entry["authenticationType"] == "KeyBased"
+        assert entry["name"] == "myhub.azure-devices.net"
+
+    def test_hostname_swap_only_refetches_key(self, fixture_cmd, mock_deps, existing_entries):
+        """Hostname-only swap on KeyBased: re-fetch key (GET masks the existing one)."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", hostname_type="device",
+        )
+        entry = existing_entries[0]
+        assert entry["name"] == "myhub.device.azure-devices.net"
+        assert entry["hostName"] == "myhub.device.azure-devices.net"
+        assert "HostName=myhub.device.azure-devices.net" in entry["connectionString"]
+        assert "fresh-key" in entry["connectionString"]
+        assert entry["authenticationType"] == "KeyBased"
+
+    def test_keybased_to_system_assigned(self, fixture_cmd, mock_deps, existing_entries):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", authentication_type="SystemAssigned",
+        )
+        entry = existing_entries[0]
+        assert entry["authenticationType"] == "SystemAssigned"
+        assert entry["connectionString"] == ""
+        assert "selectedUserAssignedIdentityResourceId" not in entry
+
+    def test_system_assigned_to_keybased_auto_fetches_key(self, fixture_cmd, mock_deps, mocker):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        mi_entries = [{
+            "name": "myhub.azure-devices.net",
+            "hostName": "myhub.azure-devices.net",
+            "authenticationType": "SystemAssigned",
+            "connectionString": "",
+        }]
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value={
+            "identity": {"type": "SystemAssigned,UserAssigned"},
+            "properties": {"iotHubs": mi_entries},
+        })
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", authentication_type="KeyBased",
+        )
+        entry = mi_entries[0]
+        assert entry["authenticationType"] == "KeyBased"
+        assert "fresh-key" in entry["connectionString"]
+        assert "myhub.azure-devices.net" in entry["connectionString"]
+
+    def test_uami_to_different_uami(self, fixture_cmd, mock_deps, mocker):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        uami_old = "/subscriptions/x/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/old"
+        uami_new = "/subscriptions/x/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/new"
+        ua_entries = [{
+            "name": "myhub.device.azure-devices.net",
+            "hostName": "myhub.device.azure-devices.net",
+            "authenticationType": "UserAssigned",
+            "selectedUserAssignedIdentityResourceId": uami_old,
+            "connectionString": "",
+        }]
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value={
+            "identity": {"type": "SystemAssigned,UserAssigned"},
+            "properties": {"iotHubs": ua_entries},
+        })
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", authentication_type="UserAssigned",
+            user_assigned_identity=uami_new,
+        )
+        assert ua_entries[0]["selectedUserAssignedIdentityResourceId"] == uami_new
+
+    def test_combined_keybased_classic_to_system_assigned_device(self, fixture_cmd, mock_deps, existing_entries):
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", hostname_type="device",
+            authentication_type="SystemAssigned",
+        )
+        entry = existing_entries[0]
+        assert entry["name"] == "myhub.device.azure-devices.net"
+        assert entry["hostName"] == "myhub.device.azure-devices.net"
+        assert entry["authenticationType"] == "SystemAssigned"
+        assert entry["connectionString"] == ""


### PR DESCRIPTION
## Description
Extends `az iot dps linked-hub update` to support switching an existing linked hub's TLS 1.3 endpoint and managed-identity authentication in a single call. Previously, the command only supported changing allocation policy/weight; customers wanting to swap endpoint or auth had to delete + re-create the link

### New Params
All new parameters are optional with "no-change" defaults - existing scripts that only change `--allocation-weight` /`--apply-allocation-policy` behave identically.

### Tests
I did comprehensive tests, here are some partial proof screenshots

Part A - validation / argparse errors
<img width="2053" height="411" alt="Screenshot 2026-05-28 215807" src="https://github.com/user-attachments/assets/39b313b1-c67a-4705-8d62-a9473bf927fd" />
<img width="2046" height="836" alt="Screenshot 2026-05-28 215925" src="https://github.com/user-attachments/assets/0a771b4c-b99d-40a6-a90e-9cbc92f9ffe8" />

Part B - Entry Lookup
<img width="2045" height="987" alt="Screenshot 2026-05-28 220539" src="https://github.com/user-attachments/assets/c0217364-24c2-466e-826e-379296a14437" />

Part C - permutations
<img width="1845" height="1116" alt="image" src="https://github.com/user-attachments/assets/2b8b4861-463c-42e4-bd26-58593f2c8c1f" />
