### PR TITLE
fix(iot edge devices create): validate device Id used as file system path

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,6 +18,8 @@ Release History
 
 **IoT Hub updates**
 
+* Fixed ``az iot edge devices create`` where a device Id supplied via ``--cfg`` or ``--device`` was used unvalidated as a file system path segment, allowing a malicious configuration file to remove or write files outside of the ``--out`` directory. Device Ids are now validated and the generated ``install.sh`` shell-quotes the device Id.
+
 * Fixed ``az iot hub state export`` to preserve routing endpoint resource names (Event Hub / Service Bus namespaces, Cosmos DB / Storage accounts) whose names begin with characters found in the URI scheme. Endpoints are no longer dropped or corrupted during export.
 
 0.29.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -18,7 +18,7 @@ Release History
 
 **IoT Hub updates**
 
-* Fixed ``az iot edge devices create`` where a device Id supplied via ``--cfg`` or ``--device`` was used unvalidated as a file system path segment, allowing a malicious configuration file to remove or write files outside of the ``--out`` directory. Device Ids are now validated and the generated ``install.sh`` shell-quotes the device Id.
+* Fixed ``az iot edge devices create`` where a device Id supplied via ``--cfg`` or ``--device`` was used unvalidated as a file system path segment, allowing a malicious configuration file to remove or write files outside of the ``--out`` directory. Device Ids are now validated before use.
 
 * Fixed ``az iot hub state export`` to preserve routing endpoint resource names (Event Hub / Service Bus namespaces, Cosmos DB / Storage accounts) whose names begin with characters found in the URI scheme. Endpoints are no longer dropped or corrupted during export.
 

--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -6,7 +6,7 @@
 from pathlib import PurePath
 from knack.prompting import prompt_y_n
 from os import makedirs
