### PR TITLE
fix: set hostName when creating KeyBased linked hub

### DIFF
--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -488,6 +488,8 @@ def iot_dps_linked_hub_create(
                     "Service hostname is not supported for DPS hub linking. "
                     "Use a connection string with device or classic hostname."
                 )
+            parsed_cs = validate_key_value_pairs(connection_string)
+            host_name = parsed_cs.get("HostName")
             if not location:
                 if not hub_name:
                     try:
@@ -507,6 +509,7 @@ def iot_dps_linked_hub_create(
         linked_hub_entry = {
             "connectionString": connection_string,
             "location": location,
+            "hostName": host_name,
         }
 
     if apply_allocation_policy is not None:

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
@@ -229,3 +229,49 @@ def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module)
     finally:
         for hostname in cleanup_targets:
             _cleanup_linked_hub(dps_name, dps_rg, hostname)
+
+
+def test_linked_hub_create_keybased_then_switch_to_mi(provisioned_iot_dps_no_hub_module):
+    """KeyBased create -> auth-only SystemAssigned swap (no hostname change)."""
+    dps_name = provisioned_iot_dps_no_hub_module["name"]
+    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+
+    gwv2_hub = _find_gwv2_hub(dps_rg)
+    if not gwv2_hub:
+        pytest.skip("No GWv2 hub available in resource group")
+
+    hub_name = gwv2_hub["name"]
+    device_hostname = gwv2_hub["properties"]["deviceHostName"]
+
+    cli.invoke(f"iot dps identity assign --name {dps_name} -g {dps_rg} --system-assigned")
+
+    try:
+        cli.invoke(
+            f"iot dps linked-hub create --dps-name {dps_name} -g {dps_rg} "
+            f"--hub-name {hub_name}"
+        )
+        initial = cli.invoke(
+            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
+        ).as_json()
+        matching = [h for h in initial if h["name"] == device_hostname]
+        assert len(matching) == 1, \
+            f"Expected linked hub with name '{device_hostname}'. Got: {[h['name'] for h in initial]}"
+        assert matching[0]["authenticationType"] == "KeyBased"
+        assert matching[0].get("hostName") == device_hostname, \
+            f"hostName should be set on KeyBased create; got: {matching[0].get('hostName')!r}"
+
+        cli.invoke(
+            f"iot dps linked-hub update --dps-name {dps_name} -g {dps_rg} "
+            f"--hub-name {hub_name} --authentication-type SystemAssigned"
+        )
+
+        after = cli.invoke(
+            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
+        ).as_json()
+        matching = [h for h in after if h["name"] == device_hostname]
+        assert len(matching) == 1, \
+            f"Expected linked hub with name '{device_hostname}'. Got: {[h['name'] for h in after]}"
+        assert matching[0]["authenticationType"] == "SystemAssigned"
+        assert matching[0].get("connectionString", "") == ""
+    finally:
+        _cleanup_linked_hub(dps_name, dps_rg, device_hostname)


### PR DESCRIPTION
When a customer creates a KeyBased linked hub and then tries to switch it to managed identity in a single follow-up update, the update fails with: ERROR: (400309) hostName is required when connectionString is not provided.


Fix: parse `HostName` from the connection string and set it explicitly on the linked-hub entry. The MI branch in the same function already does this; this change makes the KeyBased branch consistent.