### PR TITLE
feat: add Microsoft Fabric Eventstream as routing endpoint

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,21 @@
 Release History
 ===============
 
+0.32.0b1 (Preview)
+++++++++++++++++++
+
+**IoT Hub updates**
+
+* IoT Hub management SDK regenerated to ``2026-05-01-preview``, which natively exposes the new ``eventStreams`` routing endpoint type.
+
+* Added Microsoft Fabric Eventstream as a routing endpoint type. The Fabric workspace, Eventstream item and Custom Endpoint source must be created in Fabric first; pass the source's ``sb://`` URI, entity path and the Fabric IDs into the new commands:
+
+  - ``az iot hub message-endpoint create fabric-eventstream`` registers the endpoint (identity-based authentication only; requires ``--endpoint-uri``, ``--entity-path``, ``--identity``, ``--workspace-id``, ``--eventstream-id`` and ``--source-id``).
+  - ``az iot hub message-endpoint update fabric-eventstream`` modifies an existing endpoint.
+  - ``az iot hub message-endpoint show --en <name>`` returns a ``fabric-eventstream`` endpoint by name (no type flag needed).
+  - ``az iot hub message-endpoint list`` includes ``fabric-eventstream`` endpoints in its output; pass ``--endpoint-type fabric-eventstream`` to filter to only this type.
+  - ``az iot hub message-endpoint delete`` removes ``fabric-eventstream`` endpoints by name (``--en``) or in bulk (``--endpoint-type fabric-eventstream``).
+
 0.31.0b2 (Preview)
 +++++++++++++++
 

--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -57,7 +57,10 @@ def _get_credential_scopes(cli_ctx):
 
 
 def _get_arm_endpoint(cli_ctx):
-    return cli_ctx.cloud.endpoints.resource_manager
+    """TODO: Revert to cli_ctx.cloud.endpoints.resource_manager once 2026-05-01-preview
+    is registered globally in ARM for all regions (ETA mid June 2026 per IoT Hub team).
+    PBI: https://msazure.visualstudio.com/One/_workitems/edit/38228149"""
+    return "https://centraluseuap.management.azure.com"
 
 
 def iot_hub_service_factory(cli_ctx, *_):

--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -58,8 +58,7 @@ def _get_credential_scopes(cli_ctx):
 
 def _get_arm_endpoint(cli_ctx):
     """TODO: Revert to cli_ctx.cloud.endpoints.resource_manager once 2026-05-01-preview
-    is registered globally in ARM for all regions (ETA mid June 2026 per IoT Hub team).
-    PBI: https://msazure.visualstudio.com/One/_workitems/edit/38228149"""
+    is registered globally in ARM for all regions (ETA mid June 2026 per IoT Hub team)."""
     return "https://centraluseuap.management.azure.com"
 
 

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.31.0b2"
+VERSION = "0.32.0b1"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/iothub/_help.py
+++ b/azext_iot/iothub/_help.py
@@ -781,6 +781,59 @@ def load_iothub_help():
           - name: Get all the endpoints of type "EventHub" from an IoT Hub.
             text: >
               az iot hub message-endpoint list -n {iothub_name} --endpoint-type eventhub
+          - name: Get all the endpoints of type "Fabric Eventstream" from an IoT Hub.
+            text: >
+              az iot hub message-endpoint list -n {iothub_name} --endpoint-type fabric-eventstream
+    """
+
+    helps[
+        "iot hub message-endpoint create fabric-eventstream"
+    ] = """
+        type: command
+        short-summary: Add a Microsoft Fabric Eventstream endpoint for an IoT Hub.
+        long-summary: |
+          The Fabric Custom Endpoint source (workspace, Eventstream item, and source) must be
+          created separately in Microsoft Fabric — via the Fabric portal or the `fab` CLI — before
+          running this command. Then take the source's connection details (sb:// endpoint URI,
+          entity path, and the workspace / eventstream / source GUIDs) and register them here.
+
+          This endpoint type supports identity-based authentication only. The hub must have a
+          managed identity assigned (system-assigned or user-assigned).
+
+        examples:
+          - name: Create a Fabric Eventstream endpoint using the hub's system-assigned identity.
+            text: >
+              az iot hub message-endpoint create fabric-eventstream -n {iothub_name}
+              --en {endpoint_name} --endpoint-uri {endpoint_uri} --entity-path {entity_path}
+              --identity [system] --workspace-id {workspace_id} --eventstream-id {eventstream_id}
+              --source-id {source_id}
+          - name: Create a Fabric Eventstream endpoint using a user-assigned identity.
+            text: >
+              az iot hub message-endpoint create fabric-eventstream -n {iothub_name}
+              --en {endpoint_name} --endpoint-uri {endpoint_uri} --entity-path {entity_path}
+              --identity {user_identity_resource_id} --workspace-id {workspace_id}
+              --eventstream-id {eventstream_id} --source-id {source_id}
+    """
+
+    helps[
+        "iot hub message-endpoint update fabric-eventstream"
+    ] = """
+        type: command
+        short-summary: Update a Microsoft Fabric Eventstream endpoint for an IoT Hub.
+        long-summary: |
+          This endpoint type supports identity-based authentication only. To change the
+          underlying Fabric Custom Endpoint source, update --endpoint-uri and --entity-path
+          together with values from the new source.
+        examples:
+          - name: Update a Fabric Eventstream endpoint to a different user-assigned identity.
+            text: >
+              az iot hub message-endpoint update fabric-eventstream -n {iothub_name}
+              --en {endpoint_name} --identity {user_identity_resource_id}
+          - name: Update a Fabric Eventstream endpoint's Fabric metadata (display values).
+            text: >
+              az iot hub message-endpoint update fabric-eventstream -n {iothub_name}
+              --en {endpoint_name} --workspace-id {workspace_id} --eventstream-id {eventstream_id}
+              --source-id {source_id}
     """
 
     helps[

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -99,6 +99,11 @@ def load_iothub_commands(self, _):
             "message_endpoint_create_storage_container",
             transform=EndpointUpdateResultTransform(self.cli_ctx)
         )
