### PR TITLE
feat: add --disable-local-auth to az iot dps create/update

### DIFF
--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -57,7 +57,7 @@ def _get_credential_scopes(cli_ctx):
 
 
 def _get_arm_endpoint(cli_ctx):
-    return "https://centraluseuap.management.azure.com"  # TEMP-CANARY - Tracked by a PBI for removal
+    return cli_ctx.cloud.endpoints.resource_manager
 
 
 def iot_hub_service_factory(cli_ctx, *_):

--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -57,7 +57,7 @@ def _get_credential_scopes(cli_ctx):
 
 
 def _get_arm_endpoint(cli_ctx):
-    return cli_ctx.cloud.endpoints.resource_manager
+    return "https://centraluseuap.management.azure.com"  # TEMP-CANARY - Tracked by a PBI for removal
 
 
 def iot_hub_service_factory(cli_ctx, *_):

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -189,6 +189,7 @@ def iot_dps_create(
     adr_ns_identity_id=None,
     mi_system_assigned=None,
     mi_user_assigned=None,
+    disable_local_auth=None,
 ):
     """
     Create a DPS instance with support for Device Registry namespace.
@@ -198,6 +199,9 @@ def iot_dps_create(
     _check_dps_name_availability(client.iot_dps_resource, dps_name)
     location = _ensure_location(cli_ctx, resource_group_name, location)
     dps_property = {"enableDataResidency": enable_data_residency}
+
+    if disable_local_auth is not None:
+        dps_property["disableLocalAuth"] = disable_local_auth
 
     # TODO - CMS Preview - DPS ADR properties
     if adr_ns_id:
@@ -237,10 +241,14 @@ def iot_dps_update(
     adr_ns_identity_id=None,
     mi_system_assigned=None,
     mi_user_assigned=None,
+    disable_local_auth=None,
 ):
     resource_group_name = _ensure_dps_resource_group_name(client, resource_group_name, dps_name)
     if tags is not None:
         parameters["tags"] = tags
+
+    if disable_local_auth is not None:
+        parameters["properties"]["disableLocalAuth"] = disable_local_auth
 
     # Update ADR namespace configuration if provided
     if adr_ns_id or adr_ns_identity_id:

--- a/azext_iot/core/help.py
+++ b/azext_iot/core/help.py
@@ -44,9 +44,19 @@ def patch_core_help():
     text: >
         az iot dps create --name MyDps --resource-group MyResourceGroup --mi-user-assigned IdentityResourceId
         --ns-resource-id NamespaceResourceId --ns-identity-id IdentityResourceId
-  - name: Create an Azure IoT Hub Device Provisioning Service with SAS key (local) authentication disabled, requiring Azure RBAC.
+  - name: Create an Azure IoT Hub Device Provisioning Service with SAS key (local) authentication disabled, requiring Azure RBAC
     text: >
         az iot dps create --name MyDps --resource-group MyResourceGroup --disable-local-auth
+"""
+
+    # add DPS update example for disabling local (SAS key) authentication
+    if "iot dps update" in helps:
+        helps[
+            "iot dps update"
+        ] += """
+  - name: Disable SAS key (local) authentication on an existing Device Provisioning Service, requiring Azure RBAC
+    text: >
+        az iot dps update --name MyDps --resource-group MyResourceGroup --disable-local-auth
 """
 
     # add DPS identity help

--- a/azext_iot/core/help.py
+++ b/azext_iot/core/help.py
@@ -44,6 +44,9 @@ def patch_core_help():
     text: >
         az iot dps create --name MyDps --resource-group MyResourceGroup --mi-user-assigned IdentityResourceId
         --ns-resource-id NamespaceResourceId --ns-identity-id IdentityResourceId
