### PR TITLE
feat: add --disable-local-auth to az iot dps create/update

### DIFF
--- a/azext_iot/__init__.py
+++ b/azext_iot/__init__.py
@@ -9,6 +9,9 @@ from azure.cli.core.commands import CliCommandType
 from azext_iot.constants import VERSION
 import azext_iot._help  # noqa: F401
 
+from azext_iot.core.command_map import load_core_commands
+from azext_iot.core.params import load_core_arguments
+
 
 iothub_ops = CliCommandType(operations_tmpl="azext_iot.operations.hub#{}")
 iotdps_ops = CliCommandType(operations_tmpl="azext_iot.operations.dps#{}")
@@ -33,6 +36,8 @@ class IoTExtCommandsLoader(AzCommandsLoader):
         load_digitaltwins_commands(self, args)
         load_dps_commands(self, args)
 
+        load_core_commands(self, args)
+
         return self.command_table
 
     def load_arguments(self, command):
@@ -49,6 +54,8 @@ class IoTExtCommandsLoader(AzCommandsLoader):
         load_digitaltwins_arguments(self, command)
         load_dps_arguments(self, command)
         load_deviceupdate_arguments(self, command)
+
+        load_core_arguments(self, command)
 
 
 COMMAND_LOADER_CLS = IoTExtCommandsLoader

--- a/azext_iot/_factory.py
+++ b/azext_iot/_factory.py
@@ -23,6 +23,8 @@ __all__ = [
     "CloudError",
     "iot_hub_service_factory",
     "iot_service_provisioning_factory",
+    "iot_dps_resource_factory",
+    "resource_service_factory",
 ]
 
 
@@ -60,6 +62,32 @@ def iot_service_provisioning_factory(cli_ctx, *_):
     from azure.cli.core.profiles import ResourceType
 
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_IOTDPS)
+
+
+def iot_dps_resource_factory(cli_ctx, *_):
+    """
+    Factory for the provisioning service control plane client backed by the vendored SDK.
+
+    Args:
+        cli_ctx (knack.cli.CLI): CLI context.
+        *_ : all other args ignored.
+
+    Returns:
+        service_client (IotDpsClient): control plane resource for
+            working with IoT Hub Device Provisioning Service.
+    """
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+
+    from azext_iot.sdk.dps.mgmt import IotDpsClient
+
+    return get_mgmt_service_client(cli_ctx, IotDpsClient)
+
+
+def resource_service_factory(cli_ctx, **_):
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    from azure.cli.core.profiles import ResourceType
+
+    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
 
 
 class SdkResolver(object):

--- a/azext_iot/azext_metadata.json
+++ b/azext_iot/azext_metadata.json
@@ -1,4 +1,4 @@
 {
-    "azext.minCliCoreVersion": "2.67.0",
+    "azext.minCliCoreVersion": "2.73.0",
     "azext.isPreview": false
 }

--- a/azext_iot/core/_params.py
+++ b/azext_iot/core/_params.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from knack.arguments import CLIArgumentType
+from azure.cli.core.commands.parameters import (get_location_type,
+                                                get_resource_name_completion_list,
+                                                get_enum_type,
+                                                get_three_state_flag,
+                                                tags_type)
+
+from .shared import IotDpsSku
+
+
+dps_name_type = CLIArgumentType(
+    options_list=['--name', '-n'],
+    completer=get_resource_name_completion_list('Microsoft.Devices/ProvisioningServices'),
+    help='IoT Hub Device Provisioning Service name')
+
+
+def load_arguments(self, _):
+    # Arguments for IoT DPS
+    with self.argument_context('iot dps') as c:
+        c.argument('tags', tags_type)
+
+    # Direct DPS resource commands use --name -n
+    for subgroup in ['create', 'update', 'show', 'delete']:
+        with self.argument_context('iot dps {}'.format(subgroup)) as c:
+            c.argument('dps_name', dps_name_type, id_part='name')
+
+    with self.argument_context('iot dps create') as c:
+        c.argument('location', get_location_type(self.cli_ctx),
+                   help='Location of your IoT Hub Device Provisioning Service. '
+                   'Default is the location of target resource group.')
+        c.argument('sku', arg_type=get_enum_type(IotDpsSku),
+                   help='Pricing tier for the IoT Hub Device Provisioning Service.')
+        c.argument('unit', help='Units in your IoT Hub Device Provisioning Service.', type=int)
+        c.argument('enable_data_residency', arg_type=get_three_state_flag(),
+                   options_list=['--enforce-data-residency', '--edr'],
+                   help='Enforce data residency for this IoT Hub Device Provisioning Service by disabling '
+                   'cross geo-pair disaster recovery. This property is immutable once set on the resource. '
+                   'Only available in select regions. Learn more at https://aka.ms/dpsdr')