+        cmd_group.command(
+            "fabric-eventstream",
+            "message_endpoint_create_fabric_eventstream",
+            transform=EndpointUpdateResultTransform(self.cli_ctx)
+        )
 
     with self.command_group(
         "iot hub message-endpoint update",
@@ -128,6 +133,11 @@ def load_iothub_commands(self, _):
         cmd_group.command(
             "storage-container",
             "message_endpoint_update_storage_container",
+            transform=EndpointUpdateResultTransform(self.cli_ctx)
+        )
+        cmd_group.command(
+            "fabric-eventstream",
+            "message_endpoint_update_fabric_eventstream",
             transform=EndpointUpdateResultTransform(self.cli_ctx)
         )
 

--- a/azext_iot/iothub/commands_message_endpoint.py
+++ b/azext_iot/iothub/commands_message_endpoint.py
@@ -339,6 +339,60 @@ def message_endpoint_show(
     return message_endpoint_provider.show(endpoint_name=endpoint_name)
 
 
+def message_endpoint_create_fabric_eventstream(
+    cmd,
+    hub_name: str,
+    endpoint_name: str,
+    endpoint_uri: str,
+    entity_path: str,
+    identity: str,
+    workspace_id: str,
+    eventstream_id: str,
+    source_id: str,
+    resource_group_name: Optional[str] = None,
+):
+    message_endpoint_provider = MessageEndpoint(
+        cmd=cmd, hub_name=hub_name, rg=resource_group_name
+    )
+    return message_endpoint_provider.create(
+        endpoint_name=endpoint_name,
+        endpoint_type=EndpointType.FabricEventStream.value,
+        endpoint_uri=endpoint_uri,
+        entity_path=entity_path,
+        identity=identity,
+        workspace_id=workspace_id,
+        eventstream_id=eventstream_id,
+        source_id=source_id,
+    )
+
+
+def message_endpoint_update_fabric_eventstream(
+    cmd,
+    hub_name: str,
+    endpoint_name: str,
+    endpoint_uri: Optional[str] = None,
+    entity_path: Optional[str] = None,
+    identity: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    eventstream_id: Optional[str] = None,
+    source_id: Optional[str] = None,
+    resource_group_name: Optional[str] = None,
+):
+    message_endpoint_provider = MessageEndpoint(
+        cmd=cmd, hub_name=hub_name, rg=resource_group_name
+    )
+    return message_endpoint_provider.update(
+        endpoint_name=endpoint_name,
+        endpoint_type=EndpointType.FabricEventStream.value,
+        endpoint_uri=endpoint_uri,
+        entity_path=entity_path,
+        identity=identity,
+        workspace_id=workspace_id,
+        eventstream_id=eventstream_id,
+        source_id=source_id,
+    )
+
+
 def message_endpoint_list(
     cmd,
     hub_name: str,

--- a/azext_iot/iothub/common.py
+++ b/azext_iot/iothub/common.py
@@ -121,6 +121,7 @@ class EndpointType(Enum):
     ServiceBusTopic = "servicebus-topic"
     AzureStorageContainer = "storage-container"
     CosmosDBContainer = "cosmosdb-container"
+    FabricEventStream = "fabric-eventstream"
 
     @classmethod
     def list(cls):

--- a/azext_iot/iothub/params.py
+++ b/azext_iot/iothub/params.py
@@ -599,6 +599,46 @@ def load_iothub_arguments(self, _):
             "clear this property, set this to \"\""
         )
 
+    with self.argument_context("iot hub message-endpoint create fabric-eventstream") as context:
+        context.argument(
+            "workspace_id",
+            options_list=["--workspace-id", "--ws-id"],
+            help="The Fabric workspace Id. Required so the Azure Portal and Fabric Portal "
+            "can render this connection as a deep link to the specific Fabric workspace.",
+        )
+        context.argument(
+            "eventstream_id",
+            options_list=["--eventstream-id", "--es-id"],
+            help="The Fabric Eventstream Id. Required so the Azure Portal and Fabric Portal "
+            "can render this connection as a deep link to the specific Eventstream.",
+        )
+        context.argument(
+            "source_id",
+            options_list=["--source-id"],
+            help="The Fabric Custom Endpoint source Id. Required so the Azure Portal and Fabric "
+            "Portal can render this connection as a deep link to the specific source inside the Eventstream.",
+        )
+
+    with self.argument_context("iot hub message-endpoint update fabric-eventstream") as context:
+        context.argument(
+            "workspace_id",
+            options_list=["--workspace-id", "--ws-id"],
+            help="The Fabric workspace Id. Optional on update — only set if you want to overwrite "
+            "the existing value.",
+        )
+        context.argument(
+            "eventstream_id",
+            options_list=["--eventstream-id", "--es-id"],
+            help="The Fabric Eventstream Id. Optional on update — only set if you want to overwrite "
+            "the existing value.",
+        )
+        context.argument(
+            "source_id",
+            options_list=["--source-id"],
+            help="The Fabric Custom Endpoint source Id. Optional on update — only set if you want "
+            "to overwrite the existing value.",
+        )
+
     with self.argument_context("iot hub message-endpoint delete") as context:
         context.argument(
             "force",

--- a/azext_iot/iothub/providers/message_endpoint.py
+++ b/azext_iot/iothub/providers/message_endpoint.py
@@ -229,12 +229,7 @@ class MessageEndpoint(IoTHubProvider):
                 "maxChunkSizeInBytes": (chunk_size_window * BYTES_PER_MEGABYTE),
             })
             endpoints["storageContainers"].append(new_endpoint)
-        elif endpoint_type.lower() == EndpointType.FabricEventStream.value:
-            if connection_string:
-                raise MutuallyExclusiveArgumentError(
-                    "--connection-string is not supported for fabric-eventstream endpoints. "
-                    "Use --identity [system] or --identity <UAMI-resource-id>. "
-                )
+        elif endpoint_type == EndpointType.FabricEventStream.value:
             if not identity:
                 raise RequiredArgumentMissingError(
                     "--identity is required for fabric-eventstream endpoints. "
@@ -249,8 +244,7 @@ class MessageEndpoint(IoTHubProvider):
             if not workspace_id or not eventstream_id or not source_id:
                 raise RequiredArgumentMissingError(
                     "--workspace-id, --eventstream-id, and --source-id are all required for "
-                    "fabric-eventstream endpoints. Obtain these GUIDs from the Fabric Custom Endpoint "
-                    "source details so the Azure Portal and Fabric Portal can deep-link to the items."
+                    "fabric-eventstream endpoints. Obtain these from the Fabric Custom Endpoint."
                 )
             es_endpoint = {
                 "name": endpoint_name,
@@ -299,12 +293,6 @@ class MessageEndpoint(IoTHubProvider):
         # if nothing is provided -> should we block?
         # have the user say the type. Will make args easier (as in we do not need to check for unneeded args)
         original_endpoint = self._show_by_type(endpoint_name=endpoint_name, endpoint_type=endpoint_type)
-
-        if endpoint_type.lower() == EndpointType.FabricEventStream.value and connection_string:
-            raise MutuallyExclusiveArgumentError(
-                "--connection-string is not supported for fabric-eventstream endpoints. "
-                "Use --identity [system] or --identity <UAMI-resource-id>."
-            )
 
         if any([connection_string, primary_key, secondary_key]) and identity:
             cosmos_db = endpoint_type.lower() == EndpointType.CosmosDBContainer.value
@@ -393,12 +381,12 @@ class MessageEndpoint(IoTHubProvider):
         elif endpoint_type == EndpointType.FabricEventStream.value:
             if entity_path:
                 original_endpoint["entityPath"] = entity_path
-            if workspace_id is not None:
-                original_endpoint["workspaceId"] = workspace_id or None
-            if eventstream_id is not None:
-                original_endpoint["eventStreamId"] = eventstream_id or None
-            if source_id is not None:
-                original_endpoint["sourceId"] = source_id or None
+            if workspace_id:
+                original_endpoint["workspaceId"] = workspace_id
+            if eventstream_id:
+                original_endpoint["eventStreamId"] = eventstream_id
+            if source_id:
+                original_endpoint["sourceId"] = source_id
 
         return self.discovery.client.begin_create_or_update(
             self.hub_resource["resourcegroup"],

--- a/azext_iot/iothub/providers/message_endpoint.py
+++ b/azext_iot/iothub/providers/message_endpoint.py
@@ -44,6 +44,7 @@ class MessageEndpoint(IoTHubProvider):
         super(MessageEndpoint, self).__init__(cmd, hub_name, rg, dataplane=False)
         # Modelless SDK omits None/empty fields; ensure enrichments key exists.
         self.hub_resource["properties"]["routing"].setdefault("enrichments", [])
+        self.hub_resource["properties"]["routing"]["endpoints"].setdefault("eventStreams", [])
         # Temporary flag to check for which cosmos property to look for.
         self.support_cosmos = IoTHubSDKVersion.NoCosmos.value
         endpoints = self.hub_resource["properties"]["routing"]["endpoints"]
@@ -74,7 +75,10 @@ class MessageEndpoint(IoTHubProvider):
         secondary_key: Optional[str] = None,
         partition_key_name: Optional[str] = None,
         partition_key_template: Optional[str] = None,
-        identity: Optional[str] = None
+        identity: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        eventstream_id: Optional[str] = None,
+        source_id: Optional[str] = None,
     ):
         if not endpoint_resource_group:
             endpoint_resource_group = self.hub_resource["resourcegroup"]
@@ -225,6 +229,40 @@ class MessageEndpoint(IoTHubProvider):
                 "maxChunkSizeInBytes": (chunk_size_window * BYTES_PER_MEGABYTE),
             })
             endpoints["storageContainers"].append(new_endpoint)
+        elif endpoint_type.lower() == EndpointType.FabricEventStream.value:
+            if connection_string:
+                raise MutuallyExclusiveArgumentError(
+                    "--connection-string is not supported for fabric-eventstream endpoints. "
+                    "Use --identity [system] or --identity <UAMI-resource-id>. "
+                )
+            if not identity:
+                raise RequiredArgumentMissingError(
+                    "--identity is required for fabric-eventstream endpoints. "
+                    "Use --identity [system] for the hub's system-assigned identity, "
+                    "or pass a user-assigned identity resource ID."
+                )
+            if not endpoint_uri or not entity_path:
+                raise RequiredArgumentMissingError(
+                    "--endpoint-uri and --entity-path are both required for fabric-eventstream endpoints. "
+                    "Obtain these values from the Fabric Custom Endpoint source connection details."
+                )
+            if not workspace_id or not eventstream_id or not source_id:
+                raise RequiredArgumentMissingError(
+                    "--workspace-id, --eventstream-id, and --source-id are all required for "
+                    "fabric-eventstream endpoints. Obtain these GUIDs from the Fabric Custom Endpoint "
+                    "source details so the Azure Portal and Fabric Portal can deep-link to the items."
+                )
+            es_endpoint = {
+                "name": endpoint_name,
+                "endpointUri": endpoint_uri,
+                "entityPath": entity_path,
+                "authenticationType": AuthenticationType.IdentityBased.value,
+                "identity": endpoint_identity,
+                "workspaceId": workspace_id,
+                "eventStreamId": eventstream_id,
+                "sourceId": source_id,
+            }
+            endpoints["eventStreams"].append(es_endpoint)
 
         try:
             return self.discovery.client.begin_create_or_update(
@@ -253,11 +291,20 @@ class MessageEndpoint(IoTHubProvider):
         secondary_key: Optional[str] = None,
         partition_key_name: Optional[str] = None,
         partition_key_template: Optional[str] = None,
-        identity: Optional[str] = None
+        identity: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        eventstream_id: Optional[str] = None,
+        source_id: Optional[str] = None,
     ):
         # if nothing is provided -> should we block?
         # have the user say the type. Will make args easier (as in we do not need to check for unneeded args)
         original_endpoint = self._show_by_type(endpoint_name=endpoint_name, endpoint_type=endpoint_type)
+
+        if endpoint_type.lower() == EndpointType.FabricEventStream.value and connection_string:
+            raise MutuallyExclusiveArgumentError(
+                "--connection-string is not supported for fabric-eventstream endpoints. "
+                "Use --identity [system] or --identity <UAMI-resource-id>."
+            )
 
         if any([connection_string, primary_key, secondary_key]) and identity:
             cosmos_db = endpoint_type.lower() == EndpointType.CosmosDBContainer.value
@@ -343,6 +390,15 @@ class MessageEndpoint(IoTHubProvider):
                 original_endpoint["partitionKeyName"] = None if partition_key_name == "" else partition_key_name
             if partition_key_template:
                 original_endpoint["partitionKeyTemplate"] = None if partition_key_template == "" else partition_key_template
+        elif endpoint_type == EndpointType.FabricEventStream.value:
+            if entity_path:
+                original_endpoint["entityPath"] = entity_path
+            if workspace_id is not None:
+                original_endpoint["workspaceId"] = workspace_id or None
+            if eventstream_id is not None:
+                original_endpoint["eventStreamId"] = eventstream_id or None
+            if source_id is not None:
+                original_endpoint["sourceId"] = source_id or None
 
         return self.discovery.client.begin_create_or_update(
             self.hub_resource["resourcegroup"],
@@ -391,6 +447,8 @@ class MessageEndpoint(IoTHubProvider):
                 endpoint_list.extend(endpoints["cosmosDBSqlContainers"])
             elif self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
                 endpoint_list.extend(endpoints["cosmosDBSqlCollections"])
+        if endpoint_type is None or endpoint_type.lower() == EndpointType.FabricEventStream.value:
+            endpoint_list.extend(endpoints["eventStreams"])
 
         for endpoint in endpoint_list:
             if endpoint["name"].lower() == endpoint_name.lower():
@@ -426,6 +484,8 @@ class MessageEndpoint(IoTHubProvider):
             raise InvalidArgumentValueError(INVALID_CLI_CORE_FOR_COSMOS)
         elif EndpointType.AzureStorageContainer.value == endpoint_type:
             return endpoints["storageContainers"]
+        elif EndpointType.FabricEventStream.value == endpoint_type:
+            return endpoints["eventStreams"]
 
     def delete(
         self,
@@ -465,6 +525,8 @@ class MessageEndpoint(IoTHubProvider):
                         endpoint_names.extend([e["name"] for e in endpoints["cosmosDBSqlCollections"]])
                 if not endpoint_type or endpoint_type == EndpointType.AzureStorageContainer.value:
                     endpoint_names.extend([e["name"] for e in endpoints["storageContainers"]])
+                if not endpoint_type or endpoint_type == EndpointType.FabricEventStream.value:
+                    endpoint_names.extend([e["name"] for e in endpoints["eventStreams"]])
 
             # only do the routing and enrichment checks if there are endpoints to check.
             if force and endpoint_names:
@@ -522,6 +584,8 @@ class MessageEndpoint(IoTHubProvider):
                     ]
             if not endpoint_type or EndpointType.AzureStorageContainer.value == endpoint_type:
                 endpoints["storageContainers"] = [e for e in endpoints["storageContainers"] if e["name"].lower() != endpoint_name]
+            if not endpoint_type or EndpointType.FabricEventStream.value == endpoint_type:
+                endpoints["eventStreams"] = [e for e in endpoints["eventStreams"] if e["name"].lower() != endpoint_name]
         elif endpoint_type:
             # Delete all endpoints in type
             if EndpointType.EventHub.value == endpoint_type:
@@ -537,6 +601,8 @@ class MessageEndpoint(IoTHubProvider):
                     endpoints["cosmosDBSqlCollections"] = []
             elif EndpointType.AzureStorageContainer.value == endpoint_type:
                 endpoints["storageContainers"] = []
+            elif EndpointType.FabricEventStream.value == endpoint_type:
+                endpoints["eventStreams"] = []
         else:
             # Delete all endpoints
             endpoints["eventHubs"] = []
@@ -547,6 +613,7 @@ class MessageEndpoint(IoTHubProvider):
             if self.support_cosmos == IoTHubSDKVersion.CosmosCollections.value:
                 endpoints["cosmosDBSqlCollections"] = []
             endpoints["storageContainers"] = []
+            endpoints["eventStreams"] = []
 
         try:
             return self.discovery.client.begin_create_or_update(

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
@@ -1081,7 +1081,6 @@ class TestMessageEndpointUpdate:
 
 
 class TestFabricEventStreamCreate:
-    # Use a UAMI-shaped string (looks like an ARM resource id) for the user-assigned-identity case.
     uami_id = "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uami1"
 
     @pytest.mark.parametrize(
@@ -1108,7 +1107,6 @@ class TestFabricEventStreamCreate:
         assert result == generic_response
 
     def test_create_fabric_eventstream_minimum_args(self, fixture_cmd, fixture_update_endpoint_ops):
-        # All required args present (now includes the 3 Fabric IDs).
         result = subject.message_endpoint_create_fabric_eventstream(
             cmd=fixture_cmd,
             hub_name=hub_name,
@@ -1209,8 +1207,6 @@ class TestFabricEventStreamCreate:
     def test_create_fabric_eventstream_works_on_hub_without_eventstreams_key(
         self, fixture_cmd, fixture_update_endpoint_backwards_comp_ops
     ):
-        # Defensive: MessageEndpoint.__init__ setdefault should fill in eventStreams=[]
-        # even on hubs that have never had this endpoint type configured.
         result = subject.message_endpoint_create_fabric_eventstream(
             cmd=fixture_cmd,
             hub_name=hub_name,
@@ -1227,7 +1223,6 @@ class TestFabricEventStreamCreate:
 
 class TestFabricEventStreamUpdate:
     def test_update_fabric_eventstream_happy_path(self, fixture_cmd, fixture_update_endpoint_ops):
-        # The fixture seeds an eventStreams entry with the shared endpoint_name.
         result = subject.message_endpoint_update_fabric_eventstream(
             cmd=fixture_cmd,
             hub_name=hub_name,
@@ -1253,37 +1248,7 @@ class TestFabricEventStreamUpdate:
         )
         assert result == generic_response
 
-    def test_update_fabric_eventstream_rejects_connection_string(self, fixture_cmd, fixture_update_endpoint_ops):
-        # The wrapper does not expose --connection-string for fabric-eventstream, but verify
-        # the provider's defensive mutex check rejects it if reached directly.
-        from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
-        from azext_iot.iothub.common import EndpointType
-        provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
-        with pytest.raises(MutuallyExclusiveArgumentError):
-            provider.update(
-                endpoint_name=endpoint_name,
-                endpoint_type=EndpointType.FabricEventStream.value,
-                connection_string="dummy",
-            )
-
-    def test_create_fabric_eventstream_rejects_connection_string(self, fixture_cmd, fixture_update_endpoint_ops):
-        # Same defensive check on the provider create() side.
-        from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
-        from azext_iot.iothub.common import EndpointType
-        provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
-        with pytest.raises(MutuallyExclusiveArgumentError):
-            provider.create(
-                endpoint_name="es-" + generate_names(),
-                endpoint_type=EndpointType.FabricEventStream.value,
-                endpoint_uri="sb://test-ns.servicebus.windows.net",
-                entity_path="entity",
-                identity="[system]",
-                connection_string="dummy",
-            )
-
     def test_create_fabric_eventstream_provider_requires_fabric_ids(self, fixture_cmd, fixture_update_endpoint_ops):
-        # Defense-in-depth: even if a direct provider caller bypasses the wrapper,
-        # provider.create() must reject missing Fabric IDs.
         from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
         from azext_iot.iothub.common import EndpointType
         provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
@@ -1334,32 +1299,3 @@ class TestFabricEventStreamShowListDelete:
             resource_group_name=hub_rg,
         )
         assert isinstance(result, list)
-
-    def test_show_fabric_eventstream(self, fixture_cmd, fixture_update_endpoint_ops):
-        # The fixture seeds an eventStreams entry with the shared endpoint_name.
-        result = subject.message_endpoint_show(
-            cmd=fixture_cmd,
-            hub_name=hub_name,
-            endpoint_name=endpoint_name,
-            resource_group_name=hub_rg,
-        )
-        assert result is not None
-
-    def test_delete_fabric_eventstream_by_name(self, fixture_cmd, fixture_update_endpoint_ops):
-        result = subject.message_endpoint_delete(
-            cmd=fixture_cmd,
-            hub_name=hub_name,
-            endpoint_name=endpoint_name,
-            resource_group_name=hub_rg,
-        )
-        assert result == generic_response
-
-    def test_delete_all_fabric_eventstreams_by_type(self, fixture_cmd, fixture_update_endpoint_ops):
-        from azext_iot.iothub.common import EndpointType
-        result = subject.message_endpoint_delete(
-            cmd=fixture_cmd,
-            hub_name=hub_name,
-            endpoint_type=EndpointType.FabricEventStream.value,
-            resource_group_name=hub_rg,
-        )
-        assert result == generic_response

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 import azext_iot.iothub.commands_message_endpoint as subject
 from azure.cli.core.azclierror import (
     MutuallyExclusiveArgumentError,
+    RequiredArgumentMissingError,
     ResourceNotFoundError
 )
 from azext_iot.iothub.common import BYTES_PER_MEGABYTE, AuthenticationType
@@ -58,6 +59,7 @@ def fixture_update_endpoint_ops(mocker):
                     "serviceBusTopics": [create_mock_endpoint()],
                     "storageContainers": [create_mock_endpoint()],
                     "cosmosDBSqlContainers": [create_mock_endpoint()],
+                    "eventStreams": [defaultdict(lambda: None, name=endpoint_name, authenticationType="identityBased")],
                 },
                 "routes": [],
                 "enrichments": [],
@@ -1076,3 +1078,285 @@ class TestMessageEndpointUpdate:
                 assert endpoint["endpointUri"] == "get_cosmos_db_account_endpoint"
         else:
             assert endpoint["authenticationType"] == "keyBased"
+
+
+class TestFabricEventStreamCreate:
+    # Use a UAMI-shaped string (looks like an ARM resource id) for the user-assigned-identity case.
+    uami_id = "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uami1"
+
+    @pytest.mark.parametrize(
+        "identity",
+        [
+            "[system]",
+            uami_id,
+        ]
+    )
+    def test_create_fabric_eventstream_happy_path(self, fixture_cmd, fixture_update_endpoint_ops, identity):
+        es_endpoint_name = "es-" + generate_names()
+        result = subject.message_endpoint_create_fabric_eventstream(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name=es_endpoint_name,
+            endpoint_uri="sb://test-ns.servicebus.windows.net",
+            entity_path="es-entity",
+            identity=identity,
+            workspace_id="ws-id-1",
+            eventstream_id="es-id-1",
+            source_id="src-id-1",
+            resource_group_name=hub_rg,
+        )
+        assert result == generic_response
+
+    def test_create_fabric_eventstream_minimum_args(self, fixture_cmd, fixture_update_endpoint_ops):
+        # All required args present (now includes the 3 Fabric IDs).
+        result = subject.message_endpoint_create_fabric_eventstream(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name="es-" + generate_names(),
+            endpoint_uri="sb://test-ns.servicebus.windows.net",
+            entity_path="es-entity",
+            identity="[system]",
+            workspace_id="ws-id-1",
+            eventstream_id="es-id-1",
+            source_id="src-id-1",
+        )
+        assert result == generic_response
+
+    def test_create_fabric_eventstream_missing_workspace_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(TypeError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="es-entity",
+                identity="[system]",
+                eventstream_id="es-id-1",
+                source_id="src-id-1",
+            )
+
+    def test_create_fabric_eventstream_missing_eventstream_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(TypeError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="es-entity",
+                identity="[system]",
+                workspace_id="ws-id-1",
+                source_id="src-id-1",
+            )
+
+    def test_create_fabric_eventstream_missing_source_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(TypeError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="es-entity",
+                identity="[system]",
+                workspace_id="ws-id-1",
+                eventstream_id="es-id-1",
+            )
+
+    def test_create_fabric_eventstream_missing_identity_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(RequiredArgumentMissingError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="es-entity",
+                identity=None,
+                workspace_id="ws-id-1",
+                eventstream_id="es-id-1",
+                source_id="src-id-1",
+            )
+
+    def test_create_fabric_eventstream_missing_endpoint_uri_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(RequiredArgumentMissingError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri=None,
+                entity_path="es-entity",
+                identity="[system]",
+                workspace_id="ws-id-1",
+                eventstream_id="es-id-1",
+                source_id="src-id-1",
+            )
+
+    def test_create_fabric_eventstream_missing_entity_path_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(RequiredArgumentMissingError):
+            subject.message_endpoint_create_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="es-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path=None,
+                identity="[system]",
+                workspace_id="ws-id-1",
+                eventstream_id="es-id-1",
+                source_id="src-id-1",
+            )
+
+    def test_create_fabric_eventstream_works_on_hub_without_eventstreams_key(
+        self, fixture_cmd, fixture_update_endpoint_backwards_comp_ops
+    ):
+        # Defensive: MessageEndpoint.__init__ setdefault should fill in eventStreams=[]
+        # even on hubs that have never had this endpoint type configured.
+        result = subject.message_endpoint_create_fabric_eventstream(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name="es-" + generate_names(),
+            endpoint_uri="sb://test-ns.servicebus.windows.net",
+            entity_path="es-entity",
+            identity="[system]",
+            workspace_id="ws-id-1",
+            eventstream_id="es-id-1",
+            source_id="src-id-1",
+        )
+        assert result == generic_response
+
+
+class TestFabricEventStreamUpdate:
+    def test_update_fabric_eventstream_happy_path(self, fixture_cmd, fixture_update_endpoint_ops):
+        # The fixture seeds an eventStreams entry with the shared endpoint_name.
+        result = subject.message_endpoint_update_fabric_eventstream(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name=endpoint_name,
+            endpoint_uri="sb://new-ns.servicebus.windows.net",
+            entity_path="new-entity",
+            identity="[system]",
+            workspace_id="updated-ws-id",
+            eventstream_id="updated-es-id",
+            source_id="updated-src-id",
+            resource_group_name=hub_rg,
+        )
+        assert result == generic_response
+
+    def test_update_fabric_eventstream_identity_only(self, fixture_cmd, fixture_update_endpoint_ops):
+        # Should be allowed to swap from SAMI to UAMI without touching URI/entity-path.
+        uami = TestFabricEventStreamCreate.uami_id
+        result = subject.message_endpoint_update_fabric_eventstream(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name=endpoint_name,
+            identity=uami,
+        )
+        assert result == generic_response
+
+    def test_update_fabric_eventstream_rejects_connection_string(self, fixture_cmd, fixture_update_endpoint_ops):
+        # The wrapper does not expose --connection-string for fabric-eventstream, but verify
+        # the provider's defensive mutex check rejects it if reached directly.
+        from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
+        from azext_iot.iothub.common import EndpointType
+        provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
+        with pytest.raises(MutuallyExclusiveArgumentError):
+            provider.update(
+                endpoint_name=endpoint_name,
+                endpoint_type=EndpointType.FabricEventStream.value,
+                connection_string="dummy",
+            )
+
+    def test_create_fabric_eventstream_rejects_connection_string(self, fixture_cmd, fixture_update_endpoint_ops):
+        # Same defensive check on the provider create() side.
+        from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
+        from azext_iot.iothub.common import EndpointType
+        provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
+        with pytest.raises(MutuallyExclusiveArgumentError):
+            provider.create(
+                endpoint_name="es-" + generate_names(),
+                endpoint_type=EndpointType.FabricEventStream.value,
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="entity",
+                identity="[system]",
+                connection_string="dummy",
+            )
+
+    def test_create_fabric_eventstream_provider_requires_fabric_ids(self, fixture_cmd, fixture_update_endpoint_ops):
+        # Defense-in-depth: even if a direct provider caller bypasses the wrapper,
+        # provider.create() must reject missing Fabric IDs.
+        from azext_iot.iothub.providers.message_endpoint import MessageEndpoint
+        from azext_iot.iothub.common import EndpointType
+        provider = MessageEndpoint(cmd=fixture_cmd, hub_name=hub_name, rg=hub_rg)
+        for missing in ("workspace_id", "eventstream_id", "source_id"):
+            kwargs = {
+                "endpoint_name": "es-" + generate_names(),
+                "endpoint_type": EndpointType.FabricEventStream.value,
+                "endpoint_uri": "sb://test-ns.servicebus.windows.net",
+                "entity_path": "entity",
+                "identity": "[system]",
+                "workspace_id": "ws-id",
+                "eventstream_id": "es-id",
+                "source_id": "src-id",
+            }
+            kwargs[missing] = None
+            with pytest.raises(RequiredArgumentMissingError):
+                provider.create(**kwargs)
+
+    def test_update_fabric_eventstream_nonexistent_errors(self, fixture_cmd, fixture_update_endpoint_ops):
+        with pytest.raises(ResourceNotFoundError):
+            subject.message_endpoint_update_fabric_eventstream(
+                cmd=fixture_cmd,
+                hub_name=hub_name,
+                endpoint_name="nonexistent-" + generate_names(),
+                endpoint_uri="sb://test-ns.servicebus.windows.net",
+                entity_path="entity",
+                identity="[system]",
+            )
+
+
+class TestFabricEventStreamShowListDelete:
+    def test_list_includes_fabric_eventstream(self, fixture_cmd, fixture_update_endpoint_ops):
+        # Default list (no type filter) returns the endpoints dict, which now includes eventStreams.
+        result = subject.message_endpoint_list(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            resource_group_name=hub_rg,
+        )
+        assert "eventStreams" in result
+        assert len(result["eventStreams"]) >= 1
+
+    def test_list_by_type_fabric_eventstream(self, fixture_cmd, fixture_update_endpoint_ops):
+        from azext_iot.iothub.common import EndpointType
+        result = subject.message_endpoint_list(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_type=EndpointType.FabricEventStream.value,
+            resource_group_name=hub_rg,
+        )
+        assert isinstance(result, list)
+
+    def test_show_fabric_eventstream(self, fixture_cmd, fixture_update_endpoint_ops):
+        # The fixture seeds an eventStreams entry with the shared endpoint_name.
+        result = subject.message_endpoint_show(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name=endpoint_name,
+            resource_group_name=hub_rg,
+        )
+        assert result is not None
+
+    def test_delete_fabric_eventstream_by_name(self, fixture_cmd, fixture_update_endpoint_ops):
+        result = subject.message_endpoint_delete(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_name=endpoint_name,
+            resource_group_name=hub_rg,
+        )
+        assert result == generic_response
+
+    def test_delete_all_fabric_eventstreams_by_type(self, fixture_cmd, fixture_update_endpoint_ops):
+        from azext_iot.iothub.common import EndpointType
+        result = subject.message_endpoint_delete(
+            cmd=fixture_cmd,
+            hub_name=hub_name,
+            endpoint_type=EndpointType.FabricEventStream.value,
+            resource_group_name=hub_rg,
+        )
+        assert result == generic_response

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_unit.py
@@ -1123,7 +1123,7 @@ class TestFabricEventStreamCreate:
         assert result == generic_response
 
     def test_create_fabric_eventstream_missing_workspace_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
-        with pytest.raises(TypeError):
+        with pytest.raises(RequiredArgumentMissingError):
             subject.message_endpoint_create_fabric_eventstream(
                 cmd=fixture_cmd,
                 hub_name=hub_name,
@@ -1131,12 +1131,13 @@ class TestFabricEventStreamCreate:
                 endpoint_uri="sb://test-ns.servicebus.windows.net",
                 entity_path="es-entity",
                 identity="[system]",
+                workspace_id=None,
                 eventstream_id="es-id-1",
                 source_id="src-id-1",
             )
 
     def test_create_fabric_eventstream_missing_eventstream_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
-        with pytest.raises(TypeError):
+        with pytest.raises(RequiredArgumentMissingError):
             subject.message_endpoint_create_fabric_eventstream(
                 cmd=fixture_cmd,
                 hub_name=hub_name,
@@ -1145,11 +1146,12 @@ class TestFabricEventStreamCreate:
                 entity_path="es-entity",
                 identity="[system]",
                 workspace_id="ws-id-1",
+                eventstream_id=None,
                 source_id="src-id-1",
             )
 
     def test_create_fabric_eventstream_missing_source_id_errors(self, fixture_cmd, fixture_update_endpoint_ops):
-        with pytest.raises(TypeError):
+        with pytest.raises(RequiredArgumentMissingError):
             subject.message_endpoint_create_fabric_eventstream(
                 cmd=fixture_cmd,
                 hub_name=hub_name,
@@ -1159,6 +1161,7 @@ class TestFabricEventStreamCreate:
                 identity="[system]",
                 workspace_id="ws-id-1",
                 eventstream_id="es-id-1",
+                source_id=None,
             )
 
     def test_create_fabric_eventstream_missing_identity_errors(self, fixture_cmd, fixture_update_endpoint_ops):

--- a/azext_iot/tests/test_factory_unit.py
+++ b/azext_iot/tests/test_factory_unit.py
@@ -48,7 +48,8 @@ class TestFactoryCredentialScopes:
         mock_client_cls.assert_called_once()
         call_kwargs = mock_client_cls.call_args.kwargs
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
-        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
+        # TODO: Revert to cloud_config["resource_manager"] once 2026-05-01-preview is global
+        assert call_kwargs["endpoint"] == "https://centraluseuap.management.azure.com"
 
     def test_dps_factory(self, mocker, cloud_config):
         mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")
@@ -63,7 +64,8 @@ class TestFactoryCredentialScopes:
         mock_client_cls.assert_called_once()
         call_kwargs = mock_client_cls.call_args.kwargs
         assert call_kwargs["credential_scopes"] == cloud_config["expected_scopes"]
-        assert call_kwargs["endpoint"] == cloud_config["resource_manager"]
+        # TODO: Revert to cloud_config["resource_manager"] once 2026-05-01-preview is global
+        assert call_kwargs["endpoint"] == "https://centraluseuap.management.azure.com"
 
     def test_adr_factory(self, mocker, cloud_config):
         mocker.patch("azext_iot._factory.AZURE_CLI_CREDENTIAL")


### PR DESCRIPTION
# Changes
 - New commands: `az iot hub message-endpoint create/update fabric-eventstream` (identity-based auth only; required Fabric workspace/eventstream/source IDs let the Azure Portal and Fabric Portal deep-link to the items)
 - Existing `show`/`list`/`delete` recognize the new type (filter via `--endpoint-type fabric-eventstream` on `list` and `delete`)
 - New unit tests covering happy and required-argument-validation paths
 - HISTORY.rst updated under 0.32.0b1
 
 # Notes
 End-to-end testing is currently flaky on the Fabric backend. Known workarounds:
 - UAMI must be in the same Azure region as the Fabric workspace
 - SAMI is accepted by the CLI but doesn't work end-to-end today because the hub's SAMI inherits the hub's region (often different from Fabric)
 - Fabric workspace/Eventstream sensitivity label must be set to **General**
 
 Bug bash instructions will be published once the service team ships a fix.
 
 
 ## E2E examples
 `az iot device send-d2c-message -n "$HUB" -d "$DEVICE_ID" \
    --data "example-data" \
    --properties "test=e2e-610"`

Fabric side receives message flow

<img width="1741" height="1150" alt="image" src="https://github.com/user-attachments/assets/310635cf-8f05-4cef-95a8-fdd63570def9" />
