### PR TITLE
chore: add Azure IoT CLI maintainer agent and TypeSpec SDK skill

### DIFF
--- a/.github/agents/azure-iot-cli-maintainer.agent.md
+++ b/.github/agents/azure-iot-cli-maintainer.agent.md
@@ -1,0 +1,34 @@
+---
+name: azure-iot-cli-maintainer
+description: Maintain the Azure IoT CLI extension, including commands, tests, packaging, and generated control-plane and data-plane SDKs.
+---
+
+# Azure IoT CLI maintainer
+
+Work only in the `azure-iot-cli-extension` repository.
+
+## Responsibilities
+
+- Implement and maintain Azure IoT CLI commands, validators, providers, factories, help, tests, and packaging.
+- Maintain generated SDKs under `azext_iot/sdk` for IoT Hub, DPS, Digital Twins, Device Update, Device Registry,
+  and other supported services.
+- Use the `generate-typespec-sdk` skill for TypeSpec SDK generation or regeneration.
+- Follow existing repository naming, test, lint, and SDK integration patterns.
+
+## Working rules
+
+- Inspect existing implementations and history before changing behavior.
+- Preserve unrelated local changes and never overwrite a dirty generated SDK destination.
+- Keep generated SDK replacement separate from compatibility edits to factories, providers, commands, and tests unless
+  the user explicitly requests those edits.
+- For generated code, report client names, constructor changes, operation changes, API versions, endpoints, and likely
+  call-site incompatibilities.
+- Prefer focused unit tests before broader suites.
+- Never commit, push, publish, switch branches, or trigger release workflows unless explicitly requested.
+- Never modify the Azure IoT Operations CLI repository or `azext_edge` files.
+
+## Skill selection
+
+Use `generate-typespec-sdk` when the user asks to generate, regenerate, upgrade, or replace a Python SDK from an Azure
+TypeSpec specification.
+

--- a/.github/agents/azure-iot-cli-maintainer.agent.md
+++ b/.github/agents/azure-iot-cli-maintainer.agent.md
@@ -1,6 +1,7 @@
 ---
 name: azure-iot-cli-maintainer
 description: Maintain the Azure IoT CLI extension, including commands, tests, packaging, and generated control-plane and data-plane SDKs.
+tools: ["bash", "edit", "view"]
 ---
 
 # Azure IoT CLI maintainer
@@ -31,4 +32,3 @@ Work only in the `azure-iot-cli-extension` repository.
 
 Use `generate-typespec-sdk` when the user asks to generate, regenerate, upgrade, or replace a Python SDK from an Azure
 TypeSpec specification.
-

--- a/.github/skills/generate-typespec-sdk/SKILL.md
+++ b/.github/skills/generate-typespec-sdk/SKILL.md
@@ -63,8 +63,17 @@ For a GitHub repository/ref:
 
 For a GitHub pull request:
 
-1. Use `gh pr view` to resolve the PR's head repository, head ref, and exact head commit.
-2. Clone/export that exact commit into temporary storage. Do not rely on the PR base branch.
+1. Run `gh auth status` and confirm the authenticated account can access the source repository. Private repositories,
+   including `azure-rest-api-specs-pr`, require prior authentication.
+2. Parse the owner, repository, and pull-request number from the URL, then use the REST API to resolve the head
+   repository, head ref, and exact head commit:
+
+   ```shell
+   gh api repos/<owner>/<repo>/pulls/<number> \
+     --jq '{repository: .head.repo.full_name, ref: .head.ref, commit: .head.sha}'
+   ```
+
+3. Clone/export that exact commit into temporary storage. Do not rely on the PR base branch.
 
 Verify the TypeSpec directory and entrypoint exist in the exported source. Prefer `client.tsp`, because it commonly
 contains client naming and operation overrides. If only `main.tsp` is selected while `client.tsp` exists, stop and ask
@@ -112,12 +121,14 @@ If no compatible workspace exists, create:
 
 The hash must be derived from the exact package names and versions.
 
-Bootstrap it as follows:
+Bootstrap it as follows. Installing either tool changes the user's machine and requires explicit approval:
 
-1. If `nvm` is missing, inform the user and install it from the official `nvm-sh/nvm` installer.
+1. If `nvm` is missing, stop and ask for approval before installing it. Use an official installer URL pinned to an
+   explicit `nvm-sh/nvm` release tag, record the version, and never fetch a moving `install.sh`.
 2. Inspect the selected compiler's `engines.node` requirement, install/use a satisfying Node version, and write
    `.nvmrc`. TypeSpec compiler 1.12.0 and later requires Node 22 or newer.