--- a/azext_iot/core/command_map.py
+++ b/azext_iot/core/command_map.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Load CLI commands
+"""
+
+from azure.cli.core.commands import CliCommandType
+
+from azext_iot._factory import iot_dps_resource_factory
+
+core_ops = CliCommandType(operations_tmpl="azext_iot.core.custom#{}")
+
+
+def load_core_commands(self, _):
+    """
+    Load CLI commands
+    """
+    # iot dps commands
+    with self.command_group(
+        "iot dps", command_type=core_ops, client_factory=iot_dps_resource_factory
+    ) as cmd_group:
+        cmd_group.command("create", "iot_dps_create")
+        cmd_group.generic_update_command(
+            "update",
+            getter_name="iot_dps_get",
+            setter_name="iot_dps_update",
+            custom_func_type=core_ops,
+        )
+        cmd_group.show_command("show", "iot_dps_get")

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.azclierror import (
+    BadRequestError,
+    CLIInternalError,
+)
+
+from azext_iot._factory import resource_service_factory
+from azext_iot.core.shared import IotDpsSku
+
+
+def iot_dps_get(client, dps_name, resource_group_name=None):
+    if resource_group_name is None:
+        return _get_iot_dps_by_name(client, dps_name, resource_group_name)
+    return client.iot_dps_resource.get(provisioning_service_name=dps_name, resource_group_name=resource_group_name)
+
+
+def iot_dps_create(
+    cmd,
+    client,
+    dps_name,
+    resource_group_name,
+    location=None,
+    sku=IotDpsSku.S1.value,
+    unit=1,
+    tags=None,
+    enable_data_residency=None,
+    disable_local_auth=None,
+):
+    cli_ctx = cmd.cli_ctx
+    _check_dps_name_availability(client.iot_dps_resource, dps_name)
+    location = _ensure_location(cli_ctx, resource_group_name, location)
+    dps_property = {"enableDataResidency": enable_data_residency}
+
+    if disable_local_auth is not None:
+        dps_property["disableLocalAuth"] = disable_local_auth
+
+    dps_description = {
+        "location": location,
+        "properties": dps_property,
+        "sku": {"name": sku, "capacity": unit},
+        "tags": tags,
+    }
+
+    return client.iot_dps_resource.begin_create_or_update(
+        resource_group_name=resource_group_name, provisioning_service_name=dps_name,
+        iot_dps_description=dps_description
+    )
+
+
+def iot_dps_update(
+    client,
+    dps_name,
+    parameters,
+    resource_group_name=None,
+    tags=None,
+    disable_local_auth=None,
+):
+    resource_group_name = _ensure_dps_resource_group_name(client, resource_group_name, dps_name)
+    if tags is not None:
+        parameters["tags"] = tags
+
+    if disable_local_auth is not None:
+        parameters["properties"]["disableLocalAuth"] = disable_local_auth
+
+    return client.iot_dps_resource.begin_create_or_update(
+        resource_group_name=resource_group_name, provisioning_service_name=dps_name, iot_dps_description=parameters
+    )
+
+
+def iot_dps_list(client, resource_group_name=None):
+    if resource_group_name is None:
+        return client.iot_dps_resource.list_by_subscription()
+    return client.iot_dps_resource.list_by_resource_group(resource_group_name)
+
+
+def _get_iot_dps_by_name(client, dps_name, resource_group=None):
+    all_dps = iot_dps_list(client, resource_group)
+    if all_dps is None:
+        raise CLIInternalError("No DPS found in current subscription.")
+    try:
+        target_dps = next(x for x in all_dps if dps_name.lower() == x["name"].lower())
+    except StopIteration:
+        raise CLIInternalError("No DPS found with name {} in current subscription.".format(dps_name))
+    return target_dps
+
+
+def _ensure_dps_resource_group_name(client, resource_group_name, dps_name):
+    if resource_group_name is None:
+        return _get_iot_dps_by_name(client, dps_name)["resourcegroup"]
+    return resource_group_name
+
+
+def _check_dps_name_availability(iot_dps_resource, dps_name):
+    name_availability = iot_dps_resource.check_provisioning_service_name_availability({"name": dps_name})
+    if name_availability is not None and not name_availability["nameAvailable"]:
+        raise BadRequestError(name_availability["message"])
+
+
+def _ensure_location(cli_ctx, resource_group_name, location):
+    """Check to see if a location was provided. If not,
+        fall back to the resource group location.
+    :param object cli_ctx: CLI Context
+    :param str resource_group_name: Resource group name
+    :param str location: Location to create the resource
+    """
+    if location is None:
+        resource_group_client = resource_service_factory(cli_ctx).resource_groups
+        return resource_group_client.get(resource_group_name).location
+    return location

--- a/azext_iot/core/custom.py
+++ b/azext_iot/core/custom.py
@@ -34,7 +34,9 @@ def iot_dps_create(
     cli_ctx = cmd.cli_ctx
     _check_dps_name_availability(client.iot_dps_resource, dps_name)
     location = _ensure_location(cli_ctx, resource_group_name, location)
-    dps_property = {"enableDataResidency": enable_data_residency}
+    dps_property = {}
+    if enable_data_residency is not None:
+        dps_property["enableDataResidency"] = enable_data_residency
 
     if disable_local_auth is not None:
         dps_property["disableLocalAuth"] = disable_local_auth
@@ -43,8 +45,10 @@ def iot_dps_create(
         "location": location,
         "properties": dps_property,
         "sku": {"name": sku, "capacity": unit},
-        "tags": tags,
     }
+
+    if tags is not None:
+        dps_description["tags"] = tags
 
     return client.iot_dps_resource.begin_create_or_update(
         resource_group_name=resource_group_name, provisioning_service_name=dps_name,

--- a/azext_iot/core/help.py
+++ b/azext_iot/core/help.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+"""
+Help updates for CLI core commands.
+"""
+
+from knack.help_files import helps
+
+
+def patch_core_help():
+
+    # add DPS create example for local authentication
+    if "iot dps create" in helps:
+        helps[
+            "iot dps create"
+        ] += """
+  - name: Create an Azure IoT Hub Device Provisioning Service with SAS key (local) authentication disabled, requiring Azure RBAC
+    text: >
+        az iot dps create --name MyDps --resource-group MyResourceGroup --disable-local-auth
+"""
+
+    # add DPS update example for local authentication
+    if "iot dps update" in helps:
+        helps[
+            "iot dps update"
+        ] += """
+  - name: Disable SAS key (local) authentication on an existing Device Provisioning Service, requiring Azure RBAC
+    text: >
+        az iot dps update --name MyDps --resource-group MyResourceGroup --disable-local-auth
+"""

--- a/azext_iot/core/params.py
+++ b/azext_iot/core/params.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Parameter definitions for new DPS management commands.
+These will be added to CLI Core
+"""
+
+from azure.cli.core.commands.parameters import get_three_state_flag
+
+from azext_iot.core._params import load_arguments
+
+
+def load_core_arguments(self, _):
+
+    # load default CLI Core args
+    load_arguments(self, _)
+
+    # DPS local authentication params
+    for scope in ["iot dps create", "iot dps update"]:
+        with self.argument_context(scope) as c:
+            c.argument(
+                "disable_local_auth",
+                arg_type=get_three_state_flag(),
+                options_list=["--disable-local-auth", "--dla"],
+                help="A boolean indicating whether or not to disable SAS key (shared access policy) "
+                "authentication for this provisioning service. When disabled, only Azure RBAC is "
+                "used to authorize data plane requests.",
+            )

