### PR TITLE
fix: bump wheel version to fix CI linter

### DIFF
--- a/.azure-devops/templates/evaluate-command-table.yml
+++ b/.azure-devops/templates/evaluate-command-table.yml
@@ -17,7 +17,7 @@ steps:
         source ./venv/bin/activate
         git clone --single-branch -b dev https://github.com/Azure/azure-cli.git ../azure-cli
         pip install azdev
-        pip install wheel==0.30.0 setuptools==70.0.0
+        pip install wheel==0.45.1 setuptools==70.0.0
         azdev --version
         azdev setup -c ../azure-cli -r ./
         AZURE_EXTENSION_DIR=~/.azure/cliextensions

--- a/dev_requirements
+++ b/dev_requirements
@@ -5,7 +5,7 @@ pytest-env
 responses==0.22.0
 black
 setuptools==70.0.0
-wheel==0.30.0
+wheel==0.45.1
 pre-commit
 pylint==3.0.3
 flake8


### PR DESCRIPTION
Our CI can't run the linter because its setup step crashes. It crashes because a helper tool (azdev) updated last week and changed its behavior - it now uses an ancient wheel version we've had pinned since 2017, which is too old and breaks the install. The fix is a one-line bump of that pinned version; it's a CI-tooling issue and doesn't touch our actual product