### PR TITLE
fix: stabilize IoT Hub integration tests against query lag

### DIFF
--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -382,21 +382,23 @@ class DeviceIdentityProvider(IoTHubProvider):
                         .format(scope_retries, MAX_DEVICE_SCOPE_RETRIES))
             all_hub_devices = _execute_query(query_args, query_method)
 
-        # set all device scopes
+        # Set scopes required for parent / child relationships
+        required_scope_ids = set(device_to_parent_dict.values())
         scope_dict: Dict[str, str] = {}
         for device in all_hub_devices:
-            id = device["deviceId"]
-            if device_config_dict.get(id, None):
-                scope_dict[id] = device["deviceScope"]
+            device_id = device["deviceId"]
+            device_scope = device.get("deviceScope")
+            if device_id in required_scope_ids and device_scope:
+                scope_dict[device_id] = device_scope
 
-        if len(all_hub_devices) < len(config.devices):
-            missing_device_ids = sorted(set(device_config_dict).difference(scope_dict))
+        if len(scope_dict) < len(required_scope_ids):
+            missing_device_ids = sorted(required_scope_ids.difference(scope_dict))
             for device_id in missing_device_ids:
                 device = self.service_sdk.devices.get_identity(id=device_id)
                 if device.device_scope:
                     scope_dict[device_id] = device.device_scope
 
-            if len(scope_dict) < len(config.devices):
+            if len(scope_dict) < len(required_scope_ids):
                 raise AzureResponseError(
                     "An error occurred - Failed to fetch device scopes for all devices after {} retries"
                     .format(scope_retries)

--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -382,18 +382,25 @@ class DeviceIdentityProvider(IoTHubProvider):
                         .format(scope_retries, MAX_DEVICE_SCOPE_RETRIES))
             all_hub_devices = _execute_query(query_args, query_method)
 
-        if len(all_hub_devices) < len(config.devices):
-            raise AzureResponseError(
-                "An error occurred - Failed to fetch device scopes for all devices after {} retries"
-                .format(scope_retries)
-            )
-
         # set all device scopes
         scope_dict: Dict[str, str] = {}
         for device in all_hub_devices:
             id = device["deviceId"]
             if device_config_dict.get(id, None):
                 scope_dict[id] = device["deviceScope"]