--- a/azext_iot/core/shared.py
+++ b/azext_iot/core/shared.py
@@ -4,6 +4,15 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from .help import patch_core_help
+"""
+shared: Define shared data types(enums).
 
-patch_core_help()
+"""
+
+from enum import Enum
+
+
+class IotDpsSku(Enum):
+    """DPS SKU name."""
+
+    S1 = "S1"

--- a/azext_iot/tests/dps/core/test_dps_disable_local_auth_int.py
+++ b/azext_iot/tests/dps/core/test_dps_disable_local_auth_int.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+
+from azext_iot.common.embedded_cli import EmbeddedCLI
+from azext_iot.common.shared import AuthenticationTypeDataplane
+from azext_iot.tests.dps import DATAPLANE_AUTH_TYPES
+from azext_iot.tests.dps.conftest import ENTITY_RG, generate_dps_id
+from azext_iot.tests.helpers import set_cmd_auth_type
+
+cli = EmbeddedCLI()
+
+
+@pytest.fixture
+def created_dps_name():
+    name = generate_dps_id()
+    yield name
+    cli.invoke(f"iot dps delete --name {name} --resource-group {ENTITY_RG}")
+
+
+def test_dps_create_disable_local_auth(created_dps_name):
+    dps = cli.invoke(
+        f"iot dps create --name {created_dps_name} --resource-group {ENTITY_RG} --disable-local-auth true"
+    ).as_json()
+    assert dps["properties"]["disableLocalAuth"] is True
+
+    dps = cli.invoke(
+        f"iot dps show --name {created_dps_name} --resource-group {ENTITY_RG}"
+    ).as_json()
+    assert dps["properties"]["disableLocalAuth"] is True
+
+
+def test_dps_update_disable_local_auth(provisioned_iot_dps_no_hub_module):
+    dps_name = provisioned_iot_dps_no_hub_module["name"]
+    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+
+    # The property is absent until explicitly set.
+    dps = cli.invoke(f"iot dps show --name {dps_name} --resource-group {dps_rg}").as_json()
+    assert dps["properties"].get("disableLocalAuth") is not True
+
+    dps = cli.invoke(
+        f"iot dps update --name {dps_name} --resource-group {dps_rg} --disable-local-auth true"
+    ).as_json()
+    assert dps["properties"]["disableLocalAuth"] is True
+
+    # An unrelated generic update must not reset the setting.
+    dps = cli.invoke(
+        f"iot dps update --name {dps_name} --resource-group {dps_rg} --tags testtag=value"
+    ).as_json()
+    assert dps["properties"]["disableLocalAuth"] is True
+    assert dps["tags"]["testtag"] == "value"
+
+    dps = cli.invoke(
+        f"iot dps update --name {dps_name} --resource-group {dps_rg} --disable-local-auth false"
+    ).as_json()
+    assert dps["properties"]["disableLocalAuth"] is False
+
+
+def test_dps_disable_local_auth_dataplane(provisioned_iot_dps_no_hub_module):
+    dps_name = provisioned_iot_dps_no_hub_module["name"]
+    dps_rg = provisioned_iot_dps_no_hub_module["resourceGroup"]
+    dps_cstring = provisioned_iot_dps_no_hub_module["connectionString"]
+    enrollment_list = f"iot dps enrollment list --dps-name {dps_name} -g {dps_rg}"
+
+    for auth_phase in DATAPLANE_AUTH_TYPES:
+        assert cli.invoke(
+            set_cmd_auth_type(enrollment_list, auth_type=auth_phase, cstring=dps_cstring)
+        ).success()
+
+    cli.invoke(
+        f"iot dps update --name {dps_name} --resource-group {dps_rg} --disable-local-auth true"
+    )
+
+    # Only auth type login is allowed.
+    for auth_phase in DATAPLANE_AUTH_TYPES:
+        assert cli.invoke(
+            set_cmd_auth_type(enrollment_list, auth_type=auth_phase, cstring=dps_cstring)
+        ).success() is (auth_phase == AuthenticationTypeDataplane.login.value)
+
+    cli.invoke(
+        f"iot dps update --name {dps_name} --resource-group {dps_rg} --disable-local-auth false"
+    )
+
+    for auth_phase in DATAPLANE_AUTH_TYPES:
+        assert cli.invoke(
+            set_cmd_auth_type(enrollment_list, auth_type=auth_phase, cstring=dps_cstring)
+        ).success()

--- a/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
@@ -52,6 +52,44 @@ class TestDPSCreate(object):
         )
 
     @patch("azext_iot.core.custom._ensure_location")
+    def test_dps_create_omits_unset_optionals(self, mock_ensure_location):
+        """The body is raw JSON with no serializer, so unset optionals must be omitted, not sent as null."""
+        mock_ensure_location.return_value = location
+        mock_client = Mock()
+        mock_client.iot_dps_resource.check_provisioning_service_name_availability.return_value = {
+            "nameAvailable": True
+        }
+
+        iot_dps_create(Mock(), mock_client, dps_name, resource_group)
+
+        description = _get_sent_description(mock_client)
+        assert description["properties"] == {}
+        assert "tags" not in description
+
+    @patch("azext_iot.core.custom._ensure_location")
+    def test_dps_create_sends_supplied_optionals(self, mock_ensure_location):
+        """Optionals the user does supply must reach the body."""
+        mock_ensure_location.return_value = location
+        mock_client = Mock()
+        mock_client.iot_dps_resource.check_provisioning_service_name_availability.return_value = {
+            "nameAvailable": True
+        }
+
+        iot_dps_create(
+            Mock(),
+            mock_client,
+            dps_name,
+            resource_group,
+            tags={"a": "b"},
+            enable_data_residency=True,
+            disable_local_auth=True,
+        )
+
+        description = _get_sent_description(mock_client)
+        assert description["properties"] == {"enableDataResidency": True, "disableLocalAuth": True}
+        assert description["tags"] == {"a": "b"}
+
+    @patch("azext_iot.core.custom._ensure_location")
     def test_dps_create_name_unavailable(self, mock_ensure_location):
         mock_ensure_location.return_value = location
         mock_client = Mock()

--- a/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
+++ b/azext_iot/tests/dps/core/test_dps_disable_local_auth_unit.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import pytest
+from unittest.mock import Mock, patch
+from azure.cli.core.azclierror import BadRequestError
+
+from azext_iot.core.custom import iot_dps_create, iot_dps_get, iot_dps_update
+from azext_iot.tests.generators import generate_generic_id
+
+# Test constants
+dps_name = generate_generic_id()
+resource_group = generate_generic_id()
+location = "westus2"
+
+
+def _get_sent_description(mock_client):
+    return mock_client.iot_dps_resource.begin_create_or_update.call_args.kwargs["iot_dps_description"]
+
+
+class TestDPSCreate(object):
+    @pytest.mark.parametrize("disable_local_auth", [None, True, False])
+    @patch("azext_iot.core.custom._ensure_location")
+    def test_dps_create(self, mock_ensure_location, disable_local_auth):
+        """--disable-local-auth is sent only when the user provides it."""
+        mock_ensure_location.return_value = location
+        mock_client = Mock()
+        mock_client.iot_dps_resource.check_provisioning_service_name_availability.return_value = {
+            "nameAvailable": True
+        }
+
+        iot_dps_create(
+            Mock(), mock_client, dps_name, resource_group, disable_local_auth=disable_local_auth
+        )
+
+        description = _get_sent_description(mock_client)
+        if disable_local_auth is None:
+            assert "disableLocalAuth" not in description["properties"]
+        else:
+            assert description["properties"]["disableLocalAuth"] is disable_local_auth
+
+        # Takeover must keep core's defaults.
+        assert description["location"] == location
+        assert description["sku"] == {"name": "S1", "capacity": 1}
+        mock_client.iot_dps_resource.begin_create_or_update.assert_called_once_with(
+            resource_group_name=resource_group,
+            provisioning_service_name=dps_name,
+            iot_dps_description=description,
+        )
+
+    @patch("azext_iot.core.custom._ensure_location")
+    def test_dps_create_name_unavailable(self, mock_ensure_location):
+        mock_ensure_location.return_value = location
+        mock_client = Mock()
+        mock_client.iot_dps_resource.check_provisioning_service_name_availability.return_value = {
+            "nameAvailable": False,
+            "message": "name taken",
+        }
+
+        with pytest.raises(BadRequestError):
+            iot_dps_create(Mock(), mock_client, dps_name, resource_group)
+
+        mock_client.iot_dps_resource.begin_create_or_update.assert_not_called()
+
+
+class TestDPSUpdate(object):
+    @pytest.mark.parametrize("disable_local_auth", [None, True, False])
+    def test_dps_update(self, disable_local_auth):
+        """Omitting --disable-local-auth must leave the existing value untouched."""
+        mock_client = Mock()
+        parameters = {"properties": {"disableLocalAuth": True}}
+
+        iot_dps_update(
+            mock_client, dps_name, parameters, resource_group, disable_local_auth=disable_local_auth
+        )
+
+        description = _get_sent_description(mock_client)
+        expected = True if disable_local_auth is None else disable_local_auth
+        assert description["properties"]["disableLocalAuth"] is expected
+
+        # begin_update only accepts tags, so updates go through create_or_update.
+        mock_client.iot_dps_resource.begin_update.assert_not_called()
+        mock_client.iot_dps_resource.begin_create_or_update.assert_called_once()
+
+    def test_dps_update_resolves_resource_group(self):
+        mock_client = Mock()
+        mock_client.iot_dps_resource.list_by_subscription.return_value = [
+            {"name": dps_name, "resourcegroup": resource_group}
+        ]
+
+        iot_dps_update(mock_client, dps_name, {"properties": {}})
+
+        call_kwargs = mock_client.iot_dps_resource.begin_create_or_update.call_args.kwargs
+        assert call_kwargs["resource_group_name"] == resource_group
+
+
+class TestDPSGet(object):
+    def test_dps_get(self):
+        """Getter backs both show and generic update, so arguments must not swap."""
+        mock_client = Mock()
+
+        iot_dps_get(mock_client, dps_name, resource_group)
+
+        mock_client.iot_dps_resource.get.assert_called_once_with(
+            provisioning_service_name=dps_name, resource_group_name=resource_group
+        )
+
+    def test_dps_get_without_resource_group(self):
+        mock_client = Mock()
+        mock_client.iot_dps_resource.list_by_subscription.return_value = [
+            {"name": dps_name, "resourcegroup": resource_group}
+        ]
+
+        assert iot_dps_get(mock_client, dps_name)["resourcegroup"] == resource_group
+        mock_client.iot_dps_resource.get.assert_not_called()

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ if not PACKAGE_NAME:
 # and azure-eventhub for telemetry monitoring.
 
 DEPENDENCIES = [
-    "azure-core>=1.24.0,<2.0.0",
-    "azure-mgmt-core>=1.3.0,<2.0.0",
+    "azure-core>=1.31.0,<2.0.0",
+    "azure-mgmt-core>=1.5.0,<2.0.0",
     "azure-identity>=1.6.1,<1.18.0",
     "azure-storage-blob>=12.14.0,<13.0.0",
     "msrest>=0.6.21",


### PR DESCRIPTION
## Summary
Adds `--disable-local-auth` / `--dla` to `az iot dps create` and `az iot dps update`.

When on, SAS key auth is disabled and Azure RBAC becomes the only way to authorize data plane requests.

`disableLocalAuth` is new in the stable `2026-08-31` API. Core's `iot dps` commandsare pinned to `2021-10-15`, so the extension takes over `create`, `update` and `show` against the SDK vendored in #879.

`show` is not cosmetic - `generic_update_command` wires `update` and `show` to the same getter. A getter at `2021-10-15` would drop `disableLocalAuth` from the GET, so an unrelated `az iot dps update --tags` would silently reset it.

### Note 
Most of this is lifted from `preview`

Only `iot_dps_create` and `iot_dps_update` differ: preview's ADR/identity blocks are dropped and three lines are added for `disableLocalAuth`. Keeping the structure aligned means a future `dev` -> `preview` merge stays near-trivial.

## Why setup.py changed

The vendored SDK's `_client.py` imports `get_arm_endpoints` (L18) and reads `settings.current.azure_cloud` (L70). Those are absent in **azure-mgmt-core 1.4.0** and **azure-core 1.30.0**.

The old floors (`>=1.3.0` / `>=1.24.0`) allowed installing versions without those symbols, and `azure-cli-core` only floors `azure-mgmt-core>=1.2.0`.

## Test
<img width="2037" height="463" alt="image" src="https://github.com/user-attachments/assets/b4553f5e-172b-47c9-942b-4d10c5e81041" />
<img width="2037" height="463" alt="image" src="https://github.com/user-attachments/assets/0299ae59-9058-4488-a7c6-ab5d510ed988" />
