### PR TITLE
chore: add preview label for TLS1.3+MI feature

### DIFF
--- a/azext_iot/_params.py
+++ b/azext_iot/_params.py
@@ -356,6 +356,7 @@ def load_arguments(self, _):
             options_list=["--hostname-type", "--ht"],
             arg_type=get_enum_type(HostnameType),
             default=HostnameType.AUTO.value,
+            is_preview=True,
             help="Type of hostname to use in the connection string. "
             "'auto' uses the TLS 1.3 device hostname on GWv2 hubs, classic otherwise. "
             "'classic' always uses the default hostname. "
@@ -373,6 +374,7 @@ def load_arguments(self, _):
                 options_list=["--hostname-type", "--ht"],
                 arg_type=get_enum_type(HostnameType),
                 default=HostnameType.AUTO.value,
+                is_preview=True,
                 help="Type of hostname to use in the connection string. "
                 "'auto' uses the TLS 1.3 device hostname on GWv2 hubs, classic otherwise. "
                 "'classic' always uses the default hostname. "
@@ -386,6 +388,7 @@ def load_arguments(self, _):
             options_list=["--hostname-type", "--ht"],
             arg_type=get_enum_type(HostnameType),
             default=HostnameType.AUTO.value,
+            is_preview=True,
             help="Type of hostname to use as the SAS token audience. "
             "'auto' uses the device hostname for device/module-scoped tokens "
             "and the service hostname for hub-scoped tokens. "

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -137,18 +137,21 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('authentication_type',
                    options_list=['--authentication-type', '--auth-type'],
                    arg_type=get_enum_type(IotHubAuthenticationType),
+                   is_preview=True,
                    help='Authentication type for the linked IoT Hub. '
                    "'KeyBased' uses a connection string. "
                    "'SystemAssigned' uses the DPS system-assigned managed identity. "
                    "'UserAssigned' uses a user-assigned managed identity.")
         c.argument('user_assigned_identity',
                    options_list=['--user-assigned-identity', '--uai'],
+                   is_preview=True,
                    help='User-assigned managed identity resource ID. '
                    'Required when authentication type is UserAssigned.')
         c.argument('hostname_type',
                    options_list=['--hostname-type', '--ht'],
                    arg_type=get_enum_type(["auto", "device", "classic"]),
                    default="auto",
+                   is_preview=True,
                    help="Type of IoT Hub hostname to use when linking. "
                    "'auto' uses the TLS 1.3 device hostname if available, classic otherwise. "
                    "'device' uses the TLS 1.3 device hostname (errors if not GWv2). "
@@ -167,12 +170,14 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    arg_group='Linked Hub Identifier')
         c.argument('hub_name',
                    options_list=['--hub-name', '--hn'],
+                   is_preview=True,
                    help='IoT Hub short name. Preferred over --linked-hub; resolves to the correct '
                    'entry regardless of classic/device hostname.',
                    arg_group='Linked Hub Identifier')
         c.argument('authentication_type',
                    options_list=['--authentication-type', '--auth-type'],
                    arg_type=get_enum_type(IotHubAuthenticationType),
+                   is_preview=True,
                    help='Switch the linked hub to a different authentication type. '
                    "'KeyBased' uses a connection string (supplied via --connection-string, "
                    "otherwise auto-fetched from the identified hub). "
@@ -180,10 +185,12 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    "'UserAssigned' uses a user-assigned managed identity.")
         c.argument('user_assigned_identity',
                    options_list=['--user-assigned-identity', '--uai'],
+                   is_preview=True,
                    help='User-assigned managed identity resource ID. '
                    'Required when --authentication-type is UserAssigned.')
         c.argument('connection_string',
                    options_list=['--connection-string', '--cs'],
+                   is_preview=True,
                    help='IoT Hub connection string to use when switching to KeyBased authentication. '
                    'If omitted, the key is auto-fetched from the identified hub.')
         c.argument('apply_allocation_policy',

--- a/azext_iot/iothub/command_map.py
+++ b/azext_iot/iothub/command_map.py
@@ -102,7 +102,8 @@ def load_iothub_commands(self, _):
         cmd_group.command(
             "fabric-eventstream",
             "message_endpoint_create_fabric_eventstream",
-            transform=EndpointUpdateResultTransform(self.cli_ctx)
+            transform=EndpointUpdateResultTransform(self.cli_ctx),
+            is_preview=True
         )
 
     with self.command_group(
@@ -138,7 +139,8 @@ def load_iothub_commands(self, _):
         cmd_group.command(
             "fabric-eventstream",
             "message_endpoint_update_fabric_eventstream",
-            transform=EndpointUpdateResultTransform(self.cli_ctx)
+            transform=EndpointUpdateResultTransform(self.cli_ctx),
+            is_preview=True
         )
 
     with self.command_group(


### PR DESCRIPTION
Add `is-preview=true` label for TLS1.3+MI feature

`is_preview=True`  on the two `fabric-eventstream` commands is redundant, the group badge masks it. I left it in since it's harmless and future-proofs the case where  message-endpoint  graduates to GA. 