### PR TITLE
[Generated by SRE Agent] fix: avoid KeyError on missing x509Thumbprint during hub state export

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,8 @@ Release History
 
 * Fixed ``az iot hub state export`` to preserve routing endpoint resource names (Event Hub / Service Bus namespaces, Cosmos DB / Storage accounts) whose names begin with characters found in the URI scheme. Endpoints are no longer dropped or corrupted during export.
 
+* Fixed ``az iot hub state export`` failing with ``KeyError: 'x509Thumbprint'`` when a device twin does not include an ``x509Thumbprint`` property. Affected devices are now exported with an empty thumbprint pair instead of aborting the entire export.
+
 0.29.0
 +++++++++++++++
 

--- a/azext_iot/iothub/providers/state.py
+++ b/azext_iot/iothub/providers/state.py
@@ -543,9 +543,14 @@ class StateProvider(IoTHubProvider):
 
             # create the device identity from the device twin
             # primary and secondary keys show up in the "show" output but not in the "list" output
+            # x509Thumbprint is not always present on the twin (for example sas or certificate
+            # authority authenticated devices), so fall back to an empty thumbprint pair
             authentication = {
                 "type": device_twin.pop("authenticationType"),
-                "x509Thumbprint": device_twin.pop("x509Thumbprint")
+                "x509Thumbprint": device_twin.pop("x509Thumbprint", None) or {
+                    "primaryThumbprint": None,
+                    "secondaryThumbprint": None,
+                }
             }
             if authentication["type"] == DeviceAuthApiType.sas.value:
                 # Cannot retrieve the sas key for some reason - throw out the device

--- a/azext_iot/tests/iothub/state/test_hub_state_unit.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_unit.py
@@ -15,11 +15,29 @@ from azure.cli.core.azclierror import (
 import azext_iot.iothub.providers.helpers.state_strings as constants
 
 from azext_iot.tests.conftest import generate_cs
-from azext_iot.iothub.providers.state import _endpoint_resource_name
+from azext_iot.iothub.providers.state import StateProvider, _endpoint_resource_name
 
 hub_name = "hubname"
 hub_rg = "hubrg"
 resource_not_found_error = "Resource not found."
+
+
+def _build_device_twin(device_id="device1", auth_type="sas", include_thumbprint=True):
+    """Minimal device twin shaped like the output of `_iot_device_twin_list`."""
+    twin = {
+        "deviceId": device_id,
+        "authenticationType": auth_type,
+        "properties": {
+            "desired": {"$metadata": {}, "$version": 1},
+            "reported": {},
+        },
+    }
+    if include_thumbprint:
+        twin["x509Thumbprint"] = {
+            "primaryThumbprint": "AAAA",
+            "secondaryThumbprint": "BBBB",
+        }
+    return twin
 
 
 class TestHubStateExport:
@@ -105,6 +123,57 @@ class TestHubStateMigrate:
                 orig_hub_login=generate_cs()
             )
         assert constants.LOGIN_WITH_ARM_ERROR == str(error.value)
+
+
+class TestDownloadDevicesThumbprint:
+    """`state export` must not crash on twins that lack an x509Thumbprint (issue #746)."""
+
+    def _patch_device_calls(self, mocker, twins):
+        mocker.patch(
+            "azext_iot.iothub.providers.state._iot_device_twin_list", return_value=twins
+        )
+        mocker.patch(
+            "azext_iot.iothub.providers.state._iot_device_show",
+            return_value={"authentication": {"symmetricKey": {"primaryKey": "pk", "secondaryKey": "sk"}}},
+        )
+        mocker.patch(
+            "azext_iot.iothub.providers.state._iot_device_module_list", return_value=[]
+        )
+
+    def test_missing_thumbprint_does_not_raise(self, mocker):
+        # a twin without the x509Thumbprint key previously raised KeyError: 'x509Thumbprint'
+        self._patch_device_calls(mocker, [_build_device_twin(include_thumbprint=False)])
+
+        provider = StateProvider.__new__(StateProvider)
+        devices = provider.download_devices(target={})
+
+        assert "device1" in devices
+        thumbprint = devices["device1"]["identity"]["authentication"]["x509Thumbprint"]
+        assert thumbprint == {"primaryThumbprint": None, "secondaryThumbprint": None}
+
+    def test_present_thumbprint_is_preserved(self, mocker):
+        self._patch_device_calls(mocker, [_build_device_twin(include_thumbprint=True)])
+
+        provider = StateProvider.__new__(StateProvider)
+        devices = provider.download_devices(target={})
+
+        thumbprint = devices["device1"]["identity"]["authentication"]["x509Thumbprint"]
+        assert thumbprint == {"primaryThumbprint": "AAAA", "secondaryThumbprint": "BBBB"}
+
+    def test_mixed_devices_all_exported(self, mocker):
+        # one bad device must not abort the export of the rest
+        self._patch_device_calls(
+            mocker,
+            [
+                _build_device_twin(device_id="withThumbprint", include_thumbprint=True),
+                _build_device_twin(device_id="noThumbprint", include_thumbprint=False),
+            ],
+        )
+
+        provider = StateProvider.__new__(StateProvider)
+        devices = provider.download_devices(target={})
+
+        assert set(devices.keys()) == {"withThumbprint", "noThumbprint"}
 
 
 class TestEndpointHostNameParsing:


### PR DESCRIPTION
Fixes #746

## Problem

`az iot hub state export` crashes with `KeyError: 'x509Thumbprint'` partway through a large export. The reporter hit it at 73% of a 27,177 device hub, after 2h36m of collection.

`StateProvider.download_devices` builds each device's authentication block from the device twin:

```python
authentication = {
    "type": device_twin.pop("authenticationType"),
    "x509Thumbprint": device_twin.pop("x509Thumbprint")   # <-- no default
}
```

The `pop` has no default, but twins returned by the device twin *list* API do not always carry `x509Thumbprint`. A single such device aborts the entire export.

Because `save_state` only writes the state file after every device has been collected, this discards the full multi-hour run rather than skipping one device.

## Fix

Fall back to an empty primary/secondary thumbprint pair when the property is absent or null. This matches the safe `pop(key, None)` style already used a few lines below for `IMMUTABLE_DEVICE_IDENTITY_FIELDS`, so the inconsistency looks like an oversight rather than a deliberate choice.

The fallback preserves the shape the rest of the state code expects — `upload_state` reads `identity["authentication"]["x509Thumbprint"]["primaryThumbprint"]` directly, so emitting `None` rather than omitting the key keeps import working.

## Tests

Three cases added to `TestDownloadDevicesThumbprint`:

- twin missing `x509Thumbprint` no longer raises, and exports an empty thumbprint pair
- twin with a thumbprint keeps its values unchanged (no regression)
- a mix of both exports **all** devices, covering the "one bad device kills the run" symptom

`azext_iot/tests/iothub/state/test_hub_state_unit.py` passes (19 tests). Flake8 clean against the repo `setup.cfg`.

## Notes for reviewers

- Draft because I could not verify against a real hub. It would be worth confirming *which* device configurations omit the field — I inferred SAS / CA-signed devices from the twin schema, but a maintainer with hub access can confirm the exact set.
- Changelog entry added under the in-flight `0.30.0` section; there is no `v0.30.0` tag yet, so I assumed it is unreleased. Happy to move it if that is wrong.

---
Created by Azure SRE Agent: [Open thread](https://sre.azure.com/agents/subscriptions/a386d5ea-ea90-441a-8263-d816368c84a1/resourceGroups/livesite/providers/Microsoft.App/agents/cliagent/views/thread/08547775-c820-48cd-9184-27b48a20b802)