### PR TITLE
test: Integration Test Fixes

### DIFF
--- a/.github/workflows/int_test_schedule.yml
+++ b/.github/workflows/int_test_schedule.yml
@@ -3,9 +3,11 @@ run-name: "Dispatch integration tests → ${{ github.event_name == 'schedule' &&
 
 on:
     schedule:
-        # preview: once per day on weekdays; dev: once per week on Saturday.
-        - cron: "17 8 * * 1-5" # Weekdays 12:17 AM PT (08:17 UTC) → preview
-        - cron: "17 8 * * 6" # Saturday 12:17 AM PT (08:17 UTC) → dev
+        # Same schedule every day (weekday or weekend): two runs per day.
+        # Each run takes at most ~2h30m, so the two slots are spaced 4h apart and
+        # both fall in off-hours (PT). DST shifts these ~1h; exact times are not critical.
+        - cron: "17 8 * * *" # ~00:17 AM PT nightly (08:17 UTC) → preview
+        - cron: "17 12 * * *" # ~04:17 AM PT early morning (12:17 UTC) → dev
     workflow_dispatch:
 
 permissions:
@@ -24,10 +26,11 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Determine target branch based on day of week
-                  # Weekdays (Mon-Fri) → preview, Saturday → dev
-                  day_of_week=$(date -u +"%u")  # 1=Mon ... 6=Sat, 7=Sun
-                  if [ "$day_of_week" = "6" ]; then
+                  # Determine target branch based on which scheduled slot triggered the run.
+                  # Nightly slot (08:17 UTC) → preview; early-morning slot (12:17 UTC) → dev.
+                  # Manual (workflow_dispatch) runs have no schedule and default to preview.
+                  schedule="${{ github.event.schedule }}"
+                  if [ "$schedule" = "17 12 * * *" ]; then
                     branch="dev"
                   else
                     branch="preview"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Release History
 
 **Bug fixes**
 
+* ``az iot edge devices create`` now writes the device-facing hostname (``deviceHostName``) into the generated ``config.toml`` on GWv2/TLS 1.3 hubs, so edge devices can connect. Classic hubs are unaffected.
+
+* ``az iot device simulate`` and ``az iot device send-d2c-message`` now connect over MQTT using the device-facing hostname on GWv2/TLS 1.3 hubs, fixing "not authorised" failures for x509 and symmetric-key devices. Classic hubs are unaffected.
+
 * ``az iot du account create`` no longer fails with ``TypeError: unhashable type: 'dict'`` when assigning a single user-assigned managed identity via ``--assign-identity``.
 
 * ``az iot hub device-identity connection-string show`` and ``az iot hub module-identity connection-string show`` now reject ``--hostname-type service``. Use ``auto``, ``device`` or ``classic`` instead.

--- a/azext_iot/deviceupdate/providers/storage.py
+++ b/azext_iot/deviceupdate/providers/storage.py
@@ -37,4 +37,4 @@ class StorageAccountManager(object):
         storage_keys = self.client.storage_accounts.list_keys(
             resource_group_name=storage_rg, account_name=account.name)
         return BlobServiceClient(
-            account_url=account.primary_endpoints.blob, credential=storage_keys.keys[0].value)
+            account_url=account.primary_endpoints.blob, credential=storage_keys["keys"][0]["value"])

