### PR TITLE
fix: preserve scheme-prefixed endpoint names in iot hub state export

### DIFF
--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -50,6 +50,12 @@ logger = get_logger(__name__)
 cli = EmbeddedCLI()
 
 
+def _endpoint_host_name(endpoint_uri: str) -> str:
+    """Return the resource host name from a routing endpoint URI, dropping the scheme."""
+    from urllib.parse import urlparse
+    return (urlparse(endpoint_uri).hostname or "").split(".")[0]
+
+
 class StateProvider(IoTHubProvider):
     def __init__(
         self,
@@ -643,7 +649,7 @@ class StateProvider(IoTHubProvider):
         # Cosmos Db
         cosmos_endpoints = []
         for ep in endpoints.get("cosmosDBSqlContainers", []):
-            account_name = ep["endpointUri"].strip("https://").split(".")[0]
+            account_name = _endpoint_host_name(ep["endpointUri"])
             if ep.get("primaryKey") or ep.get("secondaryKey"):
                 try:
                     cosmos_keys = cli.invoke(
@@ -698,7 +704,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["eventHubs"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = endpoint_props["Endpoint"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "eventhubs eventhub authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -722,7 +728,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = ep["endpointUri"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(ep["endpointUri"])
                 success = cli.invoke(
                     "eventhubs eventhub show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -744,7 +750,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["serviceBusQueues"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = endpoint_props["Endpoint"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "servicebus queue authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -768,7 +774,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = ep["endpointUri"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(ep["endpointUri"])
                 success = cli.invoke(
                     "servicebus queue show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -790,7 +796,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["serviceBusTopics"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = endpoint_props["Endpoint"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "servicebus topic authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -816,7 +822,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = ep["endpointUri"].strip("sb://").split(".")[0]
+                namespace = _endpoint_host_name(ep["endpointUri"])
                 success = cli.invoke(
                     "servicebus topic show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -862,7 +868,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                account_name = ep["endpointUri"].strip("https://").split(".")[0]
+                account_name = _endpoint_host_name(ep["endpointUri"])
                 success = cli.invoke(
                     "storage account show --name {} --subscription {}".format(
                         account_name,

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -50,8 +50,9 @@ logger = get_logger(__name__)
 cli = EmbeddedCLI()
 
 
-def _endpoint_host_name(endpoint_uri: str) -> str:
-    """Return the resource host name from a routing endpoint URI, dropping the scheme."""
+def _endpoint_resource_name(endpoint_uri: str) -> str:
+    """Return the backing resource name (Service Bus / Event Hub namespace, or Cosmos DB / Storage
+    account) parsed from a routing endpoint URI -- i.e. the first label of the host."""
     from urllib.parse import urlparse
     return (urlparse(endpoint_uri).hostname or "").split(".")[0]
 
@@ -649,7 +650,7 @@ class StateProvider(IoTHubProvider):
         # Cosmos Db
         cosmos_endpoints = []
         for ep in endpoints.get("cosmosDBSqlContainers", []):
-            account_name = _endpoint_host_name(ep["endpointUri"])
+            account_name = _endpoint_resource_name(ep["endpointUri"])
             if ep.get("primaryKey") or ep.get("secondaryKey"):
                 try:
                     cosmos_keys = cli.invoke(
@@ -704,7 +705,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["eventHubs"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
+                namespace = _endpoint_resource_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "eventhubs eventhub authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -728,7 +729,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = _endpoint_host_name(ep["endpointUri"])
+                namespace = _endpoint_resource_name(ep["endpointUri"])
                 success = cli.invoke(
                     "eventhubs eventhub show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -750,7 +751,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["serviceBusQueues"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
+                namespace = _endpoint_resource_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "servicebus queue authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -774,7 +775,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = _endpoint_host_name(ep["endpointUri"])
+                namespace = _endpoint_resource_name(ep["endpointUri"])
                 success = cli.invoke(
                     "servicebus queue show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -796,7 +797,7 @@ class StateProvider(IoTHubProvider):
         for ep in endpoints["serviceBusTopics"]:
             if ep.get("connectionString"):
                 endpoint_props = parse_iot_hub_message_endpoint_connection_string(ep["connectionString"])
-                namespace = _endpoint_host_name(endpoint_props["Endpoint"])
+                namespace = _endpoint_resource_name(endpoint_props["Endpoint"])
                 try:
                     ep["connectionString"] = cli.invoke(
                         "servicebus topic authorization-rule keys list --namespace-name {} --resource-group {} "
@@ -822,7 +823,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                namespace = _endpoint_host_name(ep["endpointUri"])
+                namespace = _endpoint_resource_name(ep["endpointUri"])
                 success = cli.invoke(
                     "servicebus topic show --namespace-name {} --resource-group {} "
                     "--name {} --subscription {}".format(
@@ -868,7 +869,7 @@ class StateProvider(IoTHubProvider):
                 )
                 removed_endpoints.append(ep["name"])
             else:
-                account_name = _endpoint_host_name(ep["endpointUri"])
+                account_name = _endpoint_resource_name(ep["endpointUri"])
                 success = cli.invoke(
                     "storage account show --name {} --subscription {}".format(
                         account_name,

--- a/azext_iot/tests/iothub/state/test_hub_state_int.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_int.py
@@ -1020,3 +1020,106 @@ def compare_routes(routes1, routes2):
         assert route["endpointNames"] == target["endpointNames"]
         assert route["isEnabled"] == target["isEnabled"]
         assert route["source"] == target["source"]
+
+
+@pytest.mark.hub_infrastructure(count=1)
+def test_export_endpoint_resource_name_starting_with_scheme_char(
+    provisioned_only_iot_hubs_module, setup_file
+):
+    """Export must keep a routing endpoint"""
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
+    hub_rg = provisioned_only_iot_hubs_module[0]["rg"]
+    delete_system_endpoints(hub_name, hub_rg)
+
+    sb_namespace = ("sb" + generate_generic_id())[:24]
+    topic_name = "topic1"
+    endpoint_name = generate_generic_id()
+    try:
+        cli.invoke(
+            f"servicebus namespace create --name {sb_namespace} -g {hub_rg} --sku Standard"
+        )
+        cli.invoke(
+            f"servicebus topic create --namespace-name {sb_namespace} -g {hub_rg} --name {topic_name}"
+        )
+        cli.invoke(
+            f"servicebus topic authorization-rule create --namespace-name {sb_namespace} -g {hub_rg} "
+            f"--topic-name {topic_name} --name iothubroute --rights Send"
+        )
+        endpoint_cstring = cli.invoke(
+            f"servicebus topic authorization-rule keys list --namespace-name {sb_namespace} -g {hub_rg} "
+            f"--topic-name {topic_name} --name iothubroute"
+        ).as_json()["primaryConnectionString"]
+
+        # Key-based endpoint with resource group
+        cli.invoke(
+            f"iot hub message-endpoint create servicebus-topic -n {hub_name} -g {hub_rg} "
+            f"--en {endpoint_name} -c '{endpoint_cstring}' --erg {hub_rg}"
+        )
+        time.sleep(10)  # gives the hub time to update before the export
+
+        cli.invoke(
+            f"iot hub state export -n {hub_name} -f {setup_file} -g {hub_rg} -r --aspects {CONTROLPLANE}"
+        )
+
+        with open(setup_file, "r", encoding="utf-8") as f:
+            hub_info = json.load(f)
+        topics = hub_info["arm"]["resources"][0]["properties"]["routing"]["endpoints"]["serviceBusTopics"]
+
+        exported = [ep for ep in topics if ep["name"] == endpoint_name]
+        assert len(exported) == 1, "endpoint was dropped from export (namespace likely corrupted)"
+        assert sb_namespace in exported[0]["connectionString"]
+    finally:
+        cli.invoke(f"iot hub message-endpoint delete -n {hub_name} -g {hub_rg} --en {endpoint_name} -y")
+        cli.invoke(f"servicebus namespace delete --name {sb_namespace} -g {hub_rg}")
+
+
+@pytest.mark.hub_infrastructure(count=1)
+def test_export_cosmosdb_endpoint_resource_name_starting_with_scheme_char(
+    provisioned_only_iot_hubs_module, setup_file
+):
+    """Export must keep a Cosmos DB routing endpoint"""
+    hub_name = provisioned_only_iot_hubs_module[0]["name"]
+    hub_rg = provisioned_only_iot_hubs_module[0]["rg"]
+    delete_system_endpoints(hub_name, hub_rg)
+
+    cosmos_account = ("scos" + generate_generic_id())[:40]
+    database_name = "routedb"
+    container_name = "routecontainer"
+    endpoint_name = generate_generic_id()
+    try:
+        cli.invoke(
+            f"cosmosdb create --name {cosmos_account} -g {hub_rg}"
+        )
+        cli.invoke(
+            f"cosmosdb sql database create --account-name {cosmos_account} -g {hub_rg} --name {database_name}"
+        )
+        cli.invoke(
+            f"cosmosdb sql container create --account-name {cosmos_account} -g {hub_rg} "
+            f"--database-name {database_name} --name {container_name} -p /deviceid"
+        )
+        endpoint_cstring = cli.invoke(
+            f"cosmosdb keys list --name {cosmos_account} -g {hub_rg} --type connection-strings"
+        ).as_json()["connectionStrings"][0]["connectionString"]
+
+        # Key-based endpoint with resource group
+        cli.invoke(
+            f"iot hub message-endpoint create cosmosdb-container -n {hub_name} -g {hub_rg} "
+            f"--en {endpoint_name} --db {database_name} --container {container_name} "
+            f"-c '{endpoint_cstring}' --erg {hub_rg}"
+        )
+        time.sleep(10)  # gives the hub time to update before the export
+
+        cli.invoke(
+            f"iot hub state export -n {hub_name} -f {setup_file} -g {hub_rg} -r --aspects {CONTROLPLANE}"
+        )
+
+        with open(setup_file, "r", encoding="utf-8") as f:
+            hub_info = json.load(f)
+        containers = hub_info["arm"]["resources"][0]["properties"]["routing"]["endpoints"]["cosmosDBSqlContainers"]
+
+        exported = [ep for ep in containers if ep["name"] == endpoint_name]
+        assert len(exported) == 1, "endpoint was dropped from export (account name likely corrupted)"
+        assert cosmos_account in exported[0]["endpointUri"]
+    finally:
+        cli.invoke(f"iot hub message-endpoint delete -n {hub_name} -g {hub_rg} --en {endpoint_name} -y")
+        cli.invoke(f"cosmosdb delete --name {cosmos_account} -g {hub_rg} -y")

--- a/azext_iot/tests/iothub/state/test_hub_state_unit.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_unit.py
@@ -15,6 +15,7 @@ from azure.cli.core.azclierror import (
 import azext_iot.iothub.providers.helpers.state_strings as constants
 
 from azext_iot.tests.conftest import generate_cs
+from azext_iot.iothub.providers.state import _endpoint_host_name
 
 hub_name = "hubname"
 hub_rg = "hubrg"
@@ -104,3 +105,28 @@ class TestHubStateMigrate:
                 orig_hub_login=generate_cs()
             )
         assert constants.LOGIN_WITH_ARM_ERROR == str(error.value)
+
+
+class TestEndpointHostNameParsing:
+    """routing-endpoint host-name extraction used by state export."""
+
+    @pytest.mark.parametrize(
+        "endpoint_uri, expected",
+        [
+            # Service Bus / Event Hub (sb://)
+            ("sb://scyhbus.servicebus.windows.net/", "scyhbus"),
+            ("sb://bhub.servicebus.windows.net/", "bhub"),
+            ("sb://sbnamespace.servicebus.windows.net/", "sbnamespace"),
+            ("sb://normal.servicebus.windows.net/", "normal"),
+            # Cosmos DB / Storage (https://)
+            ("https://sstorage.blob.core.windows.net/", "sstorage"),
+            ("https://tcosmos.documents.azure.com:443/", "tcosmos"),
+            ("https://httpsaccount.blob.core.windows.net/", "httpsaccount"),
+            ("https://plainaccount.documents.azure.com:443/", "plainaccount"),
+            # Port must be stripped
+            ("sb://sbwithport.servicebus.windows.net:5671/", "sbwithport"),
+            ("sb://MixedCase.servicebus.windows.net/", "mixedcase"),
+        ],
+    )
+    def test_host_name_not_corrupted(self, endpoint_uri, expected):
+        assert _endpoint_host_name(endpoint_uri) == expected

--- a/azext_iot/tests/iothub/state/test_hub_state_unit.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_unit.py
@@ -15,7 +15,7 @@ from azure.cli.core.azclierror import (
 import azext_iot.iothub.providers.helpers.state_strings as constants
 
 from azext_iot.tests.conftest import generate_cs
-from azext_iot.iothub.providers.state import _endpoint_host_name
+from azext_iot.iothub.providers.state import _endpoint_resource_name
 
 hub_name = "hubname"
 hub_rg = "hubrg"
@@ -129,4 +129,4 @@ class TestEndpointHostNameParsing:
         ],
     )
     def test_host_name_not_corrupted(self, endpoint_uri, expected):
-        assert _endpoint_host_name(endpoint_uri) == expected
+        assert _endpoint_resource_name(endpoint_uri) == expected


### PR DESCRIPTION
## Description
`az iot hub state export` was dropping routing endpoints when the backing resource (Event Hub / Service Bus namespace, or Cosmos DB / Storage account) had a name that began with a URI-scheme character.


## Why it happened
The host name was pulled out of the endpoint URI with `str.strip("sb://")` / `str.strip("https://")`. `str.strip(chars)` strips any leading/trailing characters contained in `chars` (a *set*), it does **not** strip a prefix. Names starting with `s`, `b`, `h`, `t`, or `p` therefore lost those characters - e.g. `sb://scyhbus...` produced `cyhbus` instead of `scyhbus`. The follow-up lookup for the corrupted name failed and the endpoint was removed from the exported ARM template. This affected all name-/key-based endpoint types: Event Hub, Service Bus queue, Service Bus topic (`sb://`), and Cosmos DB / Storage (`https://`).


## Fix
Replaced the string stripping with `urllib.parse.urlparse`:

urlparse is Python's standard-library URL parser and returns the host correctly regardless of scheme. This is not a new dependency, urlparse is already used the same way in other files. 

The eight previously duplicated parsing sites now go through one  `_endpoint_host_name()` helper, which is what let the same defect spread across every endpoint type.
 

## Tests

- Unit ( test_hub_state_unit.py ) -  TestEndpointHostNameParsing , parametrized over both schemes, scheme-character prefixes, port stripping, and mixed case. 
-  Integration ( test_hub_state_int.py ) - two tests that provision a Service Bus namespace / Cosmos DB (covers both https and sb prefixes), add a routing endpoint, run export, and assert the endpoint survives with its name intact. Both verified against live Azure.

<img width="1969" height="998" alt="image" src="https://github.com/user-attachments/assets/04bde09d-8df9-4d83-ad3f-1de53eed2ad6" />
<img width="1947" height="209" alt="image" src="https://github.com/user-attachments/assets/a90e5969-2e72-45ed-9c89-1bd431a3f670" />


## Behavior
### Service bus topic
<img width="2187" height="603" alt="image" src="https://github.com/user-attachments/assets/90d9a214-8e4b-487d-8545-f1b592fc48ed" />

Before:
<img width="1938" height="404" alt="image" src="https://github.com/user-attachments/assets/33245ceb-328c-45e4-b780-540fe1ffde1a" />
Notice the first s being dropped -> error

After:
<img width="1949" height="170" alt="image" src="https://github.com/user-attachments/assets/2fc71a30-856d-4bc4-b30c-c50990dfbef3" />

### Cosmos DB
Before:
<img width="1961" height="340" alt="image" src="https://github.com/user-attachments/assets/98d4f2aa-d3c8-4032-ab01-e02a0e243a56" />


After:
<img width="1938" height="188" alt="image" src="https://github.com/user-attachments/assets/abee869f-7f20-4052-b5ec-4307caf05039" />
