### PR TITLE
feat: remove --hostname-type option from linked-hub update

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+0.31.0b3 (Preview)
++++++++++++++++
+
+**DPS updates**
+
+* Removed ``--hostname-type`` from ``az iot dps linked-hub update``. A linked hub's endpoint hostname (classic vs device) is now fixed at creation and can no longer be changed in place; to move a link to a different endpoint, create a new link at the desired endpoint and delete the old one. ``--hostname-type`` remains available on ``az iot dps linked-hub create``, and ``az iot dps linked-hub update`` continues to support ``--authentication-type``, ``--connection-string``, ``--user-assigned-identity``, ``--allocation-weight`` and ``--apply-allocation-policy``.
+
 0.31.0b2 (Preview)
 +++++++++++++++
 

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.31.0b2"
+VERSION = "0.31.0b3"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -170,13 +170,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='IoT Hub short name. Preferred over --linked-hub; resolves to the correct '
                    'entry regardless of classic/device hostname.',
                    arg_group='Linked Hub Identifier')
-        c.argument('hostname_type',
-                   options_list=['--hostname-type', '--ht'],
-                   arg_type=get_enum_type(["auto", "device", "classic"]),
-                   help="Switch the linked hub to a different endpoint hostname. "
-                   "'auto' uses the TLS 1.3 device hostname when available, classic otherwise. "
-                   "'device' uses the TLS 1.3 device hostname (errors on non-GWv2 hubs). "
-                   "'classic' uses the classic hostname.")
         c.argument('authentication_type',
                    options_list=['--authentication-type', '--auth-type'],
                    arg_type=get_enum_type(IotHubAuthenticationType),

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -540,7 +540,6 @@ def iot_dps_linked_hub_update(
     dps_name,
     linked_hub=None,
     hub_name=None,
-    hostname_type=None,
     authentication_type=None,
     user_assigned_identity=None,
     connection_string=None,
@@ -549,8 +548,8 @@ def iot_dps_linked_hub_update(
     allocation_weight=None,
     no_wait=False,
 ):
-    """Update a linked IoT Hub on a DPS — allocation policy/weight, endpoint hostname type,
-    and/or authentication type.
+    """Update a linked IoT Hub on a DPS — allocation policy/weight and/or
+    authentication type.
     """
     if not hub_name and not linked_hub:
         raise RequiredArgumentMissingError(
@@ -562,7 +561,6 @@ def iot_dps_linked_hub_update(
         )
 
     mutation_args = {
-        "--hostname-type": hostname_type,
         "--authentication-type": authentication_type,
         "--connection-string": connection_string,
         "--user-assigned-identity": user_assigned_identity,
@@ -619,18 +617,12 @@ def iot_dps_linked_hub_update(
 
     hub = None
     hub_client = None
-    needs_hub_fetch = hostname_type or (
+    needs_hub_fetch = (
         authentication_type == IotHubAuthenticationType.KEY_BASED.value and not connection_string
     )
     if needs_hub_fetch:
         hub_client = iot_hub_service_factory(cmd.cli_ctx)
         hub = iot_hub_get(cmd, hub_client, hub_name=hub_name)
-
-    new_hostname = None
-    if hostname_type:
-        new_hostname = _resolve_linked_hub_hostname(hub, hostname_type)
-        target_entry["name"] = new_hostname
-        target_entry["hostName"] = new_hostname
 
     if authentication_type:
         target_entry["authenticationType"] = authentication_type
@@ -651,7 +643,7 @@ def iot_dps_linked_hub_update(
 
     cs_needs_rebuild = (
         target_auth == IotHubAuthenticationType.KEY_BASED.value
-        and (authentication_type or new_hostname or connection_string)
+        and (authentication_type or connection_string)
     )
     if cs_needs_rebuild:
         if connection_string:

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_int.py
@@ -160,61 +160,6 @@ def test_linked_hub_list_shows_hostname(provisioned_iot_dps_no_hub_module, provi
         _cleanup_linked_hub(dps_name, dps_rg, device_hostname)
 
 
-def test_linked_hub_update_combined_migration(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
-    """Migrate a hub link from KeyBased + classic endpoint to
-    SystemAssigned + device endpoint in a single update call.
-    """
-    dps_name = provisioned_iot_dps_no_hub_module["name"]
-    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
-
-    gwv2_hub = _require_gwv2_hub(provisioned_only_iot_hubs_session)
-
-    hub_name = gwv2_hub["name"]
-    classic_hostname = gwv2_hub["properties"]["hostName"]
-    device_hostname = gwv2_hub["properties"]["deviceHostName"]
-
-    # Ensure DPS has SystemAssigned MI for the swap target
-    cli.invoke(f"iot dps identity assign --name {dps_name} -g {dps_rg} --system-assigned")
-
-    # Cleanup state for both possible end-state hostnames
-    cleanup_targets = [classic_hostname, device_hostname]
-
-    try:
-        # Initial state: link with KeyBased + classic
-        cli.invoke(
-            f"iot dps linked-hub create --dps-name {dps_name} -g {dps_rg} "
-            f"--hub-name {hub_name} --hostname-type classic"
-        )
-        initial = cli.invoke(
-            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
-        ).as_json()
-        assert any(
-            h["name"] == classic_hostname and h["authenticationType"] == "KeyBased"
-            for h in initial
-        ), f"Pre-condition failed; got: {[(h['name'], h['authenticationType']) for h in initial]}"
-
-        # Combined update: classic -> device endpoint + KeyBased -> SystemAssigned
-        cli.invoke(
-            f"iot dps linked-hub update --dps-name {dps_name} -g {dps_rg} "
-            f"--hub-name {hub_name} --hostname-type device "
-            f"--authentication-type SystemAssigned"
-        )
-
-        after = cli.invoke(
-            f"iot dps linked-hub list --dps-name {dps_name} -g {dps_rg}"
-        ).as_json()
-        matching = [h for h in after if h["name"] == device_hostname]
-        assert len(matching) == 1, (
-            f"Expected single entry at device hostname '{device_hostname}', "
-            f"got: {[h['name'] for h in after]}"
-        )
-        assert matching[0]["authenticationType"] == "SystemAssigned"
-        assert matching[0].get("connectionString", "") == ""
-    finally:
-        for hostname in cleanup_targets:
-            _cleanup_linked_hub(dps_name, dps_rg, hostname)
-
-
 def test_linked_hub_create_keybased_then_switch_to_mi(provisioned_iot_dps_no_hub_module, provisioned_only_iot_hubs_session):
     """KeyBased create -> auth-only SystemAssigned swap (no hostname change)."""
     dps_name = provisioned_iot_dps_no_hub_module["name"]

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -283,16 +283,6 @@ class TestLinkedHubUpdate:
                 hub_name="myhub", linked_hub="myhub.azure-devices.net",
             )
 
-    def test_hostname_type_works_with_linked_hub(self, fixture_cmd, mock_deps, existing_entries):
-        """--linked-hub + --hostname-type derives the hub short name from the hostname."""
-        from azext_iot.core.custom import iot_dps_linked_hub_update
-        iot_dps_linked_hub_update(
-            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
-            linked_hub="myhub.azure-devices.net", hostname_type="device",
-        )
-        assert existing_entries[0]["name"] == "myhub.device.azure-devices.net"
-        assert existing_entries[0]["hostName"] == "myhub.device.azure-devices.net"
-
     def test_user_assigned_requires_identity(self, fixture_cmd, mock_deps):
         from azext_iot.core.custom import iot_dps_linked_hub_update
         with pytest.raises(RequiredArgumentMissingError, match="--user-assigned-identity"):
@@ -381,8 +371,8 @@ class TestLinkedHubUpdate:
                 cmd=fixture_cmd, client=mock_deps, dps_name="dps", hub_name="myhub",
             )
 
-    def test_hostname_swap_preserves_existing_policy(self, fixture_cmd, mock_deps, existing_entries, mocker):
-        """Hostname swap on KeyBased must re-fetch using the EXISTING policy (e.g., 'service'
+    def test_keybased_refresh_preserves_existing_policy(self, fixture_cmd, mock_deps, existing_entries, mocker):
+        """Re-fetching the key on a KeyBased link must reuse the EXISTING policy (e.g., 'service'
         for least-privilege setups) — must not silently downgrade to iothubowner."""
         from azext_iot.core.custom import iot_dps_linked_hub_update
         existing_entries[0]["connectionString"] = (
@@ -396,7 +386,7 @@ class TestLinkedHubUpdate:
 
         iot_dps_linked_hub_update(
             cmd=fixture_cmd, client=mock_deps, dps_name="dps",
-            hub_name="myhub", hostname_type="device",
+            hub_name="myhub", authentication_type="KeyBased",
         )
 
         assert policy_spy.call_args.args[2] == "service", (
@@ -451,20 +441,6 @@ class TestLinkedHubUpdate:
         assert entry["authenticationType"] == "KeyBased"
         assert entry["name"] == "myhub.azure-devices.net"
 
-    def test_hostname_swap_only_refetches_key(self, fixture_cmd, mock_deps, existing_entries):
-        """Hostname-only swap on KeyBased: re-fetch key (GET masks the existing one)."""
-        from azext_iot.core.custom import iot_dps_linked_hub_update
-        iot_dps_linked_hub_update(
-            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
-            hub_name="myhub", hostname_type="device",
-        )
-        entry = existing_entries[0]
-        assert entry["name"] == "myhub.device.azure-devices.net"
-        assert entry["hostName"] == "myhub.device.azure-devices.net"
-        assert "HostName=myhub.device.azure-devices.net" in entry["connectionString"]
-        assert "fresh-key" in entry["connectionString"]
-        assert entry["authenticationType"] == "KeyBased"
-
     def test_keybased_to_system_assigned(self, fixture_cmd, mock_deps, existing_entries):
         from azext_iot.core.custom import iot_dps_linked_hub_update
         iot_dps_linked_hub_update(
@@ -518,16 +494,3 @@ class TestLinkedHubUpdate:
             user_assigned_identity=uami_new,
         )
         assert ua_entries[0]["selectedUserAssignedIdentityResourceId"] == uami_new
-
-    def test_combined_keybased_classic_to_system_assigned_device(self, fixture_cmd, mock_deps, existing_entries):
-        from azext_iot.core.custom import iot_dps_linked_hub_update
-        iot_dps_linked_hub_update(
-            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
-            hub_name="myhub", hostname_type="device",
-            authentication_type="SystemAssigned",
-        )
-        entry = existing_entries[0]
-        assert entry["name"] == "myhub.device.azure-devices.net"
-        assert entry["hostName"] == "myhub.device.azure-devices.net"
-        assert entry["authenticationType"] == "SystemAssigned"
-        assert entry["connectionString"] == ""


### PR DESCRIPTION
Removes  `--hostname-type`  from  `az iot dps linked-hub update`  - endpoint hostname is now fixed at creation  (matching the portal);  `create` keeps  `--hostname-type`  and  `update`  keeps its auth/allocation options. Bumped to  0.31.0b3 .

<img width="1931" height="529" alt="image" src="https://github.com/user-attachments/assets/2ae2af3b-8923-41c8-9854-da3f026075cd" />

<img width="1931" height="529" alt="image" src="https://github.com/user-attachments/assets/452c7f24-aa09-4aea-a86b-2cbe07908289" />
<img width="1946" height="926" alt="image" src="https://github.com/user-attachments/assets/1929e77e-75f9-4c98-b70a-ef40df0be687" />