-from os.path import exists, abspath
+from os.path import exists, abspath, commonpath, realpath
 from shutil import rmtree
 from azext_iot.common.certops import (
     create_self_signed_certificate,
@@ -52,6 +52,33 @@ from azext_iot.operations.hub import _assemble_device
 from azext_iot.sdk.iothub.service.models import Device
 
 logger = get_logger(__name__)
+
+
+def _resolve_device_bundle_directory(
+    bundle_output_directory: PurePath, device_id: str
+) -> PurePath:
+    """
+    Join a device Id onto the bundle output directory, ensuring the result stays within that
+    directory. Device Ids originate from user supplied config files and are validated when the
+    config is parsed - this is a final guard before destructive file system operations run.
+    """
+    device_directory = bundle_output_directory.joinpath(device_id)
+    bundle_root = realpath(str(bundle_output_directory))
+    resolved_device_directory = realpath(str(device_directory))
+    try:
+        contained = (
+            resolved_device_directory != bundle_root
+            and commonpath([bundle_root, resolved_device_directory]) == bundle_root
+        )
+    except ValueError:
+        # paths reside on different drives (Windows)
+        contained = False
+    if not contained:
+        raise InvalidArgumentValueError(
+            f"Device Id '{device_id}' is invalid, it resolves to a path outside of the "
+            f"output directory '{bundle_output_directory}'."
+        )
+    return device_directory
 
 
 class DeviceIdentityProvider(IoTHubProvider):
@@ -247,7 +274,9 @@ class DeviceIdentityProvider(IoTHubProvider):
             device_id = device.device_id
             device_cert_output_directory = None
             if bundle_output_directory:
-                device_cert_output_directory = bundle_output_directory.joinpath(device_id)
+                device_cert_output_directory = _resolve_device_bundle_directory(
+                    bundle_output_directory, device_id
+                )
                 # if the device's folder already exists, remove it
                 if exists(device_cert_output_directory):
                     rmtree(device_cert_output_directory)

--- a/azext_iot/iothub/providers/helpers/edge_device_config.py
+++ b/azext_iot/iothub/providers/helpers/edge_device_config.py
@@ -6,7 +6,6 @@
 """This module defines common values and functions for processing edge device configurations"""
 
 import re
-import shlex
 from pathlib import PurePath
 from os import getcwd
 from typing import Optional, List, Dict, Any
@@ -141,7 +140,7 @@ EDGE_CONFIG_SCRIPT_HEADERS = """
 # This script will attempt to configure a pre-installed iotedge as a nested node.
 # It must be run as sudo, and will modify the ca
 
-device_id={}
+device_id="{}"
 cp config.toml /etc/aziot/config.toml
 """
 EDGE_CONFIG_SCRIPT_HOSTNAME = """
@@ -502,7 +501,7 @@ def create_edge_device_config_script(
     parent_hostname: Optional[str] = None,
 ):
     return "\n".join(
-        [EDGE_CONFIG_SCRIPT_HEADERS.format(shlex.quote(device_id))]
+        [EDGE_CONFIG_SCRIPT_HEADERS.format(device_id)]
         + ([EDGE_CONFIG_SCRIPT_HOSTNAME] if not hostname else [])
         + (
             [EDGE_CONFIG_SCRIPT_PARENT_HOSTNAME]

--- a/azext_iot/iothub/providers/helpers/edge_device_config.py
+++ b/azext_iot/iothub/providers/helpers/edge_device_config.py
@@ -5,6 +5,8 @@
 # --------------------------------------------------------------------------------------------
 """This module defines common values and functions for processing edge device configurations"""
 
+import re
+import shlex
 from pathlib import PurePath
 from os import getcwd
 from typing import Optional, List, Dict, Any
@@ -35,6 +37,11 @@ from knack.log import get_logger
 logger = get_logger(__name__)
 
 MAX_DEVICE_SCOPE_RETRIES = 5
+
+# Device IDs become file system path segments (bundle folders, certificate and archive names),
+# so they are restricted to the IoT Hub allowed character set and screened for path traversal.
+MAX_DEVICE_ID_LEN = 128
+DEVICE_ID_ALLOWED_PATTERN = re.compile(r"^[A-Za-z0-9\-.+%_#*?!(),:=@$']+$")
 
 DEVICE_CONFIG_SCHEMA_VALID_VERSIONS: Dict[str, Any] = {}
 
@@ -134,7 +141,7 @@ EDGE_CONFIG_SCRIPT_HEADERS = """
 # This script will attempt to configure a pre-installed iotedge as a nested node.
 # It must be run as sudo, and will modify the ca
 
-device_id="{}"
+device_id={}
 cp config.toml /etc/aziot/config.toml
 """
 EDGE_CONFIG_SCRIPT_HOSTNAME = """
@@ -237,6 +244,33 @@ Pick a [supported OS]({EDGE_SUPPORTED_OS_LINK}) and follow the corresponding tut
 
 
 EDGE_ROOT_CERTIFICATE_SUBJECT = "Azure_IoT_CLI_Extension_Cert"
+
+
+def validate_edge_device_id(device_id: str) -> str:
+    """
+    Ensure a device Id supplied via config file or CLI argument is safe to use as a file system
+    path segment. Device Ids are used to name bundle folders, certificates and archives, so an
+    unvalidated value would allow writing to - or deleting - arbitrary locations on disk.
+    """
+    if not isinstance(device_id, str) or not device_id:
+        raise InvalidArgumentValueError(
+            "A device parameter is missing required attribute 'device_id'"
+        )
+    if len(device_id) > MAX_DEVICE_ID_LEN:
+        raise InvalidArgumentValueError(
+            f"Device Id '{device_id}' is invalid, it must be at most {MAX_DEVICE_ID_LEN} characters long."
+        )
+    if not DEVICE_ID_ALLOWED_PATTERN.match(device_id):
+        raise InvalidArgumentValueError(
+            f"Device Id '{device_id}' contains invalid characters. Device Ids may only contain "
+            "alphanumeric characters and the following symbols: - . + % _ # * ? ! ( ) , : = @ $ '"
+        )
+    # '.' is a legal device Id character, so relative traversal segments must be rejected explicitly.
+    if device_id in (".", "..") or PurePath(device_id).name != device_id:
+        raise InvalidArgumentValueError(
+            f"Device Id '{device_id}' is invalid, it cannot be used as a directory or file name."
+        )
+    return device_id
 
 
 def create_edge_device_config(
@@ -416,6 +450,7 @@ def process_edge_devices_config_file_content(
             raise InvalidArgumentValueError(
                 "A device parameter is missing required attribute 'device_id'"
             )
+        validate_edge_device_id(device_id)
         deployment = device.get("deployment", None)
         if deployment:
             # relative path from config file to deployment.json
@@ -467,7 +502,7 @@ def create_edge_device_config_script(
     parent_hostname: Optional[str] = None,
 ):
     return "\n".join(
-        [EDGE_CONFIG_SCRIPT_HEADERS.format(device_id)]
+        [EDGE_CONFIG_SCRIPT_HEADERS.format(shlex.quote(device_id))]
         + ([EDGE_CONFIG_SCRIPT_HOSTNAME] if not hostname else [])
         + (
             [EDGE_CONFIG_SCRIPT_PARENT_HOSTNAME]
@@ -541,6 +576,7 @@ def process_edge_devices_config_args(
             raise InvalidArgumentValueError(
                 "A device argument is missing required parameter 'id'"
             )
+        validate_edge_device_id(device_id)
         if all_devices.get(device_id, None):
             raise InvalidArgumentValueError(
                 f"Duplicate deviceId '{device_id}' detected"

--- a/azext_iot/tests/iothub/devices/device_configs/invalid/traversal_device_id.yml
+++ b/azext_iot/tests/iothub/devices/device_configs/invalid/traversal_device_id.yml
@@ -1,0 +1,8 @@
+configVersion: "1.0"
+iotHub:
+  authenticationMethod: symmetricKey
+edgeConfiguration:
+  templateConfigPath: "./device_configs/device_config.toml"
+
+edgeDevices:
+  - deviceId: "../../evil_device"

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -1256,8 +1256,8 @@ class TestEdgeDeviceIdValidation:
             "device_1",
             "device-1.edge",
             "dev+ice%1#2*3?4!5(6)7,8:9=0@$'",
-            # shell metacharacters that are legal IoT Hub device Id characters -
-            # neutralized by quoting in the install script, not by rejection
+            # '$', '(' and ')' are legal IoT Hub device Id characters and are accepted here;
+            # neutralizing them in the generated install.sh is tracked separately
             "device$(whoami)",
             "d" * 128,
         ],
@@ -1301,12 +1301,6 @@ class TestEdgeDeviceIdValidation:
         assert _resolve_device_bundle_directory(bundle_root, "device_1") == bundle_root.joinpath(
             "device_1"
         )
-
-    def test_device_id_is_shell_quoted_in_script(self):
-        # '$', '(' and ')' are legal IoT Hub device Id characters, so command substitution
-        # must be neutralized by quoting rather than relying on character validation alone
-        script_content = create_edge_device_config_script(device_id="device$(whoami)")
-        assert "device_id='device$(whoami)'" in script_content
 
 
 class TestDevicesDelete:

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -34,7 +34,9 @@ from azext_iot.iothub.providers.helpers.edge_device_config import (
     process_edge_devices_config_file_content,
     create_edge_device_config,
     try_parse_valid_deployment_config,
+    validate_edge_device_id,
 )
+from azext_iot.iothub.providers.device_identity import _resolve_device_bundle_directory
 from azext_iot.iothub.common import (
     EdgeContainerAuth,
     EdgeDevicesConfig,
@@ -381,6 +383,12 @@ class TestHierarchyCreateFailures:
             (
                 None,
                 "device_configs/invalid/missing_device_id.yml",
+                InvalidArgumentValueError,
+            ),
+            # path traversal in device ID
+            (
+                None,
+                "device_configs/invalid/traversal_device_id.yml",
                 InvalidArgumentValueError,
             ),
             # devices AND config
@@ -1239,6 +1247,66 @@ class TestEdgeHierarchyConfigFunctions:
         )
 
         assert script_content == "\n".join(segments)
+
+
+class TestEdgeDeviceIdValidation:
+    @pytest.mark.parametrize(
+        "device_id",
+        [
+            "device_1",
+            "device-1.edge",
+            "dev+ice%1#2*3?4!5(6)7,8:9=0@$'",
+            # shell metacharacters that are legal IoT Hub device Id characters -
+            # neutralized by quoting in the install script, not by rejection
+            "device$(whoami)",
+            "d" * 128,
+        ],
+    )
+    def test_valid_device_ids(self, device_id):
+        assert validate_edge_device_id(device_id) == device_id
+
+    @pytest.mark.parametrize(
+        "device_id",
+        [
+            None,
+            "",
+            "..",
+            ".",
+            "../evil",
+            "..\\evil",
+            "sub/device",
+            "sub\\device",
+            "/absolute/device",
+            "C:/Windows/Temp",
+            'device"; rm -rf /; #',
+            "device`whoami`",
+            "device with spaces",
+            "d" * 129,
+        ],
+    )
+    def test_invalid_device_ids(self, device_id):
+        with pytest.raises(InvalidArgumentValueError):
+            validate_edge_device_id(device_id)
+
+    @pytest.mark.parametrize(
+        "device_id",
+        ["..", "../escape", "/absolute", "C:/Windows"],
+    )
+    def test_bundle_directory_traversal_blocked(self, device_id):
+        with pytest.raises(InvalidArgumentValueError):
+            _resolve_device_bundle_directory(PurePath(test_path).joinpath("bundle"), device_id)
+
+    def test_bundle_directory_contained(self):
+        bundle_root = PurePath(test_path).joinpath("bundle")
+        assert _resolve_device_bundle_directory(bundle_root, "device_1") == bundle_root.joinpath(
+            "device_1"
+        )
+
+    def test_device_id_is_shell_quoted_in_script(self):
+        # '$', '(' and ')' are legal IoT Hub device Id characters, so command substitution
+        # must be neutralized by quoting rather than relying on character validation alone
+        script_content = create_edge_device_config_script(device_id="device$(whoami)")
+        assert "device_id='device$(whoami)'" in script_content
 
 
 class TestDevicesDelete:


### PR DESCRIPTION
## Summary

Fixes a path traversal issue in `az iot edge devices create`, found during a security review of the repo.

Device Ids from `--cfg` config files and `--device` arguments were used verbatim as file system path segments when building device bundles:

```python
device_cert_output_directory = bundle_output_directory.joinpath(device_id)
if exists(device_cert_output_directory):
    rmtree(device_cert_output_directory)   # attacker-chosen path
```

`PurePath.joinpath` honors both relative traversal and absolute-path override, so a config entry such as `deviceId: "C:/Users/<user>/.ssh"` (or `../../..`) triggered `rmtree()` on that path. This happened *before* the IoT Hub `create_or_update_identity` call that would have rejected the illegal device Id, so the service was not a mitigating control. The same unvalidated value also drove certificate/`config.toml`/`install.sh` writes and the `tar_directory()` output path.

The trust boundary here is the config file, not the CLI invocation — nested edge config files are designed as shareable fleet-definition artifacts (see `docs/samples/sample_devices_config.yaml`), so an operator can be handed one authored elsewhere.

## Changes

- **`edge_device_config.py`** — new `validate_edge_device_id()` enforcing the IoT Hub allowed character set, the 128-character limit, and rejecting path separators / `.` / `..`. Wired into both parse paths (`_process_edge_config_device` and `process_edge_devices_config_args`).
- **`device_identity.py`** — new `_resolve_device_bundle_directory()` asserts the joined path resolves within the `--out` directory (defense in depth) before any `rmtree`/`makedirs`/write. This also prevents a symlinked device directory from redirecting `rmtree` outside the bundle root.
- Tests + a `traversal_device_id.yml` invalid-config fixture.

## Scope

Deliberately limited to the path traversal. The review that found this also flagged an unquoted `device_id` interpolation into the generated `install.sh` (which the bundled README instructs the operator to run under `sudo`). That is **shell injection, not path traversal**, and it is *not* fixed here — note that `$`, `(` and `)` are all legal IoT Hub device Id characters, so the character validation added in this PR does not close it. Being tracked separately.

Other lower-severity hardening items from the same review (private key file permissions, SAS token scope, CI workflow interpolation quoting) are likewise out of scope.

## Validation

`azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py` — 71 passed. `flake8` clean on the changed files.