+
+        if len(all_hub_devices) < len(config.devices):
+            missing_device_ids = sorted(set(device_config_dict).difference(scope_dict))
+            for device_id in missing_device_ids:
+                device = self.service_sdk.devices.get_identity(id=device_id)
+                if device.device_scope:
+                    scope_dict[device_id] = device.device_scope
+
+            if len(scope_dict) < len(config.devices):
+                raise AzureResponseError(
+                    "An error occurred - Failed to fetch device scopes for all devices after {} retries"
+                    .format(scope_retries)
+                )
 
         # Set parent / child relationships
         device_to_parent_iterator = (

--- a/azext_iot/iothub/providers/device_identity.py
+++ b/azext_iot/iothub/providers/device_identity.py
@@ -372,25 +372,31 @@ class DeviceIdentityProvider(IoTHubProvider):
         scope_retries = 0
         query_args = ["SELECT deviceId, deviceScope FROM devices"]
         query_method = self.service_sdk.query.get_twins
+        required_scope_ids = set(device_to_parent_dict.values())
+
+        def get_required_scopes(devices):
+            return {
+                device["deviceId"]: device["deviceScope"]
+                for device in devices
+                if (
+                    device["deviceId"] in required_scope_ids
+                    and device.get("deviceScope")
+                )
+            }
+
         all_hub_devices = _execute_query(query_args, query_method)
+        scope_dict = get_required_scopes(all_hub_devices)
 
         # Ensure we retrieve all device scopes
-        while len(all_hub_devices) < len(config.devices) and scope_retries < MAX_DEVICE_SCOPE_RETRIES:
+        while len(scope_dict) < len(required_scope_ids) and scope_retries < MAX_DEVICE_SCOPE_RETRIES:
             sleep(3)
             scope_retries += 1
             logger.info("Retrying device scope query - attempt {} of {}"
                         .format(scope_retries, MAX_DEVICE_SCOPE_RETRIES))
             all_hub_devices = _execute_query(query_args, query_method)
+            scope_dict = get_required_scopes(all_hub_devices)
 
         # Set scopes required for parent / child relationships
-        required_scope_ids = set(device_to_parent_dict.values())
-        scope_dict: Dict[str, str] = {}
-        for device in all_hub_devices:
-            device_id = device["deviceId"]
-            device_scope = device.get("deviceScope")
-            if device_id in required_scope_ids and device_scope:
-                scope_dict[device_id] = device_scope
-
         if len(scope_dict) < len(required_scope_ids):
             missing_device_ids = sorted(required_scope_ids.difference(scope_dict))
             for device_id in missing_device_ids:

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -8,7 +8,7 @@ import json
 import os
 
 from inspect import getsourcefile
-from time import sleep
+from time import monotonic, sleep
 from azext_iot.common.certops import create_self_signed_certificate
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.common.shared import AuthenticationTypeDataplane
@@ -245,12 +245,26 @@ def delete_role_assignment(
     )
 
 
+def wait_for_assertion(check, timeout=300, poll_interval=5):
+    deadline = monotonic() + timeout
+    while True:
+        try:
+            return check()
+        except AssertionError:
+            if monotonic() >= deadline:
+                raise
+            sleep(poll_interval)
+
+
 def clean_up_iothub_device_config(
     hub_name: str,
     rg: str
 ):
     from time import sleep
     import logging
+    from azext_iot._factory import SdkResolver
+    from azext_iot.common.shared import SdkType
+    from azext_iot.iothub.providers.discovery import IotHubDiscovery
     logger = logging.getLogger(__name__)
 
     def _list_with_retry(command, retries=3, delay=30):
@@ -266,7 +280,7 @@ def clean_up_iothub_device_config(
                 if attempt < retries - 1:
                     sleep(delay)
         logger.warning("List command failed after %d retries: %s — %s", retries, command, last_exc)
-        return []
+        raise last_exc
 
     def _delete_with_retry(command, retries=3, delay=30):
         last_exc = None
@@ -281,12 +295,15 @@ def clean_up_iothub_device_config(
                 if attempt < retries - 1:
                     sleep(delay)
         logger.warning("Delete command failed after %d retries: %s — %s", retries, command, last_exc)
+        raise last_exc
 
-    device_list = [
-        d["deviceId"] for d in _list_with_retry(
-            f"iot hub device-twin list -n {hub_name} -g {rg}"
-        )
-    ]
+    cstring = cli.invoke(
+        f"iot hub connection-string show -n {hub_name} -g {rg} --policy-name iothubowner"
+    ).as_json()["connectionString"]
+    devices = SdkResolver(
+        IotHubDiscovery.get_target_by_cstring(cstring)
+    ).get_sdk(SdkType.service_sdk).devices
+    device_list = devices.get_devices(top=1000)
 
     deployment_list = [
         c["id"] for c in _list_with_retry(
@@ -301,11 +318,13 @@ def clean_up_iothub_device_config(
     ]
 
     for device in device_list:
-        _delete_with_retry(
-            "iot hub device-identity delete -d {} -n {} -g {}".format(
-                device, hub_name, rg
-            )
-        )
+        devices.delete_identity(id=device.device_id, if_match="*")
+
+    def assert_devices_deleted():
+        remaining = [device.device_id for device in devices.get_devices(top=1000)]
+        assert not remaining, f"Devices were not deleted: {remaining}"
+
+    wait_for_assertion(assert_devices_deleted, timeout=60, poll_interval=2)
 
     for deployment in deployment_list:
         _delete_with_retry(
@@ -320,6 +339,12 @@ def clean_up_iothub_device_config(
                 config, hub_name, rg
             )
         )
+
+    def assert_configurations_deleted():
+        assert not _list_with_retry(f"iot edge deployment list -n {hub_name} -g {rg}")
+        assert not _list_with_retry(f"iot hub configuration list -n {hub_name} -g {rg}")
+
+    wait_for_assertion(assert_configurations_deleted, timeout=60, poll_interval=2)
 
 
 def create_test_cert(

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -391,8 +391,14 @@ def clean_up_iothub_device_config(
         )
 
     def assert_configurations_deleted():
-        assert not _list_with_retry(f"iot edge deployment list -n {hub_name} -g {rg}")
-        assert not _list_with_retry(f"iot hub configuration list -n {hub_name} -g {rg}")
+        assert not _list_with_retry(
+            f"iot edge deployment list -n {hub_name} -g {rg}",
+            delay=2,
+        )
+        assert not _list_with_retry(
+            f"iot hub configuration list -n {hub_name} -g {rg}",
+            delay=2,
+        )
 
     wait_for_assertion(assert_configurations_deleted, timeout=60, poll_interval=2)
 

--- a/azext_iot/tests/helpers.py
+++ b/azext_iot/tests/helpers.py
@@ -9,6 +9,7 @@ import os
 
 from inspect import getsourcefile
 from time import monotonic, sleep
+from uuid import uuid4
 from azext_iot.common.certops import create_self_signed_certificate
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.common.shared import AuthenticationTypeDataplane
@@ -245,7 +246,7 @@ def delete_role_assignment(
     )
 
 
-def wait_for_assertion(check, timeout=300, poll_interval=5):
+def wait_for_assertion(check, timeout=60, poll_interval=5):
     deadline = monotonic() + timeout
     while True:
         try:
@@ -254,6 +255,55 @@ def wait_for_assertion(check, timeout=300, poll_interval=5):
             if monotonic() >= deadline:
                 raise
             sleep(poll_interval)
+
+
+def wait_for_iothub_query_ready(hub_name, rg, timeout=60, poll_interval=5):
+    probe_suffix = uuid4().hex[:16]
+    device_id = f"query-readiness-{probe_suffix}"
+    module_id = f"query-readiness-module-{probe_suffix}"
+    target = f"-n {hub_name} -g {rg} --auth-type key"
+
+    def invoke(command):
+        result = cli.invoke(command)
+        if not result.success():
+            raise RuntimeError(
+                f"IoT Hub query readiness command failed with exit code {result.error_code}: {result.output}"
+            )
+        return result
+
+    device_query = f"select deviceId from devices where deviceId='{device_id}'"
+    module_query = f"select moduleId from devices.modules where devices.deviceId='{device_id}'"
+
+    def assert_query_results(expected_device_ids, expected_module_ids):
+        devices = invoke(f'iot hub query -q "{device_query}" {target}').as_json()
+        modules = invoke(f'iot hub query -q "{module_query}" {target}').as_json()
+        actual_device_ids = {device["deviceId"] for device in devices}
+        actual_module_ids = {module["moduleId"] for module in modules}
+        assert actual_device_ids == expected_device_ids, (
+            f"Device query readiness mismatch for {hub_name}: "
+            f"expected {expected_device_ids}, got {actual_device_ids}"
+        )
+        assert actual_module_ids == expected_module_ids, (
+            f"Module query readiness mismatch for {hub_name}: "
+            f"expected {expected_module_ids}, got {actual_module_ids}"
+        )
+
+    invoke(f"iot hub device-identity create -d {device_id} {target}")
+    try:
+        invoke(f"iot hub module-identity create -d {device_id} -m {module_id} {target}")
+        wait_for_assertion(
+            lambda: assert_query_results({device_id}, {module_id}),
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+    finally:
+        invoke(f"iot hub device-identity delete -d {device_id} {target}")
+
+    wait_for_assertion(
+        lambda: assert_query_results(set(), set()),
+        timeout=timeout,
+        poll_interval=poll_interval,
+    )
 
 
 def clean_up_iothub_device_config(

--- a/azext_iot/tests/iothub/__init__.py
+++ b/azext_iot/tests/iothub/__init__.py
@@ -8,6 +8,7 @@ import pytest
 
 from azure.cli.core.azclierror import CLIInternalError
 from time import sleep
+from types import SimpleNamespace
 from azext_iot.tests.helpers import (
     add_test_tag,
     assign_role_assignment,
@@ -50,7 +51,15 @@ DEFAULT_CONTAINER = "devices"
 
 settings = DynamoSettings(req_env_set=ENV_SET_TEST_IOTHUB_REQUIRED, opt_env_set=ENV_SET_TEST_IOTHUB_OPTIONAL)
 ENTITY_RG = settings.env.azext_iot_testrg
-ENTITY_NAME = settings.env.azext_iot_testhub or "test-hub-" + generate_generic_id()
+
+
+def generate_dynamic_hub_name():
+    return "test-hub-" + generate_generic_id()
+
+
+DYNAMIC_HUB = SimpleNamespace(
+    name=settings.env.azext_iot_testhub or generate_dynamic_hub_name()
+)
 STORAGE_ACCOUNT = settings.env.azext_iot_teststorageaccount or "hubstore" + generate_generic_id()[:4]
 STORAGE_CONTAINER = settings.env.azext_iot_teststoragecontainer or DEFAULT_CONTAINER
 MAX_RBAC_ASSIGNMENT_TRIES = settings.env.azext_iot_rbac_max_tries or 10
@@ -63,7 +72,7 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
     def __init__(self, test_scenario, add_data_contributor=True):
         assert test_scenario
         self.entity_rg = ENTITY_RG
-        self.entity_name = ENTITY_NAME
+        self.entity_name = DYNAMIC_HUB.name
         super(IoTLiveScenarioTest, self).__init__(test_scenario)
 
         if hasattr(self, 'storage_cstring'):
@@ -142,6 +151,8 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
                 )
                 if attempt == HUB_PROVISION_ATTEMPTS - 1:
                     raise
+                self.entity_name = generate_dynamic_hub_name()
+                DYNAMIC_HUB.name = self.entity_name
                 self._create_dynamic_hub()
                 target_hub = self._wait_for_ready_hub()
 

--- a/azext_iot/tests/iothub/__init__.py
+++ b/azext_iot/tests/iothub/__init__.py
@@ -15,6 +15,7 @@ from azext_iot.tests.helpers import (
     create_storage_account,
     set_cmd_auth_type,
     wait_for_assertion,
+    wait_for_iothub_query_ready,
 )
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
 from azext_iot.tests.generators import generate_generic_id
@@ -54,6 +55,7 @@ STORAGE_ACCOUNT = settings.env.azext_iot_teststorageaccount or "hubstore" + gene
 STORAGE_CONTAINER = settings.env.azext_iot_teststoragecontainer or DEFAULT_CONTAINER
 MAX_RBAC_ASSIGNMENT_TRIES = settings.env.azext_iot_rbac_max_tries or 10
 ROLE_ASSIGNMENT_REFRESH_TIME = 120
+HUB_PROVISION_ATTEMPTS = 3
 
 
 @pytest.mark.usefixtures("fixture_provision_existing_hub_role", "fixture_provision_existing_hub_device_config")
@@ -67,39 +69,25 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
         if hasattr(self, 'storage_cstring'):
             self._create_storage_account()
 
+        target_hub = None
+        created_hub = False
         if not settings.env.azext_iot_testhub:
             hubs_list = self.cmd(
                 'iot hub list -g "{}"'.format(self.entity_rg)
             ).get_output_in_json()
 
-            target_hub = None
             for hub in hubs_list:
                 if hub["name"] == self.entity_name:
                     target_hub = hub
                     break
 
             if not target_hub:
-                if hasattr(self, 'storage_cstring'):
-                    self.cmd(
-                        "iot hub create --name {} --resource-group {} --fc {} --fcs {} --sku S1 ".format(
-                            self.entity_name, self.entity_rg,
-                            self.storage_container, self.storage_cstring
-                        )
-                    )
-                else:
-                    self.cmd(
-                        "iot hub create --name {} --resource-group {} --sku S1 ".format(
-                            self.entity_name, self.entity_rg
-                        )
-                    )
-                sleep(ROLE_ASSIGNMENT_REFRESH_TIME)
+                self._create_dynamic_hub()
+                created_hub = True
 
-        target_hub = wait_for_assertion(
-            lambda: self.cmd(
-                "iot hub show -n {} -g {}".format(self.entity_name, self.entity_rg),
-                checks=[self.exists("id"), self.exists("properties.hostName")],
-            )
-        ).get_output_in_json()
+        target_hub = self._wait_for_ready_hub()
+        if created_hub:
+            target_hub = self._ensure_query_ready_hub(target_hub)
 
         if add_data_contributor:
             self._add_data_contributor(target_hub)
@@ -116,6 +104,46 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
             rtype=ResourceTypes.hub.value,
             test_tag=test_scenario
         )
+
+    def _wait_for_ready_hub(self):
+        return wait_for_assertion(
+            lambda: self.cmd(
+                "iot hub show -n {} -g {}".format(self.entity_name, self.entity_rg),
+                checks=[self.exists("id"), self.exists("properties.hostName")],
+            )
+        ).get_output_in_json()
+
+    def _create_dynamic_hub(self):
+        if hasattr(self, 'storage_cstring'):
+            self.cmd(
+                "iot hub create --name {} --resource-group {} --fc {} --fcs {} --sku S1 ".format(
+                    self.entity_name, self.entity_rg,
+                    self.storage_container, self.storage_cstring
+                )
+            )
+        else:
+            self.cmd(
+                "iot hub create --name {} --resource-group {} --sku S1 ".format(
+                    self.entity_name, self.entity_rg
+                )
+            )
+        sleep(ROLE_ASSIGNMENT_REFRESH_TIME)
+
+    def _ensure_query_ready_hub(self, target_hub):
+        for attempt in range(HUB_PROVISION_ATTEMPTS):
+            try:
+                wait_for_iothub_query_ready(self.entity_name, self.entity_rg)
+                return target_hub
+            except AssertionError:
+                self.cmd(
+                    "iot hub delete --name {} --resource-group {}".format(
+                        self.entity_name, self.entity_rg
+                    )
+                )
+                if attempt == HUB_PROVISION_ATTEMPTS - 1:
+                    raise
+                self._create_dynamic_hub()
+                target_hub = self._wait_for_ready_hub()
 
     def _add_data_contributor(self, target_hub):
         account = self.cmd("account show").get_output_in_json()

--- a/azext_iot/tests/iothub/__init__.py
+++ b/azext_iot/tests/iothub/__init__.py
@@ -13,7 +13,8 @@ from azext_iot.tests.helpers import (
     assign_role_assignment,
     clean_up_iothub_device_config,
     create_storage_account,
-    set_cmd_auth_type
+    set_cmd_auth_type,
+    wait_for_assertion,
 )
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
 from azext_iot.tests.generators import generate_generic_id
@@ -93,8 +94,11 @@ class IoTLiveScenarioTest(CaptureOutputLiveScenarioTest):
                     )
                 sleep(ROLE_ASSIGNMENT_REFRESH_TIME)
 
-        target_hub = self.cmd(
-            "iot hub show -n {} -g {}".format(self.entity_name, self.entity_rg)
+        target_hub = wait_for_assertion(
+            lambda: self.cmd(
+                "iot hub show -n {} -g {}".format(self.entity_name, self.entity_rg),
+                checks=[self.exists("id"), self.exists("properties.hostName")],
+            )
         ).get_output_in_json()
 
         if add_data_contributor:

--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -22,7 +22,7 @@ from azext_iot.tests.helpers import (
     wait_for_iothub_query_ready,
 )
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
-from azext_iot.tests.iothub import ENTITY_NAME, ENTITY_RG, settings as iothub_settings
+import azext_iot.tests.iothub as iothub_test
 
 logger = get_logger(__name__)
 MAX_RBAC_ASSIGNMENT_TRIES = 10
@@ -73,18 +73,20 @@ def _cleanup_dynamic_hub():
     the same hub on the same worker).
     """
     yield
-    if not iothub_settings.env.azext_iot_testhub:
-        logger.info("Deleting dynamically created hub: %s", ENTITY_NAME)
+    if not iothub_test.settings.env.azext_iot_testhub:
+        logger.info("Deleting dynamically created hub: %s", iothub_test.DYNAMIC_HUB.name)
         from time import sleep
         for attempt in range(3):
-            delete_result = cli.invoke(f"iot hub delete --name {ENTITY_NAME} --resource-group {ENTITY_RG}")
+            delete_result = cli.invoke(
+                f"iot hub delete --name {iothub_test.DYNAMIC_HUB.name} --resource-group {iothub_test.ENTITY_RG}"
+            )
             if delete_result.success():
                 break
             if attempt < 2:
                 logger.warning("Hub deletion attempt %s failed, retrying...", attempt + 1)
                 sleep(30)
         else:
-            logger.error("Failed to delete hub %s after 3 attempts.", ENTITY_NAME)
+            logger.error("Failed to delete hub %s after 3 attempts.", iothub_test.DYNAMIC_HUB.name)
 
 
 @pytest.fixture()

--- a/azext_iot/tests/iothub/conftest.py
+++ b/azext_iot/tests/iothub/conftest.py
@@ -15,12 +15,18 @@ from knack.log import get_logger
 from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.tests.generators import generate_generic_id
 from azext_iot.common.certops import create_self_signed_certificate
-from azext_iot.tests.helpers import assign_role_assignment, clean_up_iothub_device_config, get_closest_marker
+from azext_iot.tests.helpers import (
+    assign_role_assignment,
+    clean_up_iothub_device_config,
+    get_closest_marker,
+    wait_for_iothub_query_ready,
+)
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
 from azext_iot.tests.iothub import ENTITY_NAME, ENTITY_RG, settings as iothub_settings
 
 logger = get_logger(__name__)
 MAX_RBAC_ASSIGNMENT_TRIES = 10
+HUB_PROVISION_ATTEMPTS = 3
 USER_ROLE = "IoT Hub Data Contributor"
 cli = EmbeddedCLI()
 settings = DynamoSettings(req_env_set=ENV_SET_TEST_IOTHUB_REQUIRED, opt_env_set=ENV_SET_TEST_IOTHUB_OPTIONAL)
@@ -258,7 +264,10 @@ def provisioned_iot_hubs_with_storage_user_module(
     request, provisioned_user_identity_module, provisioned_storage_module
 ) -> dict:
     result = _iot_hubs_provisioner(
-        request, provisioned_user_identity_module, provisioned_storage_module
+        request,
+        provisioned_user_identity_module,
+        provisioned_storage_module,
+        query_ready=True,
     )
     yield result
     if result:
@@ -281,7 +290,12 @@ def provisioned_only_iot_hubs_module(request) -> dict:
         _iot_hubs_removal(result)
 
 
-def _iot_hubs_provisioner(request, provisioned_user_identity=None, provisioned_storage=None):
+def _iot_hubs_provisioner(
+    request,
+    provisioned_user_identity=None,
+    provisioned_storage=None,
+    query_ready=False,
+):
     hub_marker = get_closest_marker(request)
     desired_location = None
     desired_tags = None
@@ -300,27 +314,43 @@ def _iot_hubs_provisioner(request, provisioned_user_identity=None, provisioned_s
 
     hub_results = []
     for _ in range(desired_count):
-        name = generate_hub_id()
-        base_create_command = f"iot hub create -n {name} -g {RG} --sku S1"
-        if desired_sys_identity:
-            base_create_command += " --mi-system-assigned"
-        if desired_user_identity and provisioned_user_identity:
-            user_identity_id = provisioned_user_identity["id"]
-            base_create_command += f" --mi-user-assigned {user_identity_id}"
-        if desired_tags:
-            base_create_command += f" --tags {desired_tags}"
-        if desired_location:
-            base_create_command += f" -l {desired_location}"
-        if desired_storage and provisioned_storage:
-            storage_cstring = provisioned_storage["connectionString"]
-            base_create_command += f" --fcs {storage_cstring} --fc fileupload"
+        attempts = HUB_PROVISION_ATTEMPTS if query_ready else 1
+        for attempt in range(attempts):
+            name = generate_hub_id()
+            base_create_command = f"iot hub create -n {name} -g {RG} --sku S1"
+            if desired_sys_identity:
+                base_create_command += " --mi-system-assigned"
+            if desired_user_identity and provisioned_user_identity:
+                user_identity_id = provisioned_user_identity["id"]
+                base_create_command += f" --mi-user-assigned {user_identity_id}"
+            if desired_tags:
+                base_create_command += f" --tags {desired_tags}"
+            if desired_location:
+                base_create_command += f" -l {desired_location}"
+            if desired_storage and provisioned_storage:
+                storage_cstring = provisioned_storage["connectionString"]
+                base_create_command += f" --fcs {storage_cstring} --fc fileupload"
 
-        hub_obj = cli.invoke(base_create_command).as_json()
+            hub_obj = cli.invoke(base_create_command).as_json()
+            connection_string = _get_hub_connection_string(name, RG)
+            if not query_ready:
+                break
+            try:
+                wait_for_iothub_query_ready(name, RG)
+                break
+            except AssertionError:
+                logger.warning("Replacing IoT Hub %s because its query index did not become ready.", name)
+                delete_result = cli.invoke(f"iot hub delete -n {name} -g {RG}")
+                if not delete_result.success():
+                    raise RuntimeError(f"Failed to delete query-unready IoT Hub {name}.")
+                if attempt == attempts - 1:
+                    raise
+
         hub_results.append({
             "hub": hub_obj,
             "name": name,
             "rg": RG,
-            "connectionString": _get_hub_connection_string(name, RG),
+            "connectionString": connection_string,
             "storage": provisioned_storage
         })
     return hub_results

--- a/azext_iot/tests/iothub/core/test_iot_messaging_int.py
+++ b/azext_iot/tests/iothub/core/test_iot_messaging_int.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from azext_iot.iothub.common import NON_DECODABLE_PAYLOAD
 from azext_iot.tests.conftest import get_context_path
 from azext_iot.tests.iothub import IoTLiveScenarioTest, PREFIX_DEVICE
+from azext_iot.tests.helpers import wait_for_assertion
 from azext_iot.common.utility import (
     execute_onthread,
     calculate_millisec_since_unix_epoch_utc,
@@ -1097,6 +1098,18 @@ class TestIoTHubMessaging(IoTLiveScenarioTest):
         query_string = "select * from devices where deviceId in [{}]".format(
             device_include_string
         )
+
+        expected_device_ids = set(device_subset_include)
+
+        def assert_query_ready():
+            devices = self.cmd(
+                'iot hub query -n {} -g {} -q "{}"'.format(
+                    self.entity_name, self.entity_rg, query_string
+                )
+            ).get_output_in_json()
+            assert {device["deviceId"] for device in devices} == expected_device_ids
+
+        wait_for_assertion(assert_query_ready)
 
         self.command_execute_assert(
             'iot hub monitor-events -n {} -g {} --device-query "{}" --et {} -t 8 -y -p sys anno app'.format(

--- a/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
@@ -11,6 +11,8 @@ from azure.cli.core.azclierror import ArgumentUsageError, CLIInternalError
 from azext_iot.operations import hub as subject
 from azext_iot.tests.generators import generate_generic_id
 from azext_iot.tests import helpers
+from azext_iot.tests.iothub import IoTLiveScenarioTest
+from azext_iot.tests.iothub import conftest as iothub_conftest
 
 
 def generate_valid_cs(validate_pairs=[]):
@@ -49,6 +51,118 @@ def test_wait_for_assertion(mocker):
     mocker.patch("azext_iot.tests.helpers.monotonic", side_effect=[0, 1])
     with pytest.raises(AssertionError, match="not ready"):
         helpers.wait_for_assertion(check, timeout=1, poll_interval=0)
+
+
+def test_wait_for_iothub_query_ready(mocker):
+    device_id = "query-readiness-0123456789abcdef"
+    module_id = "query-readiness-module-0123456789abcdef"
+    device_results = iter([[{"deviceId": device_id}], []])
+    module_results = iter([[{"moduleId": module_id}], []])
+    commands = []
+
+    def invoke(command):
+        commands.append(command)
+        result = mocker.Mock()
+        result.success.return_value = True
+        if "from devices.modules" in command:
+            result.as_json.return_value = next(module_results)
+        elif "iot hub query" in command:
+            result.as_json.return_value = next(device_results)
+        return result
+
+    mocker.patch.object(helpers.cli, "invoke", side_effect=invoke)
+    mocker.patch.object(helpers, "uuid4", return_value=mocker.Mock(hex="0123456789abcdef"))
+
+    helpers.wait_for_iothub_query_ready("test-hub", "test-rg")
+
+    assert len(commands) == 7
+    assert commands[0].startswith("iot hub device-identity create")
+    assert commands[1].startswith("iot hub module-identity create")
+    assert commands[4].startswith("iot hub device-identity delete")
+
+
+def test_wait_for_iothub_query_ready_cleans_up_on_timeout(mocker):
+    commands = []
+
+    def invoke(command):
+        commands.append(command)
+        result = mocker.Mock()
+        result.success.return_value = True
+        if "iot hub query" in command:
+            result.as_json.return_value = []
+        return result
+
+    mocker.patch.object(helpers.cli, "invoke", side_effect=invoke)
+
+    with pytest.raises(AssertionError, match="Device query readiness mismatch"):
+        helpers.wait_for_iothub_query_ready(
+            "test-hub",
+            "test-rg",
+            timeout=0,
+            poll_interval=0,
+        )
+
+    assert any(command.startswith("iot hub device-identity delete") for command in commands)
+
+
+def test_iot_live_scenario_replaces_query_unready_hub(mocker):
+    scenario = mocker.Mock()
+    scenario.entity_name = "test-hub"
+    scenario.entity_rg = "test-rg"
+    replacement_hub = {"id": "replacement-hub"}
+    scenario._wait_for_ready_hub.return_value = replacement_hub
+    mocker.patch(
+        "azext_iot.tests.iothub.wait_for_iothub_query_ready",
+        side_effect=[AssertionError(), None],
+    )
+
+    result = IoTLiveScenarioTest._ensure_query_ready_hub(scenario, {"id": "initial-hub"})
+
+    assert result == replacement_hub
+    scenario.cmd.assert_called_once_with(
+        "iot hub delete --name test-hub --resource-group test-rg"
+    )
+    scenario._create_dynamic_hub.assert_called_once_with()
+
+
+def test_iot_hub_provisioner_replaces_query_unready_hub(mocker):
+    marker = mocker.Mock()
+    marker.kwargs = {}
+    commands = []
+
+    def invoke(command):
+        commands.append(command)
+        result = mocker.Mock()
+        result.success.return_value = True
+        if command.startswith("iot hub create"):
+            result.as_json.return_value = {"name": command.split()[4]}
+        return result
+
+    mocker.patch.object(iothub_conftest, "RG", "test-rg")
+    mocker.patch.object(iothub_conftest, "get_closest_marker", return_value=marker)
+    mocker.patch.object(
+        iothub_conftest,
+        "generate_hub_id",
+        side_effect=["query-unready-hub", "query-ready-hub"],
+    )
+    mocker.patch.object(iothub_conftest.cli, "invoke", side_effect=invoke)
+    mocker.patch.object(
+        iothub_conftest,
+        "_get_hub_connection_string",
+        side_effect=lambda name, _rg: f"{name}-connection-string",
+    )
+    readiness = mocker.patch.object(
+        iothub_conftest,
+        "wait_for_iothub_query_ready",
+        side_effect=[AssertionError(), None],
+    )
+
+    result = iothub_conftest._iot_hubs_provisioner(mocker.Mock(), query_ready=True)
+
+    assert result[0]["name"] == "query-ready-hub"
+    assert result[0]["connectionString"] == "query-ready-hub-connection-string"
+    assert readiness.call_count == 2
+    assert "iot hub delete -n query-unready-hub -g test-rg" in commands
 
 
 class TestGenerateSasToken:

--- a/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
@@ -11,6 +11,7 @@ from azure.cli.core.azclierror import ArgumentUsageError, CLIInternalError
 from azext_iot.operations import hub as subject
 from azext_iot.tests.generators import generate_generic_id
 from azext_iot.tests import helpers
+import azext_iot.tests.iothub as iothub_test
 from azext_iot.tests.iothub import IoTLiveScenarioTest
 from azext_iot.tests.iothub import conftest as iothub_conftest
 
@@ -109,20 +110,53 @@ def test_iot_live_scenario_replaces_query_unready_hub(mocker):
     scenario = mocker.Mock()
     scenario.entity_name = "test-hub"
     scenario.entity_rg = "test-rg"
-    replacement_hub = {"id": "replacement-hub"}
-    scenario._wait_for_ready_hub.return_value = replacement_hub
-    mocker.patch(
+    replacement_hubs = [{"id": "replacement-hub-1"}, {"id": "replacement-hub-2"}]
+    scenario._wait_for_ready_hub.side_effect = replacement_hubs
+    created_names = []
+    scenario._create_dynamic_hub.side_effect = lambda: created_names.append(scenario.entity_name)
+    mocker.patch.object(iothub_test.DYNAMIC_HUB, "name", "test-hub")
+    mocker.patch.object(
+        iothub_test,
+        "generate_dynamic_hub_name",
+        side_effect=["replacement-hub-name-1", "replacement-hub-name-2"],
+    )
+    readiness = mocker.patch(
         "azext_iot.tests.iothub.wait_for_iothub_query_ready",
-        side_effect=[AssertionError(), None],
+        side_effect=[AssertionError(), AssertionError(), None],
     )
 
     result = IoTLiveScenarioTest._ensure_query_ready_hub(scenario, {"id": "initial-hub"})
 
-    assert result == replacement_hub
-    scenario.cmd.assert_called_once_with(
-        "iot hub delete --name test-hub --resource-group test-rg"
+    assert result == replacement_hubs[-1]
+    assert scenario.entity_name == "replacement-hub-name-2"
+    assert iothub_test.DYNAMIC_HUB.name == "replacement-hub-name-2"
+    assert [call.args for call in readiness.call_args_list] == [
+        ("test-hub", "test-rg"),
+        ("replacement-hub-name-1", "test-rg"),
+        ("replacement-hub-name-2", "test-rg"),
+    ]
+    assert [call.args for call in scenario.cmd.call_args_list] == [
+        ("iot hub delete --name test-hub --resource-group test-rg",),
+        ("iot hub delete --name replacement-hub-name-1 --resource-group test-rg",),
+    ]
+    assert created_names == ["replacement-hub-name-1", "replacement-hub-name-2"]
+
+
+def test_dynamic_hub_cleanup_deletes_active_replacement(mocker):
+    mocker.patch.object(iothub_test.settings.env, "azext_iot_testhub", None)
+    mocker.patch.object(iothub_test.DYNAMIC_HUB, "name", "replacement-hub-name")
+    mocker.patch.object(iothub_test, "ENTITY_RG", "test-rg")
+    invoke = mocker.patch.object(iothub_conftest.cli, "invoke")
+    invoke.return_value.success.return_value = True
+
+    cleanup = iothub_conftest._cleanup_dynamic_hub.__wrapped__()
+    next(cleanup)
+    with pytest.raises(StopIteration):
+        next(cleanup)
+
+    invoke.assert_called_once_with(
+        "iot hub delete --name replacement-hub-name --resource-group test-rg"
     )
-    scenario._create_dynamic_hub.assert_called_once_with()
 
 
 def test_iot_hub_provisioner_replaces_query_unready_hub(mocker):

--- a/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
+++ b/azext_iot/tests/iothub/core/test_iothub_utilities_unit.py
@@ -10,6 +10,7 @@ from knack.cli import CLIError
 from azure.cli.core.azclierror import ArgumentUsageError, CLIInternalError
 from azext_iot.operations import hub as subject
 from azext_iot.tests.generators import generate_generic_id
+from azext_iot.tests import helpers
 
 
 def generate_valid_cs(validate_pairs=[]):
@@ -37,6 +38,17 @@ def generate_valid_cs(validate_pairs=[]):
         "policy": policy,
         "key": shared_access_key
     }
+
+
+def test_wait_for_assertion(mocker):
+    check = mocker.Mock(side_effect=[AssertionError(), "ready"])
+    mocker.patch("azext_iot.tests.helpers.sleep")
+    assert helpers.wait_for_assertion(check, timeout=1, poll_interval=0.1) == "ready"
+
+    check = mocker.Mock(side_effect=AssertionError("not ready"))
+    mocker.patch("azext_iot.tests.helpers.monotonic", side_effect=[0, 1])
+    with pytest.raises(AssertionError, match="not ready"):
+        helpers.wait_for_assertion(check, timeout=1, poll_interval=0)
 
 
 class TestGenerateSasToken:

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_create_int.py
@@ -10,6 +10,7 @@ import tarfile
 from shutil import rmtree
 from os.path import exists
 from azext_iot.tests.iothub import IoTLiveScenarioTest
+from azext_iot.tests.helpers import wait_for_assertion
 
 
 class EdgeDevicesTestConfig(NamedTuple):
@@ -275,12 +276,15 @@ class TestNestedEdgeHierarchy(IoTLiveScenarioTest):
         cert_auth: bool = False,
         custom_device_template: bool = False,
     ):
-        # get all devices in hub
-        device_list = self.cmd(
-            f"iot hub device-identity list -n {self.entity_name} -g {self.entity_rg}"
-        ).get_output_in_json()
-        # make sure all devices were created
-        assert len(device_list) == len(devices)
+        expected_device_ids = {device.id for device in devices}
+
+        def get_device_list():
+            device_list = self.cmd(
+                f"iot hub device-identity list -n {self.entity_name} -g {self.entity_rg}"
+            ).get_output_in_json()
+            assert {device["deviceId"] for device in device_list} == expected_device_ids
+
+        wait_for_assertion(get_device_list)
         # validate each device
         for device_tuple in devices:
             device_id = device_tuple.id

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -72,6 +72,14 @@ test_device_scopes = [
     {"deviceId": "device_6", "deviceScope": "dev6-scope-value"},
     {"deviceId": "device_7", "deviceScope": "dev7-scope-value"},
 ]
+unrelated_device_scopes = [
+    {"deviceId": f"unrelated_device_{index}", "deviceScope": device["deviceScope"]}
+    for index, device in enumerate(test_device_scopes)
+]
+empty_device_scopes = [
+    {"deviceId": device["deviceId"], "deviceScope": ""}
+    for device in test_device_scopes
+]
 test_path = getcwd()
 
 
@@ -500,14 +508,17 @@ class TestHierarchyCreateConfig:
     @pytest.fixture()
     def scope_query_client(self, request, mocked_response, fixture_ghcs, fixture_sas):
         devices_url = f"https://{hub_entity}/devices"
-        # always return empty query
-        mocked_response.add(
+        query_devices, registry_device_scope = request.param
+
+        def query_response(request):
+            query = json.loads(request.body)["query"]
+            response = [] if query == "SELECT deviceId FROM devices" else query_devices
+            return 200, {}, json.dumps(response)
+
+        mocked_response.add_callback(
             method=responses.POST,
             url=f"{devices_url}/query",
-            body="[]",
-            status=200,
-            content_type="application/json",
-            match_querystring=False,
+            callback=query_response,
         )
 
         # Create / Update device-identities
@@ -522,17 +533,20 @@ class TestHierarchyCreateConfig:
             match_querystring=False,
         )
 
-        device_scope = request.param
         mocked_response.add(
             method=responses.GET,
             url=re.compile(r"{}/device_\d+".format(devices_url)),
-            body=json.dumps({"deviceScope": device_scope} if device_scope else {}),
+            body=json.dumps(
+                {"deviceScope": registry_device_scope}
+                if registry_device_scope
+                else {}
+            ),
             status=200,
             content_type="application/json",
             match_querystring=False,
         )
 
-        if device_scope:
+        if registry_device_scope:
             mocked_response.add(
                 method=responses.POST,
                 url=re.compile(
@@ -726,7 +740,12 @@ class TestHierarchyCreateConfig:
 
     @pytest.mark.parametrize(
         "scope_query_client, expect_failure",
-        [("registry-device-scope", False), (None, True)],
+        [
+            (([], "registry-device-scope"), False),
+            (([], None), True),
+            ((unrelated_device_scopes, "registry-device-scope"), False),
+            ((empty_device_scopes, "registry-device-scope"), False),
+        ],
         indirect=["scope_query_client"],
     )
     def test_edge_devices_scope_registry_fallback(
@@ -744,6 +763,18 @@ class TestHierarchyCreateConfig:
                 cmd=fixture_cmd,
                 devices=None,
                 config_file="device_configs/nested_edge_config.yml"
+            )
+            updated_devices = []
+            for request_call in scope_query_client.calls:
+                if request_call.request.method == "PUT":
+                    request_body = json.loads(request_call.request.body)
+                    if request_body.get("parentScopes"):
+                        updated_devices.append(request_body)
+
+            assert updated_devices
+            assert all(
+                device["parentScopes"] == ["registry-device-scope"]
+                for device in updated_devices
             )
 
 

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -29,6 +29,7 @@ from azext_iot.iothub.providers.helpers.edge_device_config import (
     EDGE_CONFIG_SCRIPT_PARENT_HOSTNAME,
     EDGE_ROOT_CERTIFICATE_FILENAME,
     EDGE_ROOT_CERTIFICATE_SUBJECT,
+    MAX_DEVICE_SCOPE_RETRIES,
     create_edge_device_config_script,
     process_edge_devices_config_args,
     process_edge_devices_config_file_content,
@@ -513,7 +514,7 @@ class TestHierarchyCreateConfig:
         def query_response(request):
             query = json.loads(request.body)["query"]
             response = [] if query == "SELECT deviceId FROM devices" else query_devices
-            return 200, {}, json.dumps(response)
+            return 200, {"Content-Type": "application/json"}, json.dumps(response)
 
         mocked_response.add_callback(
             method=responses.POST,
@@ -749,8 +750,10 @@ class TestHierarchyCreateConfig:
         indirect=["scope_query_client"],
     )
     def test_edge_devices_scope_registry_fallback(
-        self, fixture_cmd, scope_query_client, set_cwd, expect_failure
+        self, fixture_cmd, scope_query_client, set_cwd, expect_failure, mocker
     ):
+        mocker.patch("azext_iot.iothub.providers.device_identity.sleep")
+
         if expect_failure:
             with pytest.raises(AzureResponseError):
                 subject.iot_edge_devices_create(
@@ -764,6 +767,20 @@ class TestHierarchyCreateConfig:
                 devices=None,
                 config_file="device_configs/nested_edge_config.yml"
             )
+
+        scope_queries = [
+            json.loads(request_call.request.body)["query"]
+            for request_call in scope_query_client.calls
+            if (
+                request_call.request.method == "POST"
+                and "/query" in request_call.request.url
+                and json.loads(request_call.request.body)["query"]
+                == "SELECT deviceId, deviceScope FROM devices"
+            )
+        ]
+        assert len(scope_queries) == MAX_DEVICE_SCOPE_RETRIES + 1
+
+        if not expect_failure:
             updated_devices = []
             for request_call in scope_query_client.calls:
                 if request_call.request.method == "PUT":

--- a/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
+++ b/azext_iot/tests/iothub/devices/test_iot_edge_devices_unit.py
@@ -498,7 +498,7 @@ class TestHierarchyCreateConfig:
         yield mocked_response
 
     @pytest.fixture()
-    def scope_retry_failed_client(self, mocked_response, fixture_ghcs, fixture_sas):
+    def scope_query_client(self, request, mocked_response, fixture_ghcs, fixture_sas):
         devices_url = f"https://{hub_entity}/devices"
         # always return empty query
         mocked_response.add(
@@ -521,6 +521,28 @@ class TestHierarchyCreateConfig:
             content_type="application/json",
             match_querystring=False,
         )
+
+        device_scope = request.param
+        mocked_response.add(
+            method=responses.GET,
+            url=re.compile(r"{}/device_\d+".format(devices_url)),
+            body=json.dumps({"deviceScope": device_scope} if device_scope else {}),
+            status=200,
+            content_type="application/json",
+            match_querystring=False,
+        )
+
+        if device_scope:
+            mocked_response.add(
+                method=responses.POST,
+                url=re.compile(
+                    r"{}/device_\d+/applyConfigurationContent".format(devices_url)
+                ),
+                body="{}",
+                status=200,
+                content_type="application/json",
+                match_querystring=False,
+            )
         return mocked_response
 
     @pytest.fixture()
@@ -702,8 +724,22 @@ class TestHierarchyCreateConfig:
 
             rmtree(out)
 
-    def test_edge_devices_scope_retry_failure(self, fixture_cmd, scope_retry_failed_client, set_cwd):
-        with pytest.raises(AzureResponseError):
+    @pytest.mark.parametrize(
+        "scope_query_client, expect_failure",
+        [("registry-device-scope", False), (None, True)],
+        indirect=["scope_query_client"],
+    )
+    def test_edge_devices_scope_registry_fallback(
+        self, fixture_cmd, scope_query_client, set_cwd, expect_failure
+    ):
+        if expect_failure:
+            with pytest.raises(AzureResponseError):
+                subject.iot_edge_devices_create(
+                    cmd=fixture_cmd,
+                    devices=None,
+                    config_file="device_configs/nested_edge_config.yml"
+                )
+        else:
             subject.iot_edge_devices_create(
                 cmd=fixture_cmd,
                 devices=None,

--- a/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
+++ b/azext_iot/tests/iothub/devices/test_iothub_devices_int.py
@@ -6,6 +6,7 @@
 
 from azext_iot.tests.iothub import IoTLiveScenarioTest
 from azext_iot.tests.generators import generate_generic_id
+from azext_iot.tests.helpers import wait_for_assertion
 from azext_iot.common.utility import generate_key
 from azext_iot.tests.iothub import (
     DATAPLANE_AUTH_TYPES,
@@ -242,12 +243,14 @@ class TestIoTHubDevices(IoTLiveScenarioTest):
                     query_checks.append(self.exists(f"[?deviceId=='{d}']"))
 
                 # By default query has no return cap
-                self.cmd(
-                    self.set_cmd_auth_type(
-                        f'iot hub query --hub-name {self.host_name} -g {self.entity_rg} -q "select * from devices"',
-                        auth_type=auth_phase,
-                    ),
-                    checks=query_checks,
+                wait_for_assertion(
+                    lambda: self.cmd(
+                        self.set_cmd_auth_type(
+                            f'iot hub query --hub-name {self.host_name} -g {self.entity_rg} -q "select * from devices"',
+                            auth_type=auth_phase,
+                        ),
+                        checks=query_checks,
+                    )
                 )
 
                 # -1 Top is equivalent to unlimited

--- a/azext_iot/tests/iothub/devices/test_iothub_nested_edge_int.py
+++ b/azext_iot/tests/iothub/devices/test_iothub_nested_edge_int.py
@@ -6,7 +6,7 @@
 
 from azext_iot.tests.iothub import IoTLiveScenarioTest
 from azext_iot.tests.iothub import DATAPLANE_AUTH_TYPES
-from time import sleep
+from azext_iot.tests.helpers import wait_for_assertion
 
 # TODO: assert device scope format in device twin.
 # from azext_iot.constants import DEVICE_DEVICESCOPE_PREFIX
@@ -167,17 +167,11 @@ class TestIoTHubNestedEdge(IoTLiveScenarioTest):
                 checks=self.is_empty(),
             )
 
-            # Wait for API to catch up
-            sleep(10)
-
-            # List child devices of edge device
-            output = self.cmd(
-                self.set_cmd_auth_type(
-                    f"iot hub device-identity children list -d {edge_device_ids[0]} -n {self.host_name} -g {self.entity_rg}",
-                    auth_type=auth_phase,
-                )
+            self._wait_for_children(
+                edge_device_ids[0],
+                [device_ids[1]],
+                auth_phase,
             )
-            assert output.get_output_in_json() == [device_ids[1]]
 
             # Error - Remove all child devices of non-edge device
             self.cmd(
@@ -199,8 +193,7 @@ class TestIoTHubNestedEdge(IoTLiveScenarioTest):
                 checks=self.is_empty(),
             )
 
-            # Wait for child devices to be removed to prevent failures
-            sleep(40)
+            self._wait_for_children(edge_device_ids[1], [], auth_phase)
 
             # Error - remove all child devices of edge device which does not have any child devices
             self.cmd(
@@ -261,14 +254,19 @@ class TestIoTHubNestedEdge(IoTLiveScenarioTest):
                 expect_failure=True,
             )
 
-            # List child devices of edge device which doesn't have any children
+            self._wait_for_children(edge_device_ids[1], [], auth_phase)
+
+    def _wait_for_children(self, parent_id, expected_children, auth_phase):
+        def check():
             output = self.cmd(
                 self.set_cmd_auth_type(
-                    f"iot hub device-identity children list -d {edge_device_ids[1]} -n {self.host_name} -g {self.entity_rg}",
+                    f"iot hub device-identity children list -d {parent_id} -n {self.host_name} -g {self.entity_rg}",
                     auth_type=auth_phase,
                 )
-            )
-            assert output.get_output_in_json() == []
+            ).get_output_in_json()
+            assert output == expected_children
+
+        wait_for_assertion(check)
 
     def test_iothub_device_scope_on_create(self):
         for auth_phase in DATAPLANE_AUTH_TYPES:

--- a/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
+++ b/azext_iot/tests/iothub/jobs/test_iothub_jobs_int.py
@@ -7,6 +7,7 @@
 import json
 from datetime import datetime, timedelta, timezone
 
+from azext_iot.tests.helpers import wait_for_assertion
 from azext_iot.tests.iothub import DATAPLANE_AUTH_TYPES, IoTLiveScenarioTest
 
 
@@ -30,6 +31,8 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
                         auth_type=auth_phase,
                     )
                 )
+
+            self._wait_for_query_devices(device_ids_twin_tags + device_ids_twin_props, auth_phase)
 
             # Focus is on scheduleUpdateTwin jobs until we improve JIT device simulation
 
@@ -59,12 +62,14 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
             )
 
             for device_id in device_ids_twin_tags:
-                self.cmd(
-                    self.set_cmd_auth_type(
-                        f"iot hub device-twin show -d {device_id} -n {self.host_name} -g {self.entity_rg}",
-                        auth_type=auth_phase,
-                    ),
-                    checks=[self.check("tags", json.loads(self.kwargs["twin_patch_tags"])["tags"])],
+                wait_for_assertion(
+                    lambda device_id=device_id: self.cmd(
+                        self.set_cmd_auth_type(
+                            f"iot hub device-twin show -d {device_id} -n {self.host_name} -g {self.entity_rg}",
+                            auth_type=auth_phase,
+                        ),
+                        checks=[self.check("tags", json.loads(self.kwargs["twin_patch_tags"])["tags"])],
+                    )
                 )
 
             # Update twin desired properties
@@ -238,6 +243,22 @@ class TestIoTHubJobs(IoTLiveScenarioTest):
             ).get_output_in_json()
 
             self.validate_job_list(jobs_set=job_result_set)
+
+    def _wait_for_query_devices(self, device_ids, auth_phase):
+        expected_ids = set(device_ids)
+        query_condition = "deviceId in ['{}']".format("','".join(device_ids))
+
+        def check():
+            devices = self.cmd(
+                self.set_cmd_auth_type(
+                    f'iot hub query -q "select deviceId from devices where {query_condition}" '
+                    f"-n {self.host_name} -g {self.entity_rg}",
+                    auth_type=auth_phase,
+                )
+            ).get_output_in_json()
+            assert {device["deviceId"] for device in devices} == expected_ids
+
+        wait_for_assertion(check)
 
     def validate_job_list(self, jobs_set):
         filtered_job_ids_result = {}

--- a/azext_iot/tests/iothub/modules/test_iothub_modules_int.py
+++ b/azext_iot/tests/iothub/modules/test_iothub_modules_int.py
@@ -5,8 +5,8 @@
 # --------------------------------------------------------------------------------------------
 
 from azext_iot.tests.iothub import IoTLiveScenarioTest
-from time import sleep
 from azext_iot.common.utility import generate_key
+from azext_iot.tests.helpers import wait_for_assertion
 from azext_iot.tests.iothub import (
     DATAPLANE_AUTH_TYPES,
     PRIMARY_THUMBPRINT,
@@ -190,17 +190,15 @@ class TestIoTHubModules(IoTLiveScenarioTest):
                     query_checks.append(self.exists("[?moduleId=='$edgeAgent']"))
                     query_checks.append(self.exists("[?moduleId=='$edgeHub']"))
 
-                # wait for API to catch up before query
-                sleep(10)
-
-                # Query device modules. Edge devices include the $edgeAgent and $edgeHub system modules.
-                module_query_result = self.cmd(
-                    self.set_cmd_auth_type(
-                        f"iot hub query -n {self.host_name} -g {self.entity_rg} "
-                        f"-q \"select * from devices.modules where devices.deviceId='{device_ids[0]}'\"",
-                        auth_type=auth_phase,
-                    ),
-                    checks=query_checks,
+                module_query_result = wait_for_assertion(
+                    lambda: self.cmd(
+                        self.set_cmd_auth_type(
+                            f"iot hub query -n {self.host_name} -g {self.entity_rg} "
+                            f"-q \"select * from devices.modules where devices.deviceId='{device_ids[0]}'\"",
+                            auth_type=auth_phase,
+                        ),
+                        checks=query_checks,
+                    )
                 ).get_output_in_json()
 
                 target_module_count = (

--- a/azext_iot/tests/iothub/state/test_hub_state_int.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_int.py
@@ -194,7 +194,7 @@ def _wait_for_device_query(cstring, expected_device_ids):
 @pytest.fixture()
 def setup_hub_states_dataplane(provisioned_iot_hubs_with_storage_user_module):
     """Fixture to setup hubs with dataplane aspects."""
-    hubs = provisioned_iot_hubs_with_storage_user_module
+    hubs = [hub for hub in provisioned_iot_hubs_with_storage_user_module if hub.get("hub")]
     filename = generate_generic_id() + ".json"
     origin_hub = hubs[0]
     origin_hub["filename"] = filename

--- a/azext_iot/tests/iothub/state/test_hub_state_int.py
+++ b/azext_iot/tests/iothub/state/test_hub_state_int.py
@@ -16,6 +16,7 @@ from azext_iot.common.embedded_cli import EmbeddedCLI
 from azext_iot.tests.iothub.conftest import assign_iot_hub_dataplane_rbac_role, generate_hub_id
 from azext_iot.tests.settings import DynamoSettings, ENV_SET_TEST_IOTHUB_REQUIRED, ENV_SET_TEST_IOTHUB_OPTIONAL
 from azext_iot.tests.generators import generate_generic_id
+from azext_iot.tests.helpers import clean_up_iothub_device_config, wait_for_assertion
 from azext_iot.common.utility import generate_key, read_file_content
 from azext_iot.common.certops import create_self_signed_certificate
 from azext_iot.tests.iothub import (
@@ -47,6 +48,7 @@ def generate_device_names(count, edge=False):
 
 
 def _setup_hub_dataplane_state(cstring):
+    expected_device_ids = []
     # make a configuration for the hub (applies to 0 devices, this is just to test the configuration settings)
     labels = {generate_generic_id() : generate_generic_id(), generate_generic_id() : generate_generic_id()}
     labels = json.dumps(labels)
@@ -90,6 +92,7 @@ def _setup_hub_dataplane_state(cstring):
     for device_type in DEVICE_TYPES:
         device_count = 3
         device_ids = generate_device_names(device_count, edge=device_type == "edge")
+        expected_device_ids.extend(device_ids)
         module_id = generate_device_names(1)[0]
         edge_enabled = "--edge-enabled" if device_type == "edge" else ""
 
@@ -174,19 +177,39 @@ def _setup_hub_dataplane_state(cstring):
                 f" --tags '{patch_tags}'"
             )
 
+    return expected_device_ids
+
+
+def _wait_for_device_query(cstring, expected_device_ids):
+    def check():
+        devices = cli.invoke(f"iot hub device-identity list -l {cstring}").as_json()
+        assert {device["deviceId"] for device in devices} == set(expected_device_ids)
+        assert all("authenticationType" in device and "x509Thumbprint" in device for device in devices)
+        assert all(device.get("tags") and device.get("properties", {}).get("desired", {}).get("testProp") for device in devices)
+        assert sum(bool(device.get("parentScopes")) for device in devices) == 2
+
+    wait_for_assertion(check)
+
 
 @pytest.fixture()
 def setup_hub_states_dataplane(provisioned_iot_hubs_with_storage_user_module):
     """Fixture to setup hubs with dataplane aspects."""
+    hubs = provisioned_iot_hubs_with_storage_user_module
     filename = generate_generic_id() + ".json"
-    provisioned_iot_hubs_with_storage_user_module[0]["filename"] = filename
-    assign_iot_hub_dataplane_rbac_role(provisioned_iot_hubs_with_storage_user_module)
-    _setup_hub_dataplane_state(provisioned_iot_hubs_with_storage_user_module[0]["connectionString"])
-    # let dataplane state in hub catch up
-    time.sleep(5)
-    yield provisioned_iot_hubs_with_storage_user_module
-    if os.path.isfile(filename):
-        os.remove(filename)
+    origin_hub = hubs[0]
+    origin_hub["filename"] = filename
+    assign_iot_hub_dataplane_rbac_role(hubs)
+    try:
+        for hub in hubs:
+            clean_up_iothub_device_config(hub["name"], hub["rg"])
+        expected_device_ids = _setup_hub_dataplane_state(origin_hub["connectionString"])
+        _wait_for_device_query(origin_hub["connectionString"], expected_device_ids)
+        yield hubs
+    finally:
+        if os.path.isfile(filename):
+            os.remove(filename)
+        for hub in hubs:
+            clean_up_iothub_device_config(hub["name"], hub["rg"])
 
 
 @pytest.fixture()
@@ -224,33 +247,6 @@ def clean_up_hub_controlplane(hub_name, hub_rg, hub_location):
     os.remove(arm_file)
 
 
-def clean_up_hub_dataplane(cstring):
-    dest_hub_configs = cli.invoke(
-        f"iot hub configuration list -l {cstring}"
-    ).as_json()
-
-    dest_hub_deploys = cli.invoke(
-        f"iot edge deployment list -l {cstring}"
-    ).as_json()
-
-    for config in dest_hub_configs + dest_hub_deploys:
-        cli.invoke(
-            "iot hub configuration delete -c {} -l {}".format(config["id"], cstring)
-        )
-
-    dest_hub_identities = cli.invoke(
-        f"iot hub device-identity list -l {cstring}"
-    ).as_json()
-
-    for device in dest_hub_identities:
-        cli.invoke(
-            "iot hub device-identity delete -d {} -l {}".format(device["deviceId"], cstring)
-        )
-
-    # gives the api enough time to update
-    time.sleep(1)
-
-
 def delete_system_endpoints(hub_name, rg):
     # delete is a no-op
     cli.invoke(
@@ -285,6 +281,7 @@ def test_migrate_dataplane(setup_hub_states_dataplane):
     origin_rg = setup_hub_states_dataplane[0]["rg"]
     origin_cstring = setup_hub_states_dataplane[0]["connectionString"]
     dest_name = setup_hub_states_dataplane[1]["name"]
+    dest_rg = setup_hub_states_dataplane[1]["rg"]
     dest_cstring = setup_hub_states_dataplane[1]["connectionString"]
     for auth_phase in DATAPLANE_AUTH_TYPES:
         if auth_phase == "cstring":
@@ -302,9 +299,8 @@ def test_migrate_dataplane(setup_hub_states_dataplane):
                 )
             )
 
-        time.sleep(1)  # gives the hub time to update before the checks
-        compare_hubs_dataplane(origin_cstring, dest_cstring)
-        clean_up_hub_dataplane(dest_cstring)
+        wait_for_assertion(lambda: compare_hubs_dataplane(origin_cstring, dest_cstring))
+        clean_up_iothub_device_config(dest_name, dest_rg)
 
 
 @pytest.mark.hub_infrastructure(
@@ -452,8 +448,7 @@ def test_export_import_dataplane(setup_hub_states_dataplane):
         compare_hub_dataplane_to_file(filename, hub_cstring)
 
     for auth_phase in DATAPLANE_AUTH_TYPES:
-        clean_up_hub_dataplane(hub_cstring)
-        time.sleep(5)
+        clean_up_iothub_device_config(hub_name, hub_rg)
         cli.invoke(
             set_cmd_auth_type(
                 f"iot hub state import -n {hub_name} -f {filename} -g {hub_rg} -r --aspects {DATAPLANE}",
@@ -461,8 +456,7 @@ def test_export_import_dataplane(setup_hub_states_dataplane):
                 cstring=hub_cstring
             )
         )
-        time.sleep(10)  # gives the hub time to update before the checks
-        compare_hub_dataplane_to_file(filename, hub_cstring)
+        wait_for_assertion(lambda: compare_hub_dataplane_to_file(filename, hub_cstring))
 
 
 @pytest.mark.hub_infrastructure(count=0)
@@ -520,6 +514,7 @@ def compare_hubs_dataplane(origin_cstring: str, dest_cstring: str):
         except AssertionError:
             tries += 1
             time.sleep(1)
+    compare_configs(orig_hub_configs, dest_hub_configs)
 
     # compare edge deployments
     tries = 0
@@ -536,6 +531,7 @@ def compare_hubs_dataplane(origin_cstring: str, dest_cstring: str):
         except AssertionError:
             tries += 1
             time.sleep(1)
+    compare_configs(orig_hub_deploys, dest_hub_deploys)
 
     # compare devices
     tries = 0
@@ -635,6 +631,7 @@ def compare_hub_dataplane_to_file(filename: str, cstring: str):
         except AssertionError:
             tries += 1
             time.sleep(1)
+    compare_configs(file_configs, hub_configs)
 
     # compare edge deployments
     file_deploys = list(hub_info["configurations"]["edgeDeployments"].values())
@@ -649,6 +646,7 @@ def compare_hub_dataplane_to_file(filename: str, cstring: str):
         except AssertionError:
             tries += 1
             time.sleep(1)
+    compare_configs(file_deploys, hub_deploys)
 
     # compare devices
     file_devices = hub_info["devices"]


### PR DESCRIPTION
## Summary

Stabilizes HubData and HubMgmt integration tests against IoT Hub query-index and resource-deletion propagation delays.

- Adds bounded query-readiness checks and fresh-name Hub replacement.
- Cleans up the active replacement Hub.
- Uses authoritative identity data only when Edge scope queries remain incomplete after existing retries.

Existing assertions and coverage are preserved. The affected live suites passed twice consecutively