+  - name: Create an Azure IoT Hub Device Provisioning Service with SAS key (local) authentication disabled, requiring Azure RBAC.
+    text: >
+        az iot dps create --name MyDps --resource-group MyResourceGroup --disable-local-auth
 """
 
     # add DPS identity help

--- a/azext_iot/core/params.py
+++ b/azext_iot/core/params.py
@@ -77,6 +77,14 @@ def load_core_arguments(self, _):
             help="Enable user-assigned managed identities for this provisioning service. "
             "Accepts space-separated list of identity resource IDs.",
         )
+        c.argument(
+            "disable_local_auth",
+            arg_type=get_three_state_flag(),
+            options_list=["--disable-local-auth", "--dla"],
+            help="A boolean indicating whether or not to disable SAS key (shared access "
+            "policy) authentication for this provisioning service, requiring Azure RBAC "
+            "for all control and data-plane operations.",
+        )
 
     # DPS identity assignment params
     with self.argument_context("iot dps identity assign") as c:

--- a/azext_iot/core/params.py
+++ b/azext_iot/core/params.py
@@ -82,8 +82,7 @@ def load_core_arguments(self, _):
             arg_type=get_three_state_flag(),
             options_list=["--disable-local-auth", "--dla"],
             help="A boolean indicating whether or not to disable SAS key (shared access "
-            "policy) authentication for this provisioning service, requiring Azure RBAC "
-            "for all control and data-plane operations.",
+            "policy) authentication for this provisioning service.",
         )
 
     # DPS identity assignment params

--- a/azext_iot/tests/dps/core/test_dps_disable_local_auth_int.py
+++ b/azext_iot/tests/dps/core/test_dps_disable_local_auth_int.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Integration tests for DPS disable-local-auth (SAS key authentication)."""
+
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.tests.generators import generate_generic_id
+
+cli = EmbeddedCLI()
+
+
+def test_dps_disable_local_auth_lifecycle(provisioned_iot_dps_no_hub_module):
+    """create/update should toggle the disableLocalAuth (SAS key auth) property."""
+    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+    location = provisioned_iot_dps_no_hub_module["dps"]["location"]
+    dps_name = f"aziotclitest-dps-{generate_generic_id()}"[:35]
+    try:
+        # create with SAS key (local) auth disabled
+        created = cli.invoke(
+            f"iot dps create -n {dps_name} -g {dps_rg} -l {location} --disable-local-auth true"
+        ).as_json()
+        assert created["properties"]["disableLocalAuth"] is True
+
+        # update re-enables SAS key auth
+        updated = cli.invoke(
+            f"iot dps update -n {dps_name} -g {dps_rg} --disable-local-auth false"
+        ).as_json()
+        assert updated["properties"]["disableLocalAuth"] is False
+    finally:
+        cli.invoke(f"iot dps delete -n {dps_name} -g {dps_rg}")

--- a/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+
+from azext_iot.tests.generators import generate_generic_id
+from azext_iot.core.custom import iot_dps_create, iot_dps_update
+
+dps_name = generate_generic_id()
+resource_group = generate_generic_id()
+location = "westus2"
+
+
+class TestDPSCreateDisableLocalAuth:
+    @pytest.mark.parametrize("disable_local_auth", [True, False, None])
+    def test_create_sets_disable_local_auth(self, fixture_cmd, mocker, disable_local_auth):
+        mocker.patch("azext_iot.core.custom._check_dps_name_availability")
+        mocker.patch("azext_iot.core.custom._ensure_location", return_value=location)
+        mock_client = mocker.MagicMock()
+
+        iot_dps_create(
+            fixture_cmd,
+            mock_client,
+            dps_name=dps_name,
+            resource_group_name=resource_group,
+            disable_local_auth=disable_local_auth,
+        )
+
+        body = mock_client.iot_dps_resource.begin_create_or_update.call_args.kwargs["iot_dps_description"]
+        props = body["properties"]
+        if disable_local_auth is None:
+            # Omitted when not provided so the service default is preserved.
+            assert "disableLocalAuth" not in props
+        else:
+            assert props["disableLocalAuth"] is disable_local_auth
+
+
+class TestDPSUpdateDisableLocalAuth:
+    @pytest.mark.parametrize("disable_local_auth", [True, False, None])
+    def test_update_sets_disable_local_auth(self, mocker, disable_local_auth):
+        mocker.patch("azext_iot.core.custom._ensure_dps_resource_group_name", return_value=resource_group)
+        mock_client = mocker.MagicMock()
+        parameters = {"properties": {}}
+
+        iot_dps_update(
+            mock_client,
+            dps_name,
+            parameters,
+            disable_local_auth=disable_local_auth,
+        )
+
+        props = parameters["properties"]
+        if disable_local_auth is None:
+            assert "disableLocalAuth" not in props
+        else:
+            assert props["disableLocalAuth"] is disable_local_auth


### PR DESCRIPTION
# Summary
Adds  --disable-local-auth/--dla  to  `az iot dps create`  and  `az iot dps update`  to disable SAS-key (shared access policy) authentication on a provisioning service, requiring Azure RBAC - mirroring IoT Hub's  --dla . Depends on the 2026-06-01-preview  DPS management SDK.

## Note
1. To test on local, either hard-code ARM endpoint to **centraluseuap**, or reach out to team for a wheel file.

## Changes
1. create a rg and dps with local auth true
<img width="2739" height="596" alt="image" src="https://github.com/user-attachments/assets/b493ae06-4252-4bbd-b01c-efce47ace60d" />

2. toggle off
<img width="2651" height="381" alt="image" src="https://github.com/user-attachments/assets/821cfe46-764a-4cae-85e4-e46f310b76bb" />
 
3. turn back on -> expect true
<img width="2651" height="381" alt="image" src="https://github.com/user-attachments/assets/67547624-3f56-4272-8eb6-1115ee88b6fb" />

## Test Result
<img width="2531" height="1126" alt="image" src="https://github.com/user-attachments/assets/a4c2f545-bf44-4185-b341-989a9ff3a60b" />


 