### PR TITLE
fix: backfill hostName on dps linked hub update 

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ===============
 
+0.32.0b2 (Preview)
+++++++++++++++++++
+
+**DPS bug fixes**
+
+* ``az iot dps linked-hub update`` no longer fails with ``(400309) hostName is required when connectionString is not provided`` when switching a pre-existing linked hub to ``SystemAssigned`` or ``UserAssigned`` authentication.
+
+* ``az iot dps linked-hub update --authentication-type KeyBased`` no longer raises ``KeyError: 'hostName'`` when refreshing the key of, or switching back to, one of those same links.
+
 0.32.0b1 (Preview)
 ++++++++++++++++++
 

--- a/azext_iot/constants.py
+++ b/azext_iot/constants.py
@@ -7,7 +7,7 @@
 
 import os
 
-VERSION = "0.32.0b1"
+VERSION = "0.32.0b2"
 EXTENSION_NAME = "azure-iot"
 EXTENSION_ROOT = os.path.dirname(os.path.abspath(__file__))
 EXTENSION_CONFIG_ROOT_KEY = "iotext"

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -99,6 +99,13 @@ def _resolve_linked_hub_hostname(hub, hostname_type="auto"):
     return device_hostname or hub["properties"]["hostName"]
 
 
+def _ensure_linked_hub_hostnames(linked_hubs):
+    for entry in linked_hubs or []:
+        if not entry.get("hostName") and entry.get("name"):
+            entry["hostName"] = entry["name"]
+    return linked_hubs
+
+
 def _warn_mixed_endpoint_types(linked_hubs):
     """Warn if DPS dynamic allocation references hubs with mixed hostname types."""
     types = set()
@@ -600,6 +607,7 @@ def iot_dps_linked_hub_update(
     resource_group_name = _ensure_dps_resource_group_name(client, resource_group_name, dps_name)
     dps = iot_dps_get(client, dps_name, resource_group_name)
     linked_hubs = dps["properties"]["iotHubs"]
+    _ensure_linked_hub_hostnames(linked_hubs)
     target_entry = _find_linked_hub_entry(linked_hubs, hub_name=hub_name, linked_hub=linked_hub)
 
     if is_mi:

--- a/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_linked_hub_unit.py
@@ -494,3 +494,72 @@ class TestLinkedHubUpdate:
             user_assigned_identity=uami_new,
         )
         assert ua_entries[0]["selectedUserAssignedIdentityResourceId"] == uami_new
+
+
+class TestLegacyLinkedHubHostNameBackfill:
+    @pytest.fixture
+    def legacy_entries(self):
+        return [
+            {
+                "name": "myhub.azure-devices.net",
+                "authenticationType": "KeyBased",
+                "connectionString": (
+                    "HostName=myhub.azure-devices.net;"
+                    "SharedAccessKeyName=iothubowner;SharedAccessKey=existing-key"
+                ),
+                "location": "eastus2euap",
+            }
+        ]
+
+    @pytest.fixture
+    def mock_deps(self, mocker, legacy_entries):
+        mocker.patch("azext_iot.core.custom.iot_hub_service_factory")
+        mocker.patch("azext_iot.core.custom.iot_hub_get", return_value={
+            "name": "myhub",
+            "properties": {
+                "deviceHostName": "myhub.device.azure-devices.net",
+                "hostName": "myhub.azure-devices.net",
+            },
+            "location": "eastus2euap",
+            "resourcegroup": "test-rg",
+        })
+        mocker.patch("azext_iot.core.custom.iot_hub_policy_get", return_value={
+            "keyName": "iothubowner", "primaryKey": "fresh-key"
+        })
+        mocker.patch("azext_iot.core.custom._ensure_dps_resource_group_name", return_value="test-rg")
+        mocker.patch("azext_iot.core.custom.iot_dps_get", return_value={
+            "identity": {"type": "SystemAssigned,UserAssigned"},
+            "properties": {"iotHubs": legacy_entries},
+        })
+        mocker.patch("azext_iot.core.custom.LongRunningOperation")
+        mocker.patch("azext_iot.core.custom.iot_dps_linked_hub_get", side_effect=lambda *a, **kw: legacy_entries[0])
+        mock_client = mocker.MagicMock()
+        mock_client.iot_dps_resource.begin_create_or_update.return_value = mocker.MagicMock()
+        return mock_client
+
+    def test_legacy_switch_to_managed_identity_sets_hostname(
+        self, fixture_cmd, mock_deps, legacy_entries
+    ):
+        """Switching to managed identity clears connectionString, so hostName must be
+        backfilled or the service rejects the PUT with 400309."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", authentication_type="SystemAssigned",
+        )
+        entry = legacy_entries[0]
+        assert entry["connectionString"] == ""
+        assert entry["hostName"] == "myhub.azure-devices.net"
+
+    def test_legacy_key_refresh_does_not_raise_keyerror(
+        self, fixture_cmd, mock_deps, legacy_entries
+    ):
+        """The connection-string rebuild path reads hostName directly."""
+        from azext_iot.core.custom import iot_dps_linked_hub_update
+        iot_dps_linked_hub_update(
+            cmd=fixture_cmd, client=mock_deps, dps_name="dps",
+            hub_name="myhub", authentication_type="KeyBased",
+        )
+        entry = legacy_entries[0]
+        assert entry["hostName"] == "myhub.azure-devices.net"
+        assert "fresh-key" in entry["connectionString"]


### PR DESCRIPTION
## Problem

Before:
<img width="2048" height="373" alt="image" src="https://github.com/user-attachments/assets/0d69981c-0ae4-47df-acd0-5a0c072cb9ab" />
After:
<img width="2037" height="442" alt="image" src="https://github.com/user-attachments/assets/2d06e44a-5475-4664-a7a5-8725531a0aa7" />


`az iot dps linked-hub update` fails on existing linked hub whose stored entry has no `hostName`  - links created by extension version earlier than preview version.

- `--auth-type SystemAssigned | UserAssigned` -> `(400309) hostName is required when connectionString is not provided`
- `--auth-type KeyBased` (key refresh / switch back) -> unhandled `KeyError: 'hostName'`

Old links have no `hostName` saved - the service returns the hostname in `name` instead.
Switching a link to managed identity clears its connection string. That leaves the link with no connection string and no `hostName`, and the service requires one of the two.

## Fix
Backfill `hostName` from `name` for each linked hub before submitting the resource

`create` and `delete` are unaffected, since each stored entry already satisfies the service requirements independently: KeyBased entries always include a connection string, and MI entries always include `hostName`. Those paths simply re-PUT the unmodified existing entries.