-3. If `uv` is missing, inform the user and install it from Astral's official installer.
+3. If `uv` is missing, stop and ask for approval before installing it. Use Astral's official installer pinned to an
+   explicit `uv` release version and record the version.
 4. Create a minimal private `package.json` containing exact package versions.
 5. Run:
 
@@ -202,7 +213,8 @@ After all generation checks pass:
 3. Remove any `Zone.Identifier` files from the staged copy.
 4. Replace only the declared destination.
 5. If replacement or any validation step fails, restore the original destination exactly.
-6. Always remove temporary source, output, staging, and rollback storage.
+6. Remove temporary source, output, and staging storage when no longer needed, but retain rollback storage until all
+   integrated validation in section 8 succeeds.
 
 Do not modify another SDK directory.
 
@@ -214,12 +226,14 @@ Do not modify another SDK directory.
 4. Run:
 
    ```shell
-   python -m pytest -q azext_iot/tests/test_factory_unit.py
+   python -m pytest -q azext_iot/tests/utility/test_iot_utility_unit.py
    git diff --check
    ```
 
 5. Run focused service unit tests when they are discoverable and do not require live Azure resources.
 6. Show the final diff summary, toolchain/source provenance, API comparison, and compatibility warnings.
+7. After every validation step succeeds, remove rollback storage. If any validation step fails, restore the original
+   destination exactly before removing temporary storage and report the failure.
 
 Generated SDK files are excluded by the repository's Flake8 configuration. Run existing lint only for non-generated
 files if they were explicitly changed in a separate compatibility task.
@@ -236,7 +250,7 @@ TypeSpec directory:
 specification/iothub/resource-manager/Microsoft.Devices/IoTHub
 
 Entrypoint: client.tsp
-Workspace: /home/yuelinzhao/iothub-tsp
+Workspace: <path-to-typespec-workspace>
 Namespace: azext_iot.sdk.iothub.mgmt
 Client: IotHubClient
 Destination: azext_iot/sdk/iothub/mgmt

--- a/.github/skills/generate-typespec-sdk/SKILL.md
+++ b/.github/skills/generate-typespec-sdk/SKILL.md
@@ -97,7 +97,8 @@ An existing workspace is compatible only when:
 - it has the required Python emitter version;
 - `node_modules` is complete;
 - `uv` is available;
-- its Node version is supported by the selected compiler and is at least Node 22.
+- its Node version satisfies the selected compiler's `engines.node` requirement. TypeSpec compiler 1.12.0 and later
+  requires Node 22 or newer.
 
 If a workspace has `.nvmrc`, load `nvm` and run `nvm use`. Never trust the caller's active Node version.
 
@@ -114,7 +115,8 @@ The hash must be derived from the exact package names and versions.
 Bootstrap it as follows:
 
 1. If `nvm` is missing, inform the user and install it from the official `nvm-sh/nvm` installer.
-2. Install/use the Node version required by the selected toolchain, with Node 22 as the minimum, and write `.nvmrc`.
+2. Inspect the selected compiler's `engines.node` requirement, install/use a satisfying Node version, and write
+   `.nvmrc`. TypeSpec compiler 1.12.0 and later requires Node 22 or newer.
 3. If `uv` is missing, inform the user and install it from Astral's official installer.
 4. Create a minimal private `package.json` containing exact package versions.
 5. Run:
@@ -239,4 +241,3 @@ Namespace: azext_iot.sdk.iothub.mgmt
 Client: IotHubClient
 Destination: azext_iot/sdk/iothub/mgmt
 ```
-

--- a/.github/skills/generate-typespec-sdk/SKILL.md
+++ b/.github/skills/generate-typespec-sdk/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: generate-typespec-sdk
+description: Generate and safely replace a modeless synchronous Azure IoT Python SDK from a local or GitHub TypeSpec source.
+---
+
+# Generate a TypeSpec SDK
+
+Use this workflow for control-plane or data-plane SDKs under `azext_iot/sdk`, including IoT Hub, DPS, Digital Twins,
+Device Update, Device Registry, and future services.
+
+The workflow is instruction-driven. Do not add a generator helper to the repository.
+
+## Required inputs
+
+Collect these values before generation:
+
+- service and plane;
+- source as one of:
+  - local Git repository plus explicit branch, tag, or commit;
+  - GitHub repository plus explicit branch, tag, or commit;
+  - GitHub pull request URL;
+- TypeSpec source directory;
+- compile entrypoint, normally `client.tsp`;
+- Python namespace;
+- expected generated client class;
+- destination directory under `azext_iot/sdk`;
+- existing TypeSpec workspace path, if available;
+- explicit `@azure-tools/typespec-python` version only when neither the spec nor a compatible workspace supplies it.
+
+Normalize `\\wsl.localhost\Ubuntu\...` paths to Linux paths.
+
+Known control-plane mappings:
+
+| Service | Source directory | Entrypoint | Namespace | Client | Destination |
+| --- | --- | --- | --- | --- | --- |
+| IoT Hub | `specification/iothub/resource-manager/Microsoft.Devices/IoTHub` | `client.tsp` | `azext_iot.sdk.iothub.mgmt` | `IotHubClient` | `azext_iot/sdk/iothub/mgmt` |
+| DPS | `specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/ProvisioningService` | `client.tsp` | `azext_iot.sdk.dps.mgmt` | `IotDpsClient` | `azext_iot/sdk/dps/mgmt` |
+
+Do not guess data-plane mappings. Ask for explicit source directory, entrypoint, namespace, client, and destination.
+
+## 1. Protect the extension repository
+
+1. Confirm the current Git repository is `azure-iot-cli-extension`.
+2. Resolve the destination and ensure it is inside `azext_iot/sdk`.
+3. Inspect Git status for the destination.
+4. Refuse to proceed if tracked or untracked changes already exist inside the destination.
+5. Do not modify factories, providers, commands, tests, other SDKs, or packaging as part of generation.
+
+## 2. Resolve the exact source
+
+Never switch or modify an existing source worktree.
+
+For a local Git repository:
+
+1. Confirm the explicit ref resolves.
+2. Record the resolved commit.
+3. Export that commit into temporary storage with `git archive`.
+
+For a GitHub repository/ref:
+
+1. Resolve the ref to a commit.
+2. Use a temporary shallow, blob-filtered, sparse checkout containing the TypeSpec directory and root package files.
+
+For a GitHub pull request:
+
+1. Use `gh pr view` to resolve the PR's head repository, head ref, and exact head commit.
+2. Clone/export that exact commit into temporary storage. Do not rely on the PR base branch.
+
+Verify the TypeSpec directory and entrypoint exist in the exported source. Prefer `client.tsp`, because it commonly
+contains client naming and operation overrides. If only `main.tsp` is selected while `client.tsp` exists, stop and ask
+for confirmation.
+
+## 3. Resolve or create the toolchain workspace
+
+The selected spec revision is authoritative for TypeSpec compiler and Azure library versions.
+
+1. Read exact versions from its root `package.json` and lock file when available.
+2. Required packages normally include:
+   - `@typespec/compiler`;
+   - `@typespec/http`;
+   - `@typespec/rest`;
+   - `@typespec/versioning`;
+   - `@typespec/openapi`;
+   - `@azure-tools/typespec-azure-core`;
+   - `@azure-tools/typespec-azure-resource-manager` for ARM specs;
+   - `@azure-tools/typespec-azure-rulesets`;
+   - `@azure-tools/typespec-python`;
+   - any additional packages imported by the selected spec.
+3. If the spec does not pin `@azure-tools/typespec-python`, reuse the exact version from a compatible supplied
+   workspace. If none exists, ask for an explicit emitter version; never choose `latest`.
+
+### Reuse a workspace
+
+An existing workspace is compatible only when:
+
+- its installed compiler and imported TypeSpec package versions exactly match the selected spec revision;
+- it has the required Python emitter version;
+- `node_modules` is complete;
+- `uv` is available;
+- its Node version is supported by the selected compiler and is at least Node 22.
+
+If a workspace has `.nvmrc`, load `nvm` and run `nvm use`. Never trust the caller's active Node version.
+
+### Create a workspace
+
+If no compatible workspace exists, create:
+
+```text
+~/.cache/azure-iot-cli/typespec-sdk/<toolchain-hash>
+```
+
+The hash must be derived from the exact package names and versions.
+
+Bootstrap it as follows:
+
+1. If `nvm` is missing, inform the user and install it from the official `nvm-sh/nvm` installer.
+2. Install/use the Node version required by the selected toolchain, with Node 22 as the minimum, and write `.nvmrc`.
+3. If `uv` is missing, inform the user and install it from Astral's official installer.
+4. Create a minimal private `package.json` containing exact package versions.
+5. Run:
+
+   ```shell
+   npm install --registry=https://registry.npmjs.org/
+   ```
+
+6. Verify the local compiler and emitter versions.
+
+Do not use global TypeSpec packages. Do not use `npx`. Do not run or recreate the obsolete modeless emitter patch.
+
+## 4. Generate in temporary storage
+
+Copy the exported TypeSpec directory into temporary working storage if needed so generation cannot modify the source.
+Set `$HOME/.local/bin` on `PATH` for `uv`.
+
+Run the workspace-local compiler:
+
+```shell
+node <workspace>/node_modules/@typespec/compiler/cmd/tsp.js compile <source>/<entrypoint> \
+  --emit @azure-tools/typespec-python \
+  --option "@azure-tools/typespec-python.models-mode=none" \
+  --option "@azure-tools/typespec-python.no-async=true" \
+  --option "@azure-tools/typespec-python.namespace=<namespace>" \
+  --option "@azure-tools/typespec-python.emitter-output-dir=<temp-output>"
+```
+
+Use emitter options from the selected spec's `tspconfig.yaml` when they are required for correctness, but the four
+options above are mandatory and take precedence for extension integration.
+
+Warnings may be reported, but any compiler or emitter error stops the workflow.
+
+## 5. Verify generated output
+
+Before touching the extension repository, assert:
+
+- the expected namespace directory exists;
+- the expected client class is exported by the package;
+- no `models/` directory exists;
+- no `aio/` directory exists;
+- operation methods use synchronous definitions;
+- generated Python files compile;
+- no `Zone.Identifier` files remain;
+- no output was written outside temporary storage.
+
+Record:
+
+- source repository, ref/PR, and exact commit;
+- TypeSpec directory and entrypoint;
+- Node, compiler, emitter, and imported library versions;
+- namespace, client class, destination, and generated SDK version.
+
+## 6. Compare and report compatibility
+
+Compare the generated directory with the existing destination before replacement. Report:
+
+- files added, removed, and changed;
+- client and configuration constructor parameter changes;
+- operation groups added or removed;
+- operation method additions, removals, and signature changes;
+- default API-version and endpoint/base-URL changes;
+- generated package version changes;
+- imports and extension call sites that may become incompatible.
+
+Pay particular attention to:
+
+- expected client-class renames caused by compiling `main.tsp` instead of `client.tsp`;
+- `endpoint` versus `base_url`;
+- required constructor parameters;
+- renamed operation groups or methods;
+- changes between pageable and non-pageable operations.
+
+This report does not block replacement when generation checks pass, but compatibility warnings must be prominent.
+Do not edit call sites automatically.
+
+## 7. Replace automatically with rollback
+
+After all generation checks pass:
+
+1. Copy the current destination to temporary rollback storage.
+2. Stage the generated namespace directory beside the destination.
+3. Remove any `Zone.Identifier` files from the staged copy.
+4. Replace only the declared destination.
+5. If replacement or any validation step fails, restore the original destination exactly.
+6. Always remove temporary source, output, staging, and rollback storage.
+
+Do not modify another SDK directory.
+
+## 8. Validate the integrated SDK
+
+1. Compile every generated Python file.
+2. Import the expected client from the destination namespace.
+3. Reconfirm modeless and synchronous output.
+4. Run:
+
+   ```shell
+   python -m pytest -q azext_iot/tests/test_factory_unit.py
+   git diff --check
+   ```
+
+5. Run focused service unit tests when they are discoverable and do not require live Azure resources.
+6. Show the final diff summary, toolchain/source provenance, API comparison, and compatibility warnings.
+
+Generated SDK files are excluded by the repository's Flake8 configuration. Run existing lint only for non-generated
+files if they were explicitly changed in a separate compatibility task.
+
+Never commit, push, publish, switch the extension branch, or trigger a workflow.
+
+## IoT Hub PR example
+
+```text
+Generate the IoT Hub control-plane SDK from:
+https://github.com/Azure/azure-rest-api-specs-pr/pull/28915
+
+TypeSpec directory:
+specification/iothub/resource-manager/Microsoft.Devices/IoTHub
+
+Entrypoint: client.tsp
+Workspace: /home/yuelinzhao/iothub-tsp
+Namespace: azext_iot.sdk.iothub.mgmt
+Client: IotHubClient
+Destination: azext_iot/sdk/iothub/mgmt
+```
+


### PR DESCRIPTION
## Summary

- Add a repository-local `azure-iot-cli-maintainer` Copilot agent.
- Add the `generate-typespec-sdk` skill.
- Support modeless, synchronous TypeSpec SDK generation for control-plane and data-plane services.
- Support IoT Hub, DPS, and future Azure IoT services through configurable source, namespace, client, and destination inputs.

<img width="1054" height="389" alt="image" src="https://github.com/user-attachments/assets/04421a8f-3698-49fb-96f9-97d97d5e820e" />
<img width="2000" height="611" alt="image" src="https://github.com/user-attachments/assets/638fbb2f-5c01-49ab-b953-0a78b35b9651" />