--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -315,7 +315,7 @@ class DeviceIdentityProvider(IoTHubProvider):
                 # edge device config
                 create_edge_device_config(
                     device_id=device_id,
-                    hub_hostname=self.target["entity"],
+                    hub_hostname=self.target.get("deviceHostName") or self.target["entity"],
                     auth_method=config.auth_method,
                     default_edge_agent=config.default_edge_agent,
                     device_config=device_config_dict[device_id],

--- a/azext_iot/iothub/providers/device_messaging.py
+++ b/azext_iot/iothub/providers/device_messaging.py
@@ -53,6 +53,13 @@ class DeviceMessagingProvider(IoTHubProvider):
         self.device_resolver = SdkResolver(target=self.target, device_id=device_id)
         self.device_sdk = self.device_resolver.get_sdk(SdkType.device_sdk)
 
+    @property
+    def _device_hostname(self) -> str:
+        # Device-facing MQTT connect must target the device hostname. On GWv2 hubs
+        # target['entity'] is the SERVICE hostname, which rejects device credentials
+        # ("not authorised"); deviceHostName is the correct device-facing endpoint.
+        return self.target.get("deviceHostName") or self.target["entity"]
+
     def device_send_message(
         self,
         data: str = "Ping from Az CLI IoT Extension",
@@ -76,9 +83,11 @@ class DeviceMessagingProvider(IoTHubProvider):
         if properties:
             properties = validate_key_value_pairs(properties)
 
-        device_connection_string = _build_device_or_module_connection_string(device, KeyType.primary.value)
+        device_connection_string = _build_device_or_module_connection_string(
+            device, KeyType.primary.value, hostname_override=self._device_hostname
+        )
         client_mqtt = MQTTProvider(
-            hub_hostname=self.target["entity"],
+            hub_hostname=self._device_hostname,
             device_conn_string=device_connection_string,
             x509_files=device["authentication"].get("x509_files"),
             device_id=self.device_id,
@@ -399,10 +408,12 @@ class DeviceMessagingProvider(IoTHubProvider):
                 passphrase=passphrase
             )
             if protocol_type == ProtocolType.mqtt.name:
-                device_connection_string = _build_device_or_module_connection_string(device, KeyType.primary.value)
+                device_connection_string = _build_device_or_module_connection_string(
+                    device, KeyType.primary.value, hostname_override=self._device_hostname
+                )
 
                 client_mqtt = MQTTProvider(
-                    hub_hostname=self.target["entity"],
+                    hub_hostname=self._device_hostname,
                     device_conn_string=device_connection_string,
                     x509_files=device["authentication"].get("x509_files"),
                     device_id=self.device_id,

--- a/azext_iot/tests/core/test_core_registration_unit.py
+++ b/azext_iot/tests/core/test_core_registration_unit.py
@@ -51,33 +51,33 @@ def test_patch_core_help_with_existing_keys():
 
 
 def test_policy_update_result_transform(mocker):
-    transform = PolicyUpdateResultTransform.__new__(PolicyUpdateResultTransform)
+    transform = PolicyUpdateResultTransform(MagicMock())
     result = {"properties": {"authorizationPolicies": ["p"]}}
     mocker.patch(f"{cm_path}.LongRunningOperation.__call__", return_value=result)
     assert transform("poller") == ["p"]
 
 
 def test_endpoint_update_result_transform(mocker):
-    transform = EndpointUpdateResultTransform.__new__(EndpointUpdateResultTransform)
+    transform = EndpointUpdateResultTransform(MagicMock())
     result = {"properties": {"routing": {"endpoints": ["e"]}}}
     mocker.patch(f"{cm_path}.LongRunningOperation.__call__", return_value=result)
     assert transform("poller") == ["e"]
 
 
 def test_route_update_result_transform(mocker):
-    transform = RouteUpdateResultTransform.__new__(RouteUpdateResultTransform)
+    transform = RouteUpdateResultTransform(MagicMock())
     result = {"properties": {"routing": {"routes": ["r"]}}}
     mocker.patch(f"{cm_path}.LongRunningOperation.__call__", return_value=result)
     assert transform("poller") == ["r"]
 
 
 def test_hub_delete_result_transform_no_poller():
-    transform = HubDeleteResultTransform.__new__(HubDeleteResultTransform)
+    transform = HubDeleteResultTransform(MagicMock())
     assert transform(None) is None
 
 
 def test_hub_delete_result_transform_not_found_suppressed(mocker):
-    transform = HubDeleteResultTransform.__new__(HubDeleteResultTransform)
+    transform = HubDeleteResultTransform(MagicMock())
     mocker.patch(
         f"{cm_path}.LongRunningOperation.__call__",
         side_effect=CLIError("resource not found"),
@@ -87,7 +87,7 @@ def test_hub_delete_result_transform_not_found_suppressed(mocker):
 
 
 def test_hub_delete_result_transform_other_error_raised(mocker):
-    transform = HubDeleteResultTransform.__new__(HubDeleteResultTransform)
+    transform = HubDeleteResultTransform(MagicMock())
     mocker.patch(
         f"{cm_path}.LongRunningOperation.__call__",
         side_effect=CLIError("something else"),

--- a/azext_iot/tests/deviceupdate/test_adu_storage_unit.py
+++ b/azext_iot/tests/deviceupdate/test_adu_storage_unit.py
@@ -49,7 +49,8 @@ def test_get_sas_blob_service_client(mocker):
     acc.id = "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/target"
     acc.primary_endpoints.blob = "https://target.blob.core.windows.net/"
     mgr.client.storage_accounts.list.return_value = [acc]
-    mgr.client.storage_accounts.list_keys.return_value.keys = [MagicMock(value="key123")]
+    # list_keys returns a dict at runtime, so the provider indexes it as ["keys"][0]["value"].
+    mgr.client.storage_accounts.list_keys.return_value = {"keys": [{"value": "key123"}]}
     mocker.patch.object(subject, "parse_resource_id", return_value={"resource_group": "rg"})
     bsc = mocker.patch.object(subject, "BlobServiceClient")
     result = mgr.get_sas_blob_service_client("target")

--- a/azext_iot/tests/dps/__init__.py
+++ b/azext_iot/tests/dps/__init__.py
@@ -34,23 +34,3 @@ TEST_ENDORSEMENT_KEY = (
 )
 TEST_KEY_REGISTRATION_ID = "myarbitrarydeviceId"
 GENERATED_KEY = "cT/EXZvsplPEpT//p98Pc6sKh8mY3kYgSxavHwMkl7w="
-
-
-def clean_dps_dataplane(cli, dps_cstring):
-    # Individual Enrollments
-    enrollment_list = cli.invoke(
-        f"iot dps enrollment list --login {dps_cstring}"
-    ).as_json()
-    for enrollment in enrollment_list:
-        cli.invoke(
-            f"iot dps enrollment delete --login {dps_cstring} --eid {enrollment['registrationId']}"
-        )
-
-    # Enrollment Groups
-    enrollment_list = cli.invoke(
-        f"iot dps enrollment-group list --login {dps_cstring}"
-    ).as_json()
-    for enrollment in enrollment_list:
-        cli.invoke(
-            f"iot dps enrollment-group delete --login {dps_cstring} --eid {enrollment['enrollmentGroupId']}"
-        )

--- a/azext_iot/tests/dps/conftest.py
+++ b/azext_iot/tests/dps/conftest.py
@@ -63,7 +63,6 @@ DPS_GC_THRESHOLD_SECONDS = 24 * 60 * 60
 _LOCAL_RUN_UID = uuid.uuid4().hex
 
 
-
 def generate_hub_id() -> str:
     return f"aziotclitest-hub-{generate_generic_id()}"[:35]
 

--- a/azext_iot/tests/dps/conftest.py
+++ b/azext_iot/tests/dps/conftest.py
@@ -4,12 +4,17 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from time import sleep
-from typing import Dict, Optional
+from datetime import datetime, timezone
+from time import sleep, time
+from typing import Dict, Iterator, Optional
+import json
 import os
+import tempfile
+import uuid
 
 import pytest
 from azure.cli.core.azclierror import CLIInternalError
+from filelock import FileLock
 from knack.log import get_logger
 
 from azext_iot.common.embedded_cli import EmbeddedCLI
@@ -36,6 +41,28 @@ ENTITY_RG = settings.env.azext_iot_testrg
 ENTITY_LOCATION = "westus"
 MAX_RBAC_ASSIGNMENT_TRIES = settings.env.azext_iot_rbac_max_tries if settings.env.azext_iot_rbac_max_tries else 10
 
+# DPS instance strategy (timestamp + run-tag + age-based GC)
+# ----------------------------------------------------------
+# A subscription is limited to 10 DPS instances, the subscription is shared with the team, and
+# several integration runs may execute concurrently. To stay within quota and never accumulate
+# orphans we:
+#   * Name each instance with a UTC timestamp + a per-run token + a kind suffix so concurrent runs
+#     never collide (DPS names also map to globally-unique DNS).
+#   * Tag each instance (intTest/runUid/kind/createdEpoch) so it can be discovered and garbage
+#     collected reliably without fragile name parsing.
+#   * Share a single instance per kind across all xdist workers of the same run (ref-counted), so a
+#     run only ever holds 2 instances (hub + no-hub) regardless of "-n".
+#   * Delete our own instances at teardown once the last worker is done, and additionally GC any
+#     stale int-test instance older than ``DPS_GC_THRESHOLD_SECONDS`` (left behind by crashed runs).
+INT_TEST_DPS_PREFIX = "aziotcli-int-dps"
+INT_TEST_HUB_PREFIX = "aziotcli-int-hub"
+DPS_GC_THRESHOLD_SECONDS = 24 * 60 * 60
+
+# Unique per process; identifies a run when not executing under pytest-xdist. Under xdist all workers
+# of the same run share ``workerinput["testrunuid"]`` instead.
+_LOCAL_RUN_UID = uuid.uuid4().hex
+
+
 
 def generate_hub_id() -> str:
     return f"aziotclitest-hub-{generate_generic_id()}"[:35]
@@ -59,75 +86,228 @@ def assign_iot_dps_dataplane_rbac_role(target_dps):
 
 
 # IoT DPS fixtures
-@pytest.fixture(scope="module")
-def provisioned_iot_dps_module(provisioned_only_iot_hubs_session) -> dict:
-    result = _iot_dps_provisioner(provisioned_only_iot_hubs_session)
+@pytest.fixture(scope="session")
+def provisioned_iot_dps_module(request, provisioned_only_iot_hubs_session) -> Iterator[dict]:
+    result = _iot_dps_provisioner(request, provisioned_only_iot_hubs_session)
     yield result
     if result:
         _iot_dps_removal(result)
 
 
-@pytest.fixture(scope="module")
-def provisioned_iot_dps_no_hub_module() -> dict:
-    result = _iot_dps_provisioner()
+@pytest.fixture(scope="session")
+def provisioned_iot_dps_no_hub_module(request) -> Iterator[dict]:
+    result = _iot_dps_provisioner(request)
     yield result
     if result:
         _iot_dps_removal(result)
 
 
-def _iot_dps_provisioner(iot_hub: Optional[Dict] = None) -> dict:
-    """Create a device provisioning service for testing purposes."""
-    dps_name = settings.env.azext_iot_testdps or generate_dps_id()
+def _get_run_uid(request) -> str:
+    """Return an id that is identical for every worker of the same test run.
 
-    dps_list = cli.invoke(
-        'iot dps list -g "{}"'.format(ENTITY_RG)
-    ).as_json()
+    Under pytest-xdist all workers receive the same ``testrunuid``; outside of xdist we fall back
+    to a per-process uuid so each fresh invocation is treated as its own run.
+    """
+    workerinput = getattr(request.config, "workerinput", None)
+    if workerinput and workerinput.get("testrunuid"):
+        return workerinput["testrunuid"]
+    return _LOCAL_RUN_UID
 
-    # Check if the generated name is already used
-    target_dps = None
-    for dps in dps_list:
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+# --- Cross-worker shared-resource coordination -------------------------------------------------
+# A single instance per kind is shared by every xdist worker of the same run. State is a small JSON
+# file (``{"name", "refcount"}``) guarded by a file lock so only the first worker creates the
+# resource and the last worker out deletes it. ``kind`` is one of "h" (hub-linked DPS), "nh"
+# (no-hub DPS) or "hub" (the shared IoT Hub).
+def _state_paths(run_uid: str, kind: str):
+    base = os.path.join(tempfile.gettempdir(), f"{INT_TEST_DPS_PREFIX}-{run_uid}-{kind}")
+    return base + ".lock", base + ".json"
+
+
+def _read_state(state_path: str) -> Optional[Dict]:
+    try:
+        with open(state_path) as state_file:
+            return json.load(state_file)
+    except (OSError, ValueError):
+        return None
+
+
+def _write_state(state_path: str, state: Dict) -> None:
+    with open(state_path, "w") as state_file:
+        json.dump(state, state_file)
+
+
+def _safe_remove(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _shared_acquire(run_uid: str, kind: str, create_fn, find_fn) -> dict:
+    """Create or reuse the shared resource for ``kind``, bumping its reference count."""
+    lock_path, state_path = _state_paths(run_uid, kind)
+    with FileLock(lock_path):
+        state = _read_state(state_path)
+        if state:
+            resource = find_fn(state["name"])
+            if resource:
+                state["refcount"] += 1
+                _write_state(state_path, state)
+                return resource
+        name, resource = create_fn(run_uid, kind)
+        _write_state(state_path, {"name": name, "refcount": 1})
+        return resource
+
+
+def _shared_release(run_uid: str, kind: str, delete_fn) -> None:
+    """Drop one reference to the shared resource for ``kind``; the last worker deletes it."""
+    lock_path, state_path = _state_paths(run_uid, kind)
+    with FileLock(lock_path):
+        state = _read_state(state_path)
+        if not state:
+            return
+        state["refcount"] -= 1
+        if state["refcount"] <= 0:
+            delete_fn(state["name"])
+            _safe_remove(state_path)
+        else:
+            _write_state(state_path, state)
+
+
+# --- Age-based garbage collection of orphans (from crashed runs) -------------------------------
+def _gc_stale_resources_once(run_uid: str) -> None:
+    """Reap int-test resources older than the threshold, exactly once per run."""
+    gc_lock = os.path.join(tempfile.gettempdir(), f"{INT_TEST_DPS_PREFIX}-gc.lock")
+    gc_marker = os.path.join(tempfile.gettempdir(), f"{INT_TEST_DPS_PREFIX}-gc-{run_uid}.done")
+    with FileLock(gc_lock):
+        if os.path.exists(gc_marker):
+            return
+        try:
+            _gc_stale(run_uid, INT_TEST_DPS_PREFIX, _list_dps, _delete_dps)
+            _gc_stale(run_uid, INT_TEST_HUB_PREFIX, _list_hubs, _delete_hub)
+        finally:
+            with open(gc_marker, "w"):
+                pass
+
+
+def _gc_stale(current_run_uid: str, prefix: str, list_fn, delete_fn) -> None:
+    now = time()
+    for resource in list_fn():
+        name = resource.get("name", "")
+        if not name.startswith(prefix):
+            continue
+        tags = resource.get("tags") or {}
+        # Only reap resources we positively recognise as expired int-test artifacts. Anything
+        # missing the marker tags or an unparseable timestamp is left untouched (defensive against
+        # deleting manually-created or in-use resources).
+        if tags.get("intTest") != "true" or tags.get("runUid") == current_run_uid:
+            continue
+        try:
+            age = now - int(tags.get("createdEpoch"))
+        except (TypeError, ValueError):
+            continue
+        if age > DPS_GC_THRESHOLD_SECONDS:
+            logger.info(f"Garbage-collecting stale int-test resource '{name}' (age {int(age)}s).")
+            delete_fn(name)
+
+
+# --- DPS helpers -------------------------------------------------------------------------------
+def _list_dps() -> list:
+    return cli.invoke('iot dps list -g "{}"'.format(ENTITY_RG)).as_json() or []
+
+
+def _find_dps_by_name(dps_name: str) -> Optional[dict]:
+    for dps in _list_dps():
         if dps["name"] == dps_name:
-            target_dps = dps
-            break
+            return dps
+    return None
 
-    # Create the min version dps and assign the correct roles
-    if not target_dps:
-        if settings.env.azext_iot_testdps:
-            logger.error(f"DPS {dps_name} specified in pytest settings not found. DPS will be created")
 
-        base_command = f"iot dps create --name {dps_name} --resource-group {ENTITY_RG} --location {ENTITY_LOCATION}"
-        if iot_hub:
-            base_command += f" --tags hubname={iot_hub['name']}"
-        target_dps = cli.invoke(base_command).as_json()
+def _delete_dps(dps_name: str) -> None:
+    cli.invoke(f"iot dps delete --name {dps_name} --resource-group {ENTITY_RG}")
 
-    assign_iot_dps_dataplane_rbac_role(target_dps)
 
-    # Add link between dps and first iot hub
-    hub_host_name = None
+def _link_hub(dps_name: str, iot_hub: Dict) -> str:
+    linked_hubs = cli.invoke(
+        "iot dps linked-hub list --dps-name {} -g {}".format(dps_name, ENTITY_RG)
+    ).as_json()
+    hub_host_name = "{}.azure-devices.net".format(iot_hub["name"])
+    if hub_host_name not in [hub["name"] for hub in linked_hubs]:
+        cli.invoke(
+            f"iot dps linked-hub create --dps-name {dps_name} -g {ENTITY_RG} "
+            f"--connection-string {iot_hub['connectionString']}"
+        )
+    return hub_host_name
+
+
+def _unlink_all_hubs(dps_name: str) -> None:
+    linked_hubs = cli.invoke(
+        "iot dps linked-hub list --dps-name {} -g {}".format(dps_name, ENTITY_RG)
+    ).as_json()
+    for hub in linked_hubs:
+        cli.invoke(
+            f"iot dps linked-hub delete --dps-name {dps_name} -g {ENTITY_RG} --linked-hub {hub['name']}"
+        )
+
+
+def _create_managed_dps(run_uid: str, kind: str, iot_hub: Optional[Dict]) -> tuple:
+    """Create a tagged, run-scoped DPS and perform one-time RBAC + hub linking (creator only)."""
+    name = f"{INT_TEST_DPS_PREFIX}-{_timestamp()}-{run_uid[:8]}-{kind}"
+    tags = f"intTest=true runUid={run_uid} kind={kind} createdEpoch={int(time())}"
     if iot_hub:
-        target_hub = iot_hub
-        linked_hubs = cli.invoke(
-            "iot dps linked-hub list --dps-name {} -g {}".format(dps_name, ENTITY_RG)
-        ).as_json()
-        hub_host_name = "{}.azure-devices.net".format(target_hub["name"])
-
-        if hub_host_name not in [hub["name"] for hub in linked_hubs]:
-            cli.invoke(
-                f"iot dps linked-hub create --dps-name {dps_name} -g {ENTITY_RG} "
-                f"--connection-string {target_hub['connectionString']}"
-            )
-    elif settings.env.azext_iot_testdps:
-        # Ensure 0 linked hubs
-        linked_hubs = cli.invoke(
-            "iot dps linked-hub list --dps-name {} -g {}".format(dps_name, ENTITY_RG)
-        ).as_json()
-        for hub in linked_hubs:
-            cli.invoke(
-                f"iot dps linked-hub delete --dps-name {dps_name} -g {ENTITY_RG} --linked-hub {hub['name']}"
-            )
+        tags += f" hubname={iot_hub['name']}"
+    target_dps = cli.invoke(
+        f"iot dps create --name {name} --resource-group {ENTITY_RG} "
+        f"--location {ENTITY_LOCATION} --tags {tags}"
+    ).as_json()
+    assign_iot_dps_dataplane_rbac_role(target_dps)
+    if iot_hub:
+        _link_hub(name, iot_hub)
     else:
-        # time passed if hub was not linked
+        _unlink_all_hubs(name)
+        # Allow data-plane RBAC propagation to settle on the fresh instance.
         sleep(60)
+    return name, target_dps
+
+
+def _create_unmanaged_dps(dps_name: str, iot_hub: Optional[Dict]) -> dict:
+    base_command = f"iot dps create --name {dps_name} --resource-group {ENTITY_RG} --location {ENTITY_LOCATION}"
+    if iot_hub:
+        base_command += f" --tags hubname={iot_hub['name']}"
+    return cli.invoke(base_command).as_json()
+
+
+def _iot_dps_provisioner(request, iot_hub: Optional[Dict] = None) -> dict:
+    """Create or reuse a device provisioning service for testing purposes."""
+    use_managed = not settings.env.azext_iot_testdps
+    kind = "h" if iot_hub else "nh"
+    run_uid = _get_run_uid(request)
+
+    if use_managed:
+        _gc_stale_resources_once(run_uid)
+        target_dps = _shared_acquire(
+            run_uid,
+            kind,
+            create_fn=lambda ru, k: _create_managed_dps(ru, k, iot_hub),
+            find_fn=_find_dps_by_name,
+        )
+        dps_name = target_dps["name"]
+        hub_host_name = "{}.azure-devices.net".format(iot_hub["name"]) if iot_hub else None
+    else:
+        dps_name = settings.env.azext_iot_testdps
+        target_dps = _find_dps_by_name(dps_name)
+        if not target_dps:
+            logger.error(f"DPS {dps_name} specified in pytest settings not found. DPS will be created")
+            target_dps = _create_unmanaged_dps(dps_name, iot_hub)
+        assign_iot_dps_dataplane_rbac_role(target_dps)
+        hub_host_name = _link_hub(dps_name, iot_hub) if iot_hub else None
+        if not iot_hub:
+            _unlink_all_hubs(dps_name)
 
     return {
         "name": dps_name,
@@ -136,7 +316,9 @@ def _iot_dps_provisioner(iot_hub: Optional[Dict] = None) -> dict:
         "connectionString": get_dps_cstring(dps_name, ENTITY_RG),
         "hubHostName": hub_host_name,
         "hubConnectionString": iot_hub["connectionString"] if iot_hub else None,
-        "certificates": []
+        "certificates": [],
+        "_runUid": run_uid if use_managed else None,
+        "_kind": kind if use_managed else None,
     }
 
 
@@ -155,50 +337,71 @@ def _iot_dps_removal(dps):
                 os.remove(cert)
             except OSError as e:
                 logger.error(f"Failed to remove {cert}. {e}")
-    if not settings.env.azext_iot_testdps:
-        cli.invoke(
-            "iot dps delete --name {} --resource-group {}".format(
-                dps["name"], dps["resourceGroup"]
-            )
-        )
+    # Release this run's shared DPS; the last worker out deletes it. An env-pinned DPS
+    # (azext_iot_testdps) carries no run id and is intentionally left in place. Any instance that
+    # escapes deletion (e.g. crashed worker) is reaped by the age-based GC on a subsequent run.
+    run_uid = dps.get("_runUid")
+    kind = dps.get("_kind")
+    if run_uid and kind:
+        _shared_release(run_uid, kind, delete_fn=_delete_dps)
 
 
 # IoT Hub fixtures for DPS
 @pytest.fixture(scope="session")
-def provisioned_only_iot_hubs_session() -> dict:
-    result = _iot_hubs_provisioner()
+def provisioned_only_iot_hubs_session(request) -> Iterator[dict]:
+    result = _iot_hubs_provisioner(request)
     yield result
     if result:
         _iot_hubs_removal(result)
 
 
-def _iot_hubs_provisioner():
-    """Note that this will create min iot hub for a dps test."""
-    name = settings.env.azext_iot_testdps_hub or generate_hub_id()
-    hub_list = cli.invoke(
-        'iot hub list -g "{}"'.format(ENTITY_RG)
-    ).as_json()
+def _list_hubs() -> list:
+    return cli.invoke('iot hub list -g "{}"'.format(ENTITY_RG)).as_json() or []
 
-    # Check if the generated name is already used
-    target_hub = None
-    for hub in hub_list:
+
+def _find_hub_by_name(name: str) -> Optional[dict]:
+    for hub in _list_hubs():
         if hub["name"] == name:
-            target_hub = hub
-            break
+            return hub
+    return None
 
-    # Create the min version dps and assign the correct roles
-    if not target_hub:
-        if settings.env.azext_iot_testdps_hub:
-            logger.error(f"Hub {name} specified in pytest settings not found. DPS will be created")
 
-        base_create_command = f"iot hub create -n {name} -g {ENTITY_RG} --sku S1"
-        target_hub = cli.invoke(base_create_command).as_json()
+def _create_managed_hub(run_uid: str, kind: str) -> tuple:
+    name = f"{INT_TEST_HUB_PREFIX}-{_timestamp()}-{run_uid[:8]}"
+    target_hub = cli.invoke(
+        f"iot hub create -n {name} -g {ENTITY_RG} --sku S1 "
+        f"--tags intTest=true runUid={run_uid} kind=hub createdEpoch={int(time())}"
+    ).as_json()
+    return name, target_hub
+
+
+def _delete_hub(name: str) -> None:
+    if not cli.invoke(f"iot hub delete -n {name} -g {ENTITY_RG}").success():
+        logger.error(f"Failed to delete iot hub resource {name}.")
+
+
+def _iot_hubs_provisioner(request):
+    """Provision (or reuse) a single IoT Hub shared by all workers of the run for DPS tests."""
+    if settings.env.azext_iot_testdps_hub:
+        name = settings.env.azext_iot_testdps_hub
+        target_hub = _find_hub_by_name(name)
+        if not target_hub:
+            logger.error(f"Hub {name} specified in pytest settings not found. Hub will be created")
+            target_hub = cli.invoke(f"iot hub create -n {name} -g {ENTITY_RG} --sku S1").as_json()
+        run_uid = None
+    else:
+        run_uid = _get_run_uid(request)
+        target_hub = _shared_acquire(
+            run_uid, "hub", create_fn=_create_managed_hub, find_fn=_find_hub_by_name
+        )
+        name = target_hub["name"]
 
     return {
         "hub": target_hub,
         "name": name,
         "rg": ENTITY_RG,
         "connectionString": _get_hub_connection_string(name, ENTITY_RG),
+        "_runUid": run_uid,
     }
 
 
@@ -211,8 +414,8 @@ def _get_hub_connection_string(name, rg, policy="iothubowner"):
 
 
 def _iot_hubs_removal(hub_result):
-    if not settings.env.azext_iot_testdps_hub:
-        name = hub_result["name"]
-        delete_result = cli.invoke(f"iot hub delete -n {name} -g {ENTITY_RG}")
-        if not delete_result.success():
-            logger.error(f"Failed to delete iot hub resource {name}.")
+    # Release this run's shared hub; the last worker out deletes it. An env-pinned hub
+    # (azext_iot_testdps_hub) carries no run id and is intentionally left in place.
+    run_uid = hub_result.get("_runUid")
+    if run_uid:
+        _shared_release(run_uid, "hub", delete_fn=_delete_hub)

--- a/azext_iot/tests/dps/conftest.py
+++ b/azext_iot/tests/dps/conftest.py
@@ -231,11 +231,26 @@ def _delete_dps(dps_name: str) -> None:
     cli.invoke(f"iot dps delete --name {dps_name} --resource-group {ENTITY_RG}")
 
 
+def _hub_link_host_name(iot_hub: Dict) -> str:
+    """Return the hub hostname the way DPS actually links it.
+
+    DPS links the hub from its connection string and records the linked hub by the
+    connection string's ``HostName``. On GWv2/TLS 1.3 hubs that is the device-facing
+    hostname (``<name>.device.azure-devices.net``) rather than the classic
+    ``<name>.azure-devices.net``. Enrollment ``--iot-hubs`` and the registration
+    ``assignedHub`` must use this same value, so derive it from the connection string.
+    """
+    for segment in iot_hub["connectionString"].split(";"):
+        if segment.lower().startswith("hostname="):
+            return segment.split("=", 1)[1]
+    return "{}.azure-devices.net".format(iot_hub["name"])
+
+
 def _link_hub(dps_name: str, iot_hub: Dict) -> str:
     linked_hubs = cli.invoke(
         "iot dps linked-hub list --dps-name {} -g {}".format(dps_name, ENTITY_RG)
     ).as_json()
-    hub_host_name = "{}.azure-devices.net".format(iot_hub["name"])
+    hub_host_name = _hub_link_host_name(iot_hub)
     if hub_host_name not in [hub["name"] for hub in linked_hubs]:
         cli.invoke(
             f"iot dps linked-hub create --dps-name {dps_name} -g {ENTITY_RG} "
@@ -296,7 +311,7 @@ def _iot_dps_provisioner(request, iot_hub: Optional[Dict] = None) -> dict:
             find_fn=_find_dps_by_name,
         )
         dps_name = target_dps["name"]
-        hub_host_name = "{}.azure-devices.net".format(iot_hub["name"]) if iot_hub else None
+        hub_host_name = _hub_link_host_name(iot_hub) if iot_hub else None
     else:
         dps_name = settings.env.azext_iot_testdps
         target_dps = _find_dps_by_name(dps_name)

--- a/azext_iot/tests/dps/conftest.py
+++ b/azext_iot/tests/dps/conftest.py
@@ -129,14 +129,14 @@ def _state_paths(run_uid: str, kind: str):
 
 def _read_state(state_path: str) -> Optional[Dict]:
     try:
-        with open(state_path) as state_file:
+        with open(state_path, encoding="utf-8") as state_file:
             return json.load(state_file)
     except (OSError, ValueError):
         return None
 
 
 def _write_state(state_path: str, state: Dict) -> None:
-    with open(state_path, "w") as state_file:
+    with open(state_path, "w", encoding="utf-8") as state_file:
         json.dump(state, state_file)
 
 
@@ -190,7 +190,7 @@ def _gc_stale_resources_once(run_uid: str) -> None:
             _gc_stale(run_uid, INT_TEST_DPS_PREFIX, _list_dps, _delete_dps)
             _gc_stale(run_uid, INT_TEST_HUB_PREFIX, _list_hubs, _delete_hub)
         finally:
-            with open(gc_marker, "w"):
+            with open(gc_marker, "w", encoding="utf-8"):
                 pass
 
 

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
@@ -19,13 +19,12 @@ from azext_iot.common.embedded_cli import EmbeddedCLI
 cli = EmbeddedCLI()
 
 
-def _find_gwv2_hub(rg):
-    """Find a GWv2 hub in the RG"""
-    hubs = cli.invoke(f"iot hub list -g {rg}").as_json()
-    for hub in hubs:
-        if hub.get("properties", {}).get("deviceHostName"):
-            return hub
-    return None
+def _require_gwv2_hub(provisioned_hub):
+    """Return the provisioned hub resource, skipping if it is not a GWv2 (TLS 1.3) hub."""
+    hub = cli.invoke(f"iot hub show -n {provisioned_hub['name']}").as_json()
+    if not hub.get("properties", {}).get("deviceHostName"):
+        pytest.skip("Provisioned hub is not GWv2 — TLS 1.3 linked-hub tests require a GWv2 hub")
+    return hub
 
 
 def _cleanup_linked_hub(dps_name, rg, linked_hub_name):
@@ -35,14 +34,12 @@ def _cleanup_linked_hub(dps_name, rg, linked_hub_name):
     )
 
 
-def test_linked_hub_create_auto_hostname(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_create_auto_hostname(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """On a GWv2 hub, auto (default) should resolve to the device hostname."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group for TLS 1.3 testing")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     device_hostname = gwv2_hub["properties"]["deviceHostName"]
@@ -64,14 +61,12 @@ def test_linked_hub_create_auto_hostname(provisioned_iot_dps_no_hub_module):
         _cleanup_linked_hub(dps_name, dps_rg, device_hostname)
 
 
-def test_linked_hub_create_classic_hostname(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_create_classic_hostname(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """Create linked hub with explicit classic hostname type."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     classic_hostname = gwv2_hub["properties"]["hostName"]
@@ -93,14 +88,12 @@ def test_linked_hub_create_classic_hostname(provisioned_iot_dps_no_hub_module):
         _cleanup_linked_hub(dps_name, dps_rg, classic_hostname)
 
 
-def test_linked_hub_create_device_hostname(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_create_device_hostname(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """Create linked hub with explicit device hostname type on a GWv2 hub."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     device_hostname = gwv2_hub["properties"]["deviceHostName"]
@@ -122,17 +115,12 @@ def test_linked_hub_create_device_hostname(provisioned_iot_dps_no_hub_module):
         _cleanup_linked_hub(dps_name, dps_rg, device_hostname)
 
 
-def test_hub_show_returns_tls13_hostnames(provisioned_iot_dps_no_hub_module):
+def test_hub_show_returns_tls13_hostnames(provisioned_only_iot_hubs_session):
     """Verify hub show returns TLS 1.3 hostname properties for GWv2 hubs."""
-    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
-
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
-    result = cli.invoke(f"iot hub show -n {hub_name}").as_json()
-    props = result["properties"]
+    props = gwv2_hub["properties"]
 
     assert props.get("hostName"), "hostName (classic) should be present"
     assert props.get("deviceHostName"), "deviceHostName should be present for GWv2 hub"
@@ -145,14 +133,12 @@ def test_hub_show_returns_tls13_hostnames(provisioned_iot_dps_no_hub_module):
     assert hub_name in props["serviceHostName"]
 
 
-def test_linked_hub_list_shows_hostname(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_list_shows_hostname(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """Verify linked hub list returns the correct hostname after linking."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     device_hostname = gwv2_hub["properties"]["deviceHostName"]
@@ -174,16 +160,14 @@ def test_linked_hub_list_shows_hostname(provisioned_iot_dps_no_hub_module):
         _cleanup_linked_hub(dps_name, dps_rg, device_hostname)
 
 
-def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """Migrate a hub link from KeyBased + classic endpoint to
     SystemAssigned + device endpoint in a single update call.
     """
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     classic_hostname = gwv2_hub["properties"]["hostName"]
@@ -231,14 +215,12 @@ def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module)
             _cleanup_linked_hub(dps_name, dps_rg, hostname)
 
 
-def test_linked_hub_create_keybased_then_switch_to_mi(provisioned_iot_dps_no_hub_module):
+def test_linked_hub_create_keybased_then_switch_to_mi(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """KeyBased create -> auth-only SystemAssigned swap (no hostname change)."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]
     dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
 
-    gwv2_hub = _find_gwv2_hub(dps_rg)
-    if not gwv2_hub:
-        pytest.skip("No GWv2 hub available in resource group")
+    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
 
     hub_name = gwv2_hub["name"]
     device_hostname = gwv2_hub["properties"]["deviceHostName"]

--- a/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
+++ b/azext_iot/tests/dps/device_registration/test_iot_device_registration_group_int.py
@@ -16,7 +16,7 @@ from azure.cli.core.azclierror import (
 import pytest
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.common.shared import EntityStatusType
-from azext_iot.tests.dps import DATAPLANE_AUTH_TYPES, clean_dps_dataplane
+from azext_iot.tests.dps import DATAPLANE_AUTH_TYPES
 from azext_iot.tests.dps.device_registration import check_hub_device, compare_registrations
 from azext_iot.tests.generators import generate_generic_id, generate_names
 from azext_iot.tests.helpers import CERT_ENDING, KEY_ENDING, set_cmd_auth_type
@@ -33,7 +33,6 @@ def test_dps_device_registration_symmetrickey_lifecycle(provisioned_iot_dps_modu
     dps_cstring = provisioned_iot_dps_module["connectionString"]
     hub_cstring = provisioned_iot_dps_module["hubConnectionString"]
     id_scope = provisioned_iot_dps_module["dps"]["properties"]["idScope"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     for auth_phase in DATAPLANE_AUTH_TYPES:
         group_id, device_id1, device_id2 = generate_names(count=3)
@@ -271,7 +270,6 @@ def test_dps_device_registration_x509_lifecycle(provisioned_iot_dps_module):
     dps_cstring = provisioned_iot_dps_module["connectionString"]
     hub_cstring = provisioned_iot_dps_module["hubConnectionString"]
     id_scope = provisioned_iot_dps_module["dps"]["properties"]["idScope"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     fake_pass = "pass1234"
     root_name, devices = _prepare_x509_certificates_for_dps(
@@ -400,7 +398,6 @@ def test_dps_device_registration_unlinked_hub(provisioned_iot_dps_no_hub_module)
     dps_rg = provisioned_iot_dps_no_hub_module['resourceGroup']
     dps_cstring = provisioned_iot_dps_no_hub_module["connectionString"]
     id_scope = provisioned_iot_dps_no_hub_module["dps"]["properties"]["idScope"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     for auth_phase in DATAPLANE_AUTH_TYPES:
         group_id, device_id = generate_names(count=2)
@@ -457,7 +454,6 @@ def test_dps_device_registration_disabled_enrollment(provisioned_iot_dps_module)
     dps_name = provisioned_iot_dps_module['name']
     dps_rg = provisioned_iot_dps_module['resourceGroup']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     for auth_phase in DATAPLANE_AUTH_TYPES:
         group_id, device_id = generate_names(count=2)

--- a/azext_iot/tests/dps/device_registration/test_iot_device_registration_individual_int.py
+++ b/azext_iot/tests/dps/device_registration/test_iot_device_registration_individual_int.py
@@ -15,10 +15,7 @@ from azure.cli.core.azclierror import (
 import pytest
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.common.shared import EntityStatusType, AttestationType
-from azext_iot.tests.dps import (
-    DATAPLANE_AUTH_TYPES,
-    clean_dps_dataplane
-)
+from azext_iot.tests.dps import DATAPLANE_AUTH_TYPES
 from azext_iot.tests.dps.device_registration import compare_registrations, check_hub_device
 from azext_iot.tests.helpers import CERT_ENDING, KEY_ENDING, create_test_cert, set_cmd_auth_type
 from azext_iot.tests.generators import generate_names
@@ -33,7 +30,6 @@ def test_dps_device_registration_symmetrickey_lifecycle(provisioned_iot_dps_modu
     dps_cstring = provisioned_iot_dps_module["connectionString"]
     hub_cstring = provisioned_iot_dps_module["hubConnectionString"]
     id_scope = provisioned_iot_dps_module["dps"]["properties"]["idScope"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     attestation_type = AttestationType.symmetricKey.value
     for auth_phase in DATAPLANE_AUTH_TYPES:
@@ -234,7 +230,6 @@ def test_dps_device_registration_x509_lifecycle(provisioned_iot_dps_module):
     hub_cstring = provisioned_iot_dps_module["hubConnectionString"]
     id_scope = provisioned_iot_dps_module["dps"]["properties"]["idScope"]
     tracked_certs = provisioned_iot_dps_module["certificates"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     # Create two test certs - have the same subject but a different file name
     cert_name = generate_names()
@@ -418,7 +413,6 @@ def test_dps_device_registration_unlinked_hub(provisioned_iot_dps_no_hub_module)
     dps_rg = provisioned_iot_dps_no_hub_module['resourceGroup']
     dps_cstring = provisioned_iot_dps_no_hub_module["connectionString"]
     id_scope = provisioned_iot_dps_no_hub_module["dps"]["properties"]["idScope"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     attestation_type = AttestationType.symmetricKey.value
     for auth_phase in DATAPLANE_AUTH_TYPES:
@@ -472,7 +466,6 @@ def test_dps_device_registration_disabled_enrollment(provisioned_iot_dps_module)
     dps_name = provisioned_iot_dps_module['name']
     dps_rg = provisioned_iot_dps_module['resourceGroup']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     attestation_type = AttestationType.symmetricKey.value
     for auth_phase in DATAPLANE_AUTH_TYPES:

--- a/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
+++ b/azext_iot/tests/dps/enrollment/test_iot_dps_enrollment_int.py
@@ -12,7 +12,6 @@ from azext_iot.tests.dps import (
     DATAPLANE_AUTH_TYPES,
     WEBHOOK_URL,
     TEST_ENDORSEMENT_KEY,
-    clean_dps_dataplane
 )
 from azext_iot.tests.helpers import CERT_ENDING, create_test_cert, set_cmd_auth_type
 from azext_iot.tests.generators import generate_generic_id, generate_names
@@ -25,7 +24,6 @@ def test_dps_enrollment_tpm_lifecycle(provisioned_iot_dps_module):
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     generic_dict = {
         generate_generic_id(): generate_generic_id(),
@@ -121,7 +119,6 @@ def test_dps_enrollment_x509_lifecycle(provisioned_iot_dps_module):
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     generic_dict = {
         generate_generic_id(): generate_generic_id(),
@@ -217,7 +214,6 @@ def test_dps_enrollment_symmetrickey_lifecycle(provisioned_iot_dps_module):
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     generic_dict = {
         generate_generic_id(): generate_generic_id(),

--- a/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
+++ b/azext_iot/tests/dps/enrollment_group/test_iot_dps_enrollment_group_int.py
@@ -13,7 +13,6 @@ from azext_iot.tests.dps import (
     API_VERSION,
     DATAPLANE_AUTH_TYPES,
     WEBHOOK_URL,
-    clean_dps_dataplane,
 )
 from azext_iot.tests.helpers import CERT_ENDING, create_test_cert, set_cmd_auth_type
 from azext_iot.tests.generators import generate_generic_id, generate_names
@@ -27,7 +26,6 @@ def test_dps_enrollment_group_x509_lifecycle(provisioned_iot_dps_module):
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
 
     cert_name = generate_names()
     cert_path = cert_name + CERT_ENDING
@@ -174,7 +172,6 @@ def test_dps_enrollment_group_symmetrickey_lifecycle(provisioned_iot_dps_module)
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
     generic_dict = {
         generate_generic_id(): generate_generic_id(),
         "key": "value",
@@ -361,7 +358,6 @@ def test_dps_enrollment_twin_array(provisioned_iot_dps_module):
     dps_host_name = provisioned_iot_dps_module['dps']['properties']['serviceOperationsHostName']
     hub_hostname = provisioned_iot_dps_module['hubHostName']
     dps_cstring = provisioned_iot_dps_module["connectionString"]
-    clean_dps_dataplane(cli, dps_cstring)
     base_enrollment_props = {
         "count": None,
         "metadata": None,

--- a/azext_iot/tests/iothub/__init__.py
+++ b/azext_iot/tests/iothub/__init__.py
@@ -101,6 +101,8 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
             self._add_data_contributor(target_hub)
 
         self.host_name = target_hub["properties"]["hostName"]
+        # Device-facing hostname (GWv2 hubs expose a distinct deviceHostName; classic hubs reuse hostName)
+        self.device_host_name = target_hub["properties"].get("deviceHostName") or self.host_name
         self.region = self.get_region()
         self.connection_string = self.get_hub_cstring()
         add_test_tag(

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
@@ -354,10 +354,10 @@ class TestNestedEdgeHierarchy(IoTLiveScenarioTest):
                     assert config["provisioning"]["authentication"]["method"] == (
                         "x509" if cert_auth else "sas"
                     )
-                    # hub hostname
+                    # hub hostname (edge config.toml targets the device-facing hostname)
                     assert (
                         config["provisioning"]["iothub_hostname"]
-                        == self.host_name
+                        == self.device_host_name
                     )
                     # device_id
                     assert config["provisioning"]["device_id"] == device_id

--- a/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_int.py
+++ b/azext_iot/tests/iothub/message_endpoint/test_iothub_message_endpoint_int.py
@@ -1041,7 +1041,7 @@ def test_iot_cosmos_endpoint_lifecycle(provisioned_cosmosdb_with_identity_module
     ).as_json()
 
     assert len(cosmos_list) == 3
-    expected_list = endpoint_list.get("cosmosDbSqlCollections", []) + endpoint_list.get("cosmosDbSqlContainers", [])
+    expected_list = endpoint_list.get("cosmosDBSqlCollections", []) + endpoint_list.get("cosmosDBSqlContainers", [])
     assert cosmos_list == expected_list
 
     # Update

--- a/azext_iot/tests/iothub/message_route/test_message_route_unit.py
+++ b/azext_iot/tests/iothub/message_route/test_message_route_unit.py
@@ -274,7 +274,7 @@ class TestCommandMapTransforms:
     def test_endpoint_update_result_transform(self, mocker):
         from azext_iot.iothub.command_map import EndpointUpdateResultTransform
 
-        transform = EndpointUpdateResultTransform.__new__(EndpointUpdateResultTransform)
+        transform = EndpointUpdateResultTransform(mocker.MagicMock())
         result = {"properties": {"routing": {"endpoints": ["ep"]}}}
         mocker.patch(
             "azext_iot.iothub.command_map.LongRunningOperation.__call__",
@@ -285,7 +285,7 @@ class TestCommandMapTransforms:
     def test_route_update_result_transform(self, mocker):
         from azext_iot.iothub.command_map import RouteUpdateResultTransform
 
-        transform = RouteUpdateResultTransform.__new__(RouteUpdateResultTransform)
+        transform = RouteUpdateResultTransform(mocker.MagicMock())
         result = {"properties": {"routing": {"routes": ["r"]}}}
         mocker.patch(
             "azext_iot.iothub.command_map.LongRunningOperation.__call__",

--- a/azext_iot/tests/iothub/test_iothub_registration_unit.py
+++ b/azext_iot/tests/iothub/test_iothub_registration_unit.py
@@ -35,7 +35,7 @@ def test_load_iothub_arguments():
 def test_endpoint_update_result_transform(mocker):
     from azext_iot.iothub.command_map import EndpointUpdateResultTransform
 
-    transform = EndpointUpdateResultTransform.__new__(EndpointUpdateResultTransform)
+    transform = EndpointUpdateResultTransform(MagicMock())
     result = {"properties": {"routing": {"endpoints": ["e"]}}}
     mocker.patch(
         "azext_iot.iothub.command_map.LongRunningOperation.__call__",
@@ -47,7 +47,7 @@ def test_endpoint_update_result_transform(mocker):
 def test_route_update_result_transform(mocker):
     from azext_iot.iothub.command_map import RouteUpdateResultTransform
 
-    transform = RouteUpdateResultTransform.__new__(RouteUpdateResultTransform)
+    transform = RouteUpdateResultTransform(MagicMock())
     result = {"properties": {"routing": {"routes": ["r"]}}}
     mocker.patch(
         "azext_iot.iothub.command_map.LongRunningOperation.__call__",

--- a/azext_iot/tests/iothub/tls13/test_tls13_int.py
+++ b/azext_iot/tests/iothub/tls13/test_tls13_int.py
@@ -17,20 +17,9 @@ import pytest
 from azure.cli.testsdk.reverse_dependency import get_dummy_cli
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.iothub.providers.discovery import IotHubDiscovery
-from azext_iot.tests.settings import (
-    DynamoSettings,
-    Setting,
-    ENV_SET_TEST_IOTHUB_REQUIRED,
-    ENV_SET_TEST_IOTHUB_OPTIONAL,
-)
+from azext_iot.tests.settings import Setting
 
 cli = EmbeddedCLI()
-settings = DynamoSettings(
-    req_env_set=ENV_SET_TEST_IOTHUB_REQUIRED,
-    opt_env_set=ENV_SET_TEST_IOTHUB_OPTIONAL,
-)
-ENTITY_RG = settings.env.azext_iot_testrg
-ENTITY_NAME = settings.env.azext_iot_testhub
 
 
 @pytest.fixture(scope="module")
@@ -40,12 +29,11 @@ def discovery():
     return IotHubDiscovery(cmd_shell)
 
 
-def test_find_resource_returns_hostname_properties(discovery):
+def test_find_resource_returns_hostname_properties(discovery, provisioned_only_iot_hubs_module):
     """Verify find_resource returns TLS 1.3 hostname properties."""
-    if not ENTITY_NAME:
-        pytest.skip("azext_iot_testhub not set")
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
 
-    resource = discovery.find_resource(resource_name=ENTITY_NAME)
+    resource = discovery.find_resource(resource_name=hub_name)
     props = resource.get("properties", {})
 
     assert props.get("hostName"), "hostName (classic) should be present"
@@ -53,20 +41,20 @@ def test_find_resource_returns_hostname_properties(discovery):
     device_hostname = props.get("deviceHostName")
     service_hostname = props.get("serviceHostName")
     if device_hostname:
-        assert ENTITY_NAME in device_hostname
+        assert hub_name in device_hostname
         assert ".device." in device_hostname
     if service_hostname:
-        assert ENTITY_NAME in service_hostname
+        assert hub_name in service_hostname
         assert ".service." in service_hostname
 
 
-def test_build_target_includes_hostname_fields(discovery):
+def test_build_target_includes_hostname_fields(discovery, provisioned_only_iot_hubs_module):
     """Verify _build_target populates deviceHostName and serviceHostName."""
-    if not ENTITY_NAME:
-        pytest.skip("azext_iot_testhub not set")
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
+    hub_rg = provisioned_only_iot_hubs_module[0]["rg"]
 
-    resource = discovery.find_resource(resource_name=ENTITY_NAME)
-    policy = discovery.find_policy(resource_name=ENTITY_NAME, rg=ENTITY_RG)
+    resource = discovery.find_resource(resource_name=hub_name)
+    policy = discovery.find_policy(resource_name=hub_name, rg=hub_rg)
     target = discovery._build_target(resource=resource, policy=policy)
 
     assert target.get("entity"), "entity (hostname) should be set"
@@ -75,12 +63,12 @@ def test_build_target_includes_hostname_fields(discovery):
     assert "serviceHostName" in target, "target should include serviceHostName key"
 
 
-def test_gwv2_target_uses_service_hostname(discovery):
+def test_gwv2_target_uses_service_hostname(discovery, provisioned_only_iot_hubs_module):
     """For GWv2 hubs, _build_target should use service hostname for entity."""
-    if not ENTITY_NAME:
-        pytest.skip("azext_iot_testhub not set")
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
+    hub_rg = provisioned_only_iot_hubs_module[0]["rg"]
 
-    resource = discovery.find_resource(resource_name=ENTITY_NAME)
+    resource = discovery.find_resource(resource_name=hub_name)
     props = resource.get("properties", {})
     gw_version = props.get("iotHubDetails", {}).get("gatewayVersion")
     service_hostname = props.get("serviceHostName")
@@ -88,7 +76,7 @@ def test_gwv2_target_uses_service_hostname(discovery):
     if gw_version != "V2" or not service_hostname:
         pytest.skip("Hub is not GWv2 — skipping service hostname test")
 
-    policy = discovery.find_policy(resource_name=ENTITY_NAME, rg=ENTITY_RG)
+    policy = discovery.find_policy(resource_name=hub_name, rg=hub_rg)
     target = discovery._build_target(resource=resource, policy=policy)
 
     assert target["entity"] == service_hostname, \
@@ -97,16 +85,15 @@ def test_gwv2_target_uses_service_hostname(discovery):
         "Connection string should use service hostname for GWv2 hub"
 
 
-def test_connection_string_uses_gwv2_hostname():
+def test_connection_string_uses_gwv2_hostname(provisioned_only_iot_hubs_module):
     """Verify connection-string show uses the device hostname for GWv2 hubs."""
-    if not ENTITY_NAME:
-        pytest.skip("azext_iot_testhub not set")
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
 
-    hub = cli.invoke(f"iot hub show -n {ENTITY_NAME}").as_json()
+    hub = cli.invoke(f"iot hub show -n {hub_name}").as_json()
     props = hub.get("properties", {})
     device_hostname = props.get("deviceHostName")
 
-    result = cli.invoke(f"iot hub connection-string show -n {ENTITY_NAME}").as_json()
+    result = cli.invoke(f"iot hub connection-string show -n {hub_name}").as_json()
     cs = result["connectionString"]
     assert "HostName=" in cs
 

--- a/dev_requirements
+++ b/dev_requirements
@@ -11,5 +11,6 @@ pylint==3.0.3
 flake8
 pytest-xdist
 pytest-rerunfailures
+filelock
 tox
 build

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,5 @@ per-file-ignores =
 
 [tool:pytest]
 junit_family = xunit1
+markers =
+    adu_infrastructure: provisions ADU accounts/instances for Device Update integration tests

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ if not PACKAGE_NAME:
 # and azure-eventhub for telemetry monitoring.
 
 DEPENDENCIES = [
-    "azure-core>=1.24.0,<2.0.0",
+    "azure-core>=1.24.0,<1.40.0",
     "azure-mgmt-core>=1.3.0,<2.0.0",
     "azure-identity>=1.6.1,<1.18.0",
-    "azure-storage-blob>=12.14.0,<13.0.0",
+    "azure-storage-blob>=12.14.0,<12.30.0",
     "msrest>=0.6.21",
     "msrestazure>=0.6.3,<2.0.0",
     "jsonschema>=4.25,<5",


### PR DESCRIPTION
| Service | Test / Area | Issue | Fix |
|---------|-------------|-------|-----|
| **Hub** | `test_iot_edge_devices_create_int.py` (edge create tests) | Edge `config.toml` used the GWv2 **service** hostname, so the device can't connect | Use `deviceHostName` (falls back to classic host) in `device_identity.py` |
| **Hub** | `test_iot_messaging_int.py::test_mqtt_device_simulation_x509` | x509 / symmetric MQTT connect used the GWv2 **service** hostname → "not authorised" | Connect via device hostname in `device_messaging.py` |
| **Hub** | `test_iothub_message_endpoint_int.py::test_iot_cosmos_endpoint_lifecycle` | Test read wrong key casing `cosmosDbSqlContainers`; SDK emits `cosmosDBSqlContainers` (capital `DB`) | Fix key casing in the test |
| **DPS** | all DPS `_int` tests (`dps/conftest.py`) | Hit per-subscription 10-instance DPS quota | Share one DPS+Hub across runs/workers with ref-counting + age-based cleanup |
| **ADR** | DPS-backed ADR tests | `Max Iot Dps exceeded (Max Allowed=10)` — environmental quota, not a code bug | Mitigated by the DPS sharing/GC above (no ADR code change) |
| **ADU** | ADU `_int` tests | pip dependency conflicts during install | Version pins in `setup.py` (`azure-core`, `azure-storage-blob`) |

## Known issue (not fixed here)

- **Hub** — `az iot hub certificate create` returns a deterministic `(500019) Internal Error IH500019` on GWv2 hubs (reproduced 5/5). This is an IoT Hub **service-side** 500, not a CLI bug; needs escalation to the IoT Hub service team.
- **DPS** — `az iot dps certificate create` (`PUT .../provisioningServices/{dps}/certificates/{name}?api-version=2021-10-15`) returns a deterministic `(500019) Internal Error IH500019` (reproduced 3/3 across reruns). The same self-signed CA cert is accepted inline by `enrollment-group create`, so the payload is valid — this is a DPS **service-side** 500, not a CLI bug; needs escalation to the DPS service team.
- **DPS** — `az iot dps certificate generate-verification-code` then returns `(404015) Certificate not found IH404015`. This is a downstream symptom of the failed `certificate create` above (the cert was never persisted), not a separate bug